### PR TITLE
#3: Define MQTT topic namespace hierarchy

### DIFF
--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -1,0 +1,144 @@
+"""MQTT topic namespace for OpenBaD inter-module communication.
+
+Topic Naming Conventions
+========================
+- All topics are rooted under ``agent/``.
+- Hierarchy uses ``/`` as the level separator (standard MQTT).
+- Static segments are lower-case kebab-style identifiers.
+- Dynamic segments are represented as ``{placeholder}`` in template strings
+  and substituted at runtime via :func:`topic_for`.
+- Wildcard subscriptions follow MQTT v5 rules:
+  - ``+`` matches exactly one level  (e.g. ``agent/telemetry/+``)
+  - ``#`` matches zero or more levels (e.g. ``agent/#``)
+- No trailing slashes.  No leading slashes.
+- Characters restricted to ``[a-z0-9/_{}+-]`` (MQTT UTF-8 safe subset).
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Telemetry (interoception → endocrine / dashboard)
+# ---------------------------------------------------------------------------
+TELEMETRY_CPU = "agent/telemetry/cpu"
+TELEMETRY_MEMORY = "agent/telemetry/memory"
+TELEMETRY_DISK = "agent/telemetry/disk"
+TELEMETRY_TOKENS = "agent/telemetry/tokens"
+
+# Wildcard: subscribe to all telemetry
+TELEMETRY_ALL = "agent/telemetry/+"
+
+# ---------------------------------------------------------------------------
+# Reflex arc (FSM triggers and results)
+# ---------------------------------------------------------------------------
+REFLEX_TRIGGER = "agent/reflex/{reflex_id}/trigger"
+REFLEX_RESULT = "agent/reflex/{reflex_id}/result"
+REFLEX_STATE = "agent/reflex/state"
+
+# Wildcard: all reflex traffic
+REFLEX_ALL = "agent/reflex/#"
+
+# ---------------------------------------------------------------------------
+# Sensory inputs
+# ---------------------------------------------------------------------------
+SENSORY_VISION = "agent/sensory/vision/{source_id}"
+SENSORY_AUDIO = "agent/sensory/audio/{source_id}"
+
+# Wildcard: all sensory data
+SENSORY_ALL = "agent/sensory/#"
+
+# ---------------------------------------------------------------------------
+# Cognitive (System 2 escalation interface)
+# ---------------------------------------------------------------------------
+COGNITIVE_ESCALATION = "agent/cognitive/escalation"
+COGNITIVE_RESULT = "agent/cognitive/result"
+
+# ---------------------------------------------------------------------------
+# Immune system
+# ---------------------------------------------------------------------------
+IMMUNE_ALERT = "agent/immune/alert"
+IMMUNE_QUARANTINE = "agent/immune/quarantine"
+
+# ---------------------------------------------------------------------------
+# Endocrine (hormone channels)
+# ---------------------------------------------------------------------------
+ENDOCRINE = "agent/endocrine/{hormone}"
+ENDOCRINE_CORTISOL = "agent/endocrine/cortisol"
+ENDOCRINE_ADRENALINE = "agent/endocrine/adrenaline"
+ENDOCRINE_ENDORPHIN = "agent/endocrine/endorphin"
+
+# Wildcard: all endocrine events
+ENDOCRINE_ALL = "agent/endocrine/+"
+
+# ---------------------------------------------------------------------------
+# Memory subsystem
+# ---------------------------------------------------------------------------
+MEMORY_STM_WRITE = "agent/memory/stm/write"
+MEMORY_LTM_CONSOLIDATE = "agent/memory/ltm/consolidate"
+
+# Wildcard: all memory events
+MEMORY_ALL = "agent/memory/#"
+
+# ---------------------------------------------------------------------------
+# Sleep / maintenance cycles
+# ---------------------------------------------------------------------------
+SLEEP = "agent/sleep/{phase}"
+SLEEP_ALL = "agent/sleep/+"
+
+# ---------------------------------------------------------------------------
+# Proprioception (tool / MCP server awareness)
+# ---------------------------------------------------------------------------
+PROPRIOCEPTION_HEARTBEAT = "agent/proprioception/{tool_id}/heartbeat"
+PROPRIOCEPTION_ALL = "agent/proprioception/#"
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve topic templates
+# ---------------------------------------------------------------------------
+def topic_for(template: str, /, **kwargs: str) -> str:
+    """Substitute placeholders in a topic template.
+
+    >>> topic_for(REFLEX_TRIGGER, reflex_id="thermal-throttle")
+    'agent/reflex/thermal-throttle/trigger'
+    """
+    return template.format(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# All static (non-template) topics for programmatic enumeration
+# ---------------------------------------------------------------------------
+STATIC_TOPICS: tuple[str, ...] = (
+    TELEMETRY_CPU,
+    TELEMETRY_MEMORY,
+    TELEMETRY_DISK,
+    TELEMETRY_TOKENS,
+    REFLEX_STATE,
+    COGNITIVE_ESCALATION,
+    COGNITIVE_RESULT,
+    IMMUNE_ALERT,
+    IMMUNE_QUARANTINE,
+    ENDOCRINE_CORTISOL,
+    ENDOCRINE_ADRENALINE,
+    ENDOCRINE_ENDORPHIN,
+    MEMORY_STM_WRITE,
+    MEMORY_LTM_CONSOLIDATE,
+)
+
+TEMPLATE_TOPICS: tuple[str, ...] = (
+    REFLEX_TRIGGER,
+    REFLEX_RESULT,
+    SENSORY_VISION,
+    SENSORY_AUDIO,
+    ENDOCRINE,
+    SLEEP,
+    PROPRIOCEPTION_HEARTBEAT,
+)
+
+WILDCARD_TOPICS: tuple[str, ...] = (
+    TELEMETRY_ALL,
+    REFLEX_ALL,
+    SENSORY_ALL,
+    ENDOCRINE_ALL,
+    MEMORY_ALL,
+    SLEEP_ALL,
+    PROPRIOCEPTION_ALL,
+)

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -1,0 +1,145 @@
+"""Tests for the MQTT topic namespace — Issue #3."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from openbad.nervous_system import topics
+
+# Valid MQTT topic characters (our restricted subset).
+_TOPIC_RE = re.compile(r"^[a-z0-9/_{}+#-]+$")
+
+# A topic segment must not be empty (no double slashes).
+_NO_DOUBLE_SLASH = re.compile(r"//")
+
+
+def _all_topic_strings() -> list[str]:
+    """Collect every topic constant exported by the module."""
+    return list(topics.STATIC_TOPICS + topics.TEMPLATE_TOPICS + topics.WILDCARD_TOPICS)
+
+
+class TestTopicFormat:
+    """Every topic constant must obey the naming conventions."""
+
+    @pytest.mark.parametrize("topic", _all_topic_strings())
+    def test_no_leading_slash(self, topic: str) -> None:
+        assert not topic.startswith("/"), f"{topic!r} starts with /"
+
+    @pytest.mark.parametrize("topic", _all_topic_strings())
+    def test_no_trailing_slash(self, topic: str) -> None:
+        assert not topic.endswith("/"), f"{topic!r} ends with /"
+
+    @pytest.mark.parametrize("topic", _all_topic_strings())
+    def test_valid_characters(self, topic: str) -> None:
+        assert _TOPIC_RE.match(topic), f"{topic!r} contains invalid characters"
+
+    @pytest.mark.parametrize("topic", _all_topic_strings())
+    def test_no_double_slashes(self, topic: str) -> None:
+        assert not _NO_DOUBLE_SLASH.search(topic), f"{topic!r} has empty segment"
+
+    @pytest.mark.parametrize("topic", _all_topic_strings())
+    def test_rooted_under_agent(self, topic: str) -> None:
+        assert topic.startswith("agent/"), f"{topic!r} not rooted under agent/"
+
+    @pytest.mark.parametrize("topic", _all_topic_strings())
+    def test_lowercase(self, topic: str) -> None:
+        # Only check non-placeholder parts
+        cleaned = re.sub(r"\{[^}]+}", "", topic)
+        assert cleaned == cleaned.lower(), f"{topic!r} contains uppercase"
+
+
+class TestStaticTopics:
+    """Static topics must not contain placeholders or wildcards."""
+
+    @pytest.mark.parametrize("topic", list(topics.STATIC_TOPICS))
+    def test_no_placeholders(self, topic: str) -> None:
+        assert "{" not in topic and "}" not in topic
+
+    @pytest.mark.parametrize("topic", list(topics.STATIC_TOPICS))
+    def test_no_wildcards(self, topic: str) -> None:
+        assert "+" not in topic and "#" not in topic
+
+
+class TestTemplatTopics:
+    """Template topics must contain at least one placeholder."""
+
+    @pytest.mark.parametrize("topic", list(topics.TEMPLATE_TOPICS))
+    def test_has_placeholder(self, topic: str) -> None:
+        assert "{" in topic and "}" in topic
+
+
+class TestWildcardTopics:
+    """Wildcard topics must contain + or #."""
+
+    @pytest.mark.parametrize("topic", list(topics.WILDCARD_TOPICS))
+    def test_has_wildcard(self, topic: str) -> None:
+        assert "+" in topic or "#" in topic
+
+
+class TestTopicFor:
+    """topic_for() must resolve templates correctly."""
+
+    def test_reflex_trigger(self) -> None:
+        result = topics.topic_for(topics.REFLEX_TRIGGER, reflex_id="thermal-throttle")
+        assert result == "agent/reflex/thermal-throttle/trigger"
+
+    def test_endocrine(self) -> None:
+        result = topics.topic_for(topics.ENDOCRINE, hormone="cortisol")
+        assert result == "agent/endocrine/cortisol"
+
+    def test_proprioception_heartbeat(self) -> None:
+        result = topics.topic_for(topics.PROPRIOCEPTION_HEARTBEAT, tool_id="fs-write")
+        assert result == "agent/proprioception/fs-write/heartbeat"
+
+    def test_missing_key_raises(self) -> None:
+        with pytest.raises(KeyError):
+            topics.topic_for(topics.REFLEX_TRIGGER)
+
+
+class TestImportability:
+    """All topic constants must be importable from the public path."""
+
+    def test_import_from_module(self) -> None:
+        from openbad.nervous_system.topics import (
+            COGNITIVE_ESCALATION,
+            COGNITIVE_RESULT,
+            ENDOCRINE_CORTISOL,
+            IMMUNE_ALERT,
+            IMMUNE_QUARANTINE,
+            MEMORY_LTM_CONSOLIDATE,
+            MEMORY_STM_WRITE,
+            PROPRIOCEPTION_HEARTBEAT,
+            REFLEX_STATE,
+            REFLEX_TRIGGER,
+            SENSORY_AUDIO,
+            SENSORY_VISION,
+            SLEEP,
+            TELEMETRY_CPU,
+            TELEMETRY_DISK,
+            TELEMETRY_MEMORY,
+            TELEMETRY_TOKENS,
+        )
+
+        # Smoke check — they're all strings
+        for name in (
+            COGNITIVE_ESCALATION,
+            COGNITIVE_RESULT,
+            ENDOCRINE_CORTISOL,
+            IMMUNE_ALERT,
+            IMMUNE_QUARANTINE,
+            MEMORY_LTM_CONSOLIDATE,
+            MEMORY_STM_WRITE,
+            PROPRIOCEPTION_HEARTBEAT,
+            REFLEX_STATE,
+            REFLEX_TRIGGER,
+            SENSORY_AUDIO,
+            SENSORY_VISION,
+            SLEEP,
+            TELEMETRY_CPU,
+            TELEMETRY_DISK,
+            TELEMETRY_MEMORY,
+            TELEMETRY_TOKENS,
+        ):
+            assert isinstance(name, str)


### PR DESCRIPTION
Closes #3

## Summary

Defines the hierarchical MQTT topic namespace used by all OpenBaD modules for inter-module communication.

## Changes

- **`src/openbad/nervous_system/topics.py`** — All topic string constants organized by subsystem (telemetry, reflex, sensory, cognitive, immune, endocrine, memory, sleep, proprioception). Includes static topics, template topics (with `{placeholder}` segments), wildcard topics, and a `topic_for()` helper to resolve templates. Module docstring documents naming conventions.
- **`tests/test_topics.py`** — 215 parametrized tests covering: no leading/trailing slashes, valid MQTT characters, no double slashes, `agent/` root prefix, lowercase enforcement, static topics have no placeholders/wildcards, templates have placeholders, wildcards have `+`/`#`, `topic_for()` resolution + error handling, importability.

## How to Test

```bash
make test   # 234 passed (215 new + 18 broker + 1 scaffold)
make lint   # all checks passed
```