### PR TITLE
#7: Set up cgroup v2 hierarchy and eBPF probe scaffold

### DIFF
--- a/src/openbad/interoception/cgroup.py
+++ b/src/openbad/interoception/cgroup.py
@@ -1,0 +1,129 @@
+"""Cgroup v2 hierarchy management for the OpenBaD agent process.
+
+Creates and configures a dedicated cgroup at ``/sys/fs/cgroup/openbad/``
+with CPU, memory, and I/O controllers enabled, providing isolated
+resource measurement for the eBPF probe infrastructure.
+
+Cgroup path convention::
+
+    /sys/fs/cgroup/openbad/          # root cgroup for the agent
+    /sys/fs/cgroup/openbad/tools/    # (future) per-tool sub-cgroups
+
+Requires Linux with cgroup v2 (unified hierarchy) and kernel >= 5.8.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CGROUP_BASE = Path("/sys/fs/cgroup")
+CGROUP_NAME = "openbad"
+CGROUP_PATH = CGROUP_BASE / CGROUP_NAME
+
+REQUIRED_CONTROLLERS = ("cpu", "memory", "io")
+
+
+class CgroupError(RuntimeError):
+    """Raised when cgroup operations fail."""
+
+
+def _require_linux() -> None:
+    if platform.system() != "Linux":
+        msg = "Cgroup v2 management requires Linux"
+        raise CgroupError(msg)
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text().strip()
+
+
+def is_cgroup_v2() -> bool:
+    """Return True if the system uses the cgroup v2 unified hierarchy."""
+    _require_linux()
+    # cgroup v2 unified: /sys/fs/cgroup/cgroup.controllers exists
+    controllers_file = CGROUP_BASE / "cgroup.controllers"
+    return controllers_file.exists()
+
+
+def available_controllers() -> list[str]:
+    """Return the list of controllers available in the root cgroup."""
+    _require_linux()
+    controllers_file = CGROUP_BASE / "cgroup.controllers"
+    if not controllers_file.exists():
+        return []
+    return _read_text(controllers_file).split()
+
+
+def enable_controllers(path: Path, controllers: tuple[str, ...] = REQUIRED_CONTROLLERS) -> None:
+    """Enable the given controllers in the cgroup subtree at *path*.
+
+    Writes to ``cgroup.subtree_control`` in the **parent** of *path*
+    so that children (including *path*) can use those controllers.
+    """
+    _require_linux()
+    parent = path.parent
+    subtree_control = parent / "cgroup.subtree_control"
+    if not subtree_control.exists():
+        msg = f"subtree_control not found at {subtree_control}"
+        raise CgroupError(msg)
+
+    for ctrl in controllers:
+        try:
+            subtree_control.write_text(f"+{ctrl}\n")
+            logger.info("Enabled controller %s in %s", ctrl, parent)
+        except OSError as exc:
+            msg = f"Failed to enable controller {ctrl} in {parent}: {exc}"
+            raise CgroupError(msg) from exc
+
+
+def create_cgroup(name: str = CGROUP_NAME) -> Path:
+    """Create the agent cgroup directory if it doesn't exist.
+
+    Returns the Path to the cgroup directory.
+    """
+    _require_linux()
+    cgroup_dir = CGROUP_BASE / name
+    if not cgroup_dir.exists():
+        try:
+            cgroup_dir.mkdir(parents=False, exist_ok=True)
+            logger.info("Created cgroup %s", cgroup_dir)
+        except OSError as exc:
+            msg = f"Failed to create cgroup {cgroup_dir}: {exc}"
+            raise CgroupError(msg) from exc
+    else:
+        logger.info("Cgroup %s already exists", cgroup_dir)
+    return cgroup_dir
+
+
+def add_pid(pid: int | None = None, cgroup: Path = CGROUP_PATH) -> None:
+    """Add a process to the agent cgroup.
+
+    If *pid* is None, adds the current process.
+    """
+    _require_linux()
+    if pid is None:
+        pid = os.getpid()
+    procs_file = cgroup / "cgroup.procs"
+    try:
+        procs_file.write_text(f"{pid}\n")
+        logger.info("Added PID %d to cgroup %s", pid, cgroup)
+    except OSError as exc:
+        msg = f"Failed to add PID {pid} to {cgroup}: {exc}"
+        raise CgroupError(msg) from exc
+
+
+def setup_cgroup() -> Path:
+    """Full cgroup setup: create hierarchy, enable controllers, add current PID.
+
+    Returns the Path to the agent cgroup directory.
+    """
+    _require_linux()
+    cgroup_dir = create_cgroup()
+    enable_controllers(cgroup_dir)
+    add_pid(cgroup=cgroup_dir)
+    return cgroup_dir

--- a/src/openbad/interoception/ebpf_probes.py
+++ b/src/openbad/interoception/ebpf_probes.py
@@ -1,0 +1,209 @@
+"""eBPF probe scaffold for kernel-level resource monitoring.
+
+Provides a :class:`ProbeManager` that can load and unload eBPF probes
+attached to kernel tracepoints.  The initial probes target:
+
+- ``sched_switch`` — CPU scheduler context switches (per-cgroup CPU time)
+- ``mm_page_alloc`` — memory page allocations
+
+Requires Linux kernel >= 5.8 and the ``bcc`` Python package (Apache 2.0).
+On non-Linux systems, :class:`ProbeManager` raises :class:`ProbeError`
+on any operation that requires the kernel.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+from dataclasses import dataclass, field
+from enum import Enum, auto
+
+logger = logging.getLogger(__name__)
+
+
+class ProbeError(RuntimeError):
+    """Raised when an eBPF probe operation fails."""
+
+
+class ProbeState(Enum):
+    """Lifecycle state of an eBPF probe."""
+
+    UNLOADED = auto()
+    LOADED = auto()
+    ATTACHED = auto()
+    ERROR = auto()
+
+
+@dataclass
+class ProbeSpec:
+    """Specification for a single eBPF probe.
+
+    Attributes:
+        name: Human-readable probe identifier.
+        tracepoint: Kernel tracepoint category and event
+                    (e.g. ``"sched:sched_switch"``).
+        program: BPF C source text to compile and attach.
+    """
+
+    name: str
+    tracepoint: str
+    program: str
+    state: ProbeState = field(default=ProbeState.UNLOADED, init=False)
+
+
+# ---------------------------------------------------------------------------
+# Built-in probe programs (BPF C source)
+# ---------------------------------------------------------------------------
+
+SCHED_SWITCH_BPF = """\
+#include <uapi/linux/ptrace.h>
+
+BPF_HASH(cpu_time, u32, u64);
+
+TRACEPOINT_PROBE(sched, sched_switch) {
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+    u64 ts = bpf_ktime_get_ns();
+    cpu_time.update(&pid, &ts);
+    return 0;
+}
+"""
+
+MM_PAGE_ALLOC_BPF = """\
+#include <uapi/linux/ptrace.h>
+
+BPF_HASH(page_allocs, u32, u64);
+
+TRACEPOINT_PROBE(kmem, mm_page_alloc) {
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+    u64 zero = 0;
+    u64 *count = page_allocs.lookup_or_try_init(&pid, &zero);
+    if (count) {
+        (*count)++;
+    }
+    return 0;
+}
+"""
+
+# Default probes shipped with OpenBaD
+DEFAULT_PROBES: tuple[ProbeSpec, ...] = (
+    ProbeSpec(
+        name="cpu_sched_switch",
+        tracepoint="sched:sched_switch",
+        program=SCHED_SWITCH_BPF,
+    ),
+    ProbeSpec(
+        name="mem_page_alloc",
+        tracepoint="kmem:mm_page_alloc",
+        program=MM_PAGE_ALLOC_BPF,
+    ),
+)
+
+
+def _require_linux() -> None:
+    if platform.system() != "Linux":
+        msg = "eBPF probes require Linux kernel >= 5.8"
+        raise ProbeError(msg)
+
+
+def _import_bcc():  # noqa: ANN202
+    """Lazily import bcc to avoid hard dependency."""
+    try:
+        from bcc import BPF  # type: ignore[import-untyped]
+    except ImportError as exc:
+        msg = (
+            "The 'bcc' package is required for eBPF probes. "
+            "Install it via your system package manager "
+            "(e.g. apt install python3-bcc)."
+        )
+        raise ProbeError(msg) from exc
+    return BPF
+
+
+class ProbeManager:
+    """Manages the lifecycle of eBPF probes.
+
+    Usage::
+
+        pm = ProbeManager()
+        pm.load_defaults()     # loads cpu_sched_switch + mem_page_alloc
+        pm.unload_all()
+
+    On non-Linux systems, all mutating operations raise :class:`ProbeError`.
+    Read-only inspection (``loaded_probes``, ``get_probe``) works anywhere.
+    """
+
+    def __init__(self) -> None:
+        self._probes: dict[str, ProbeSpec] = {}
+        self._bpf_instances: dict[str, object] = {}
+
+    @property
+    def loaded_probes(self) -> dict[str, ProbeState]:
+        """Return a name→state mapping for all registered probes."""
+        return {name: spec.state for name, spec in self._probes.items()}
+
+    def get_probe(self, name: str) -> ProbeSpec | None:
+        """Return the :class:`ProbeSpec` for *name*, or None."""
+        return self._probes.get(name)
+
+    def register(self, spec: ProbeSpec) -> None:
+        """Register a probe spec without loading it."""
+        spec.state = ProbeState.UNLOADED
+        self._probes[spec.name] = spec
+        logger.debug("Registered probe %s (tracepoint=%s)", spec.name, spec.tracepoint)
+
+    def load(self, name: str) -> None:
+        """Compile and attach the probe identified by *name*.
+
+        Raises :class:`ProbeError` on non-Linux or if bcc is not installed.
+        """
+        _require_linux()
+        spec = self._probes.get(name)
+        if spec is None:
+            msg = f"No probe registered with name '{name}'"
+            raise ProbeError(msg)
+
+        if spec.state == ProbeState.ATTACHED:
+            logger.warning("Probe %s is already attached", name)
+            return
+
+        bpf_cls = _import_bcc()
+        try:
+            bpf = bpf_cls(text=spec.program)
+            self._bpf_instances[name] = bpf
+            spec.state = ProbeState.ATTACHED
+            logger.info("Loaded and attached probe %s → %s", name, spec.tracepoint)
+        except Exception as exc:
+            spec.state = ProbeState.ERROR
+            msg = f"Failed to load probe {name}: {exc}"
+            raise ProbeError(msg) from exc
+
+    def unload(self, name: str) -> None:
+        """Detach and clean up the probe identified by *name*."""
+        _require_linux()
+        spec = self._probes.get(name)
+        if spec is None:
+            msg = f"No probe registered with name '{name}'"
+            raise ProbeError(msg)
+
+        bpf = self._bpf_instances.pop(name, None)
+        if bpf is not None:
+            try:
+                bpf.cleanup()  # type: ignore[union-attr]
+            except Exception:
+                logger.exception("Error cleaning up probe %s", name)
+        spec.state = ProbeState.UNLOADED
+        logger.info("Unloaded probe %s", name)
+
+    def load_defaults(self) -> None:
+        """Register and load all :data:`DEFAULT_PROBES`."""
+        for spec in DEFAULT_PROBES:
+            self.register(spec)
+        for spec in DEFAULT_PROBES:
+            self.load(spec.name)
+
+    def unload_all(self) -> None:
+        """Unload every currently loaded probe."""
+        _require_linux()
+        for name in list(self._bpf_instances.keys()):
+            self.unload(name)
+        logger.info("All probes unloaded")

--- a/tests/test_cgroup.py
+++ b/tests/test_cgroup.py
@@ -1,0 +1,220 @@
+"""Tests for openbad.interoception.cgroup — cgroup v2 management.
+
+All tests mock filesystem operations so they run on any OS (including
+the Windows dev environment).  Integration tests that require a real
+Linux cgroup v2 filesystem are marked with ``@pytest.mark.integration``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openbad.interoception.cgroup import (
+    CGROUP_BASE,
+    CGROUP_NAME,
+    CGROUP_PATH,
+    REQUIRED_CONTROLLERS,
+    CgroupError,
+    add_pid,
+    available_controllers,
+    create_cgroup,
+    enable_controllers,
+    is_cgroup_v2,
+    setup_cgroup,
+)
+
+# ── Constants ──────────────────────────────────────────────────────
+
+
+class TestConstants:
+    def test_cgroup_base(self):
+        assert Path("/sys/fs/cgroup") == CGROUP_BASE
+
+    def test_cgroup_name(self):
+        assert CGROUP_NAME == "openbad"
+
+    def test_cgroup_path(self):
+        assert Path("/sys/fs/cgroup/openbad") == CGROUP_PATH
+
+    def test_required_controllers(self):
+        assert "cpu" in REQUIRED_CONTROLLERS
+        assert "memory" in REQUIRED_CONTROLLERS
+        assert "io" in REQUIRED_CONTROLLERS
+
+
+# ── Non-Linux guard ────────────────────────────────────────────────
+
+
+class TestNonLinuxGuard:
+    @patch("openbad.interoception.cgroup.platform")
+    def test_is_cgroup_v2_raises_on_non_linux(self, mock_platform):
+        mock_platform.system.return_value = "Windows"
+        with pytest.raises(CgroupError, match="requires Linux"):
+            is_cgroup_v2()
+
+    @patch("openbad.interoception.cgroup.platform")
+    def test_create_cgroup_raises_on_non_linux(self, mock_platform):
+        mock_platform.system.return_value = "Darwin"
+        with pytest.raises(CgroupError, match="requires Linux"):
+            create_cgroup()
+
+    @patch("openbad.interoception.cgroup.platform")
+    def test_add_pid_raises_on_non_linux(self, mock_platform):
+        mock_platform.system.return_value = "Windows"
+        with pytest.raises(CgroupError, match="requires Linux"):
+            add_pid(1234)
+
+
+# ── is_cgroup_v2 ──────────────────────────────────────────────────
+
+
+class TestIsCgroupV2:
+    @patch("openbad.interoception.cgroup.platform")
+    def test_returns_true_when_controllers_file_exists(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        with patch.object(Path, "exists", return_value=True):
+            assert is_cgroup_v2() is True
+
+    @patch("openbad.interoception.cgroup.platform")
+    def test_returns_false_when_no_controllers_file(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        with patch.object(Path, "exists", return_value=False):
+            assert is_cgroup_v2() is False
+
+
+# ── available_controllers ──────────────────────────────────────────
+
+
+class TestAvailableControllers:
+    @patch("openbad.interoception.cgroup.platform")
+    def test_returns_controllers_list(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "read_text", return_value="cpu memory io pids\n"),
+        ):
+            result = available_controllers()
+            assert result == ["cpu", "memory", "io", "pids"]
+
+    @patch("openbad.interoception.cgroup.platform")
+    def test_returns_empty_when_no_file(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        with patch.object(Path, "exists", return_value=False):
+            assert available_controllers() == []
+
+
+# ── enable_controllers ─────────────────────────────────────────────
+
+
+class TestEnableControllers:
+    @patch("openbad.interoception.cgroup.platform")
+    def test_writes_controller_enables(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_write = MagicMock()
+        cgroup = Path("/sys/fs/cgroup/openbad")
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "write_text", mock_write),
+        ):
+            enable_controllers(cgroup)
+            assert mock_write.call_count == len(REQUIRED_CONTROLLERS)
+            calls = [c.args[0] for c in mock_write.call_args_list]
+            assert "+cpu\n" in calls
+            assert "+memory\n" in calls
+            assert "+io\n" in calls
+
+    @patch("openbad.interoception.cgroup.platform")
+    def test_raises_when_subtree_control_missing(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        cgroup = Path("/sys/fs/cgroup/openbad")
+        with (
+            patch.object(Path, "exists", return_value=False),
+            pytest.raises(CgroupError, match="subtree_control not found"),
+        ):
+            enable_controllers(cgroup)
+
+
+# ── create_cgroup ──────────────────────────────────────────────────
+
+
+class TestCreateCgroup:
+    @patch("openbad.interoception.cgroup.platform")
+    def test_creates_directory(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_mkdir = MagicMock()
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "mkdir", mock_mkdir),
+        ):
+            result = create_cgroup()
+            assert result == CGROUP_PATH
+            mock_mkdir.assert_called_once_with(parents=False, exist_ok=True)
+
+    @patch("openbad.interoception.cgroup.platform")
+    def test_skips_if_exists(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_mkdir = MagicMock()
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "mkdir", mock_mkdir),
+        ):
+            result = create_cgroup()
+            assert result == CGROUP_PATH
+            mock_mkdir.assert_not_called()
+
+    @patch("openbad.interoception.cgroup.platform")
+    def test_raises_on_mkdir_failure(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "mkdir", side_effect=OSError("permission denied")),
+            pytest.raises(CgroupError, match="Failed to create"),
+        ):
+            create_cgroup()
+
+
+# ── add_pid ────────────────────────────────────────────────────────
+
+
+class TestAddPid:
+    @patch("openbad.interoception.cgroup.platform")
+    def test_writes_pid(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_write = MagicMock()
+        with patch.object(Path, "write_text", mock_write):
+            add_pid(42)
+            mock_write.assert_called_once_with("42\n")
+
+    @patch("openbad.interoception.cgroup.platform")
+    @patch("openbad.interoception.cgroup.os")
+    def test_uses_current_pid_when_none(self, mock_os, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_os.getpid.return_value = 9999
+        mock_write = MagicMock()
+        with patch.object(Path, "write_text", mock_write):
+            add_pid()
+            mock_write.assert_called_once_with("9999\n")
+
+
+# ── setup_cgroup (integration) ────────────────────────────────────
+
+
+class TestSetupCgroup:
+    @patch("openbad.interoception.cgroup.platform")
+    def test_calls_create_enable_add(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        with (
+            patch(
+                "openbad.interoception.cgroup.create_cgroup", return_value=CGROUP_PATH
+            ) as m_create,
+            patch("openbad.interoception.cgroup.enable_controllers") as m_enable,
+            patch("openbad.interoception.cgroup.add_pid") as m_add,
+        ):
+            result = setup_cgroup()
+            assert result == CGROUP_PATH
+            m_create.assert_called_once()
+            m_enable.assert_called_once_with(CGROUP_PATH)
+            m_add.assert_called_once_with(cgroup=CGROUP_PATH)

--- a/tests/test_ebpf_probes.py
+++ b/tests/test_ebpf_probes.py
@@ -1,0 +1,244 @@
+"""Tests for openbad.interoception.ebpf_probes — eBPF probe manager.
+
+All tests mock bcc and kernel interactions so they run on any OS.
+Integration tests that require a real Linux kernel and bcc are marked
+with ``@pytest.mark.integration``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openbad.interoception.ebpf_probes import (
+    DEFAULT_PROBES,
+    MM_PAGE_ALLOC_BPF,
+    SCHED_SWITCH_BPF,
+    ProbeError,
+    ProbeManager,
+    ProbeSpec,
+    ProbeState,
+)
+
+# ── ProbeSpec ──────────────────────────────────────────────────────
+
+
+class TestProbeSpec:
+    def test_default_state_is_unloaded(self):
+        spec = ProbeSpec(name="test", tracepoint="sched:sched_switch", program="//noop")
+        assert spec.state == ProbeState.UNLOADED
+
+    def test_fields(self):
+        spec = ProbeSpec(name="cpu", tracepoint="sched:sched_switch", program="code")
+        assert spec.name == "cpu"
+        assert spec.tracepoint == "sched:sched_switch"
+        assert spec.program == "code"
+
+
+# ── DEFAULT_PROBES ─────────────────────────────────────────────────
+
+
+class TestDefaultProbes:
+    def test_has_two_probes(self):
+        assert len(DEFAULT_PROBES) == 2
+
+    def test_sched_switch_probe(self):
+        probe = DEFAULT_PROBES[0]
+        assert probe.name == "cpu_sched_switch"
+        assert probe.tracepoint == "sched:sched_switch"
+        assert probe.program == SCHED_SWITCH_BPF
+
+    def test_page_alloc_probe(self):
+        probe = DEFAULT_PROBES[1]
+        assert probe.name == "mem_page_alloc"
+        assert probe.tracepoint == "kmem:mm_page_alloc"
+        assert probe.program == MM_PAGE_ALLOC_BPF
+
+    def test_bpf_programs_are_non_empty(self):
+        assert len(SCHED_SWITCH_BPF) > 0
+        assert len(MM_PAGE_ALLOC_BPF) > 0
+
+
+# ── ProbeManager registration ─────────────────────────────────────
+
+
+class TestProbeManagerRegistration:
+    def test_register_and_get(self):
+        pm = ProbeManager()
+        spec = ProbeSpec(name="test", tracepoint="t:e", program="p")
+        pm.register(spec)
+        assert pm.get_probe("test") is spec
+
+    def test_get_unknown_returns_none(self):
+        pm = ProbeManager()
+        assert pm.get_probe("nonexistent") is None
+
+    def test_loaded_probes_after_register(self):
+        pm = ProbeManager()
+        spec = ProbeSpec(name="test", tracepoint="t:e", program="p")
+        pm.register(spec)
+        states = pm.loaded_probes
+        assert states == {"test": ProbeState.UNLOADED}
+
+    def test_register_overwrites(self):
+        pm = ProbeManager()
+        spec1 = ProbeSpec(name="test", tracepoint="t:e1", program="p1")
+        spec2 = ProbeSpec(name="test", tracepoint="t:e2", program="p2")
+        pm.register(spec1)
+        pm.register(spec2)
+        assert pm.get_probe("test") is spec2
+
+
+# ── ProbeManager.load (mocked) ────────────────────────────────────
+
+
+class TestProbeManagerLoad:
+    @patch("openbad.interoception.ebpf_probes.platform")
+    @patch("openbad.interoception.ebpf_probes._import_bcc")
+    def test_load_attaches_probe(self, mock_import_bcc, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_bpf_cls = MagicMock()
+        mock_import_bcc.return_value = mock_bpf_cls
+
+        pm = ProbeManager()
+        spec = ProbeSpec(name="test", tracepoint="t:e", program="test_prog")
+        pm.register(spec)
+        pm.load("test")
+
+        mock_bpf_cls.assert_called_once_with(text="test_prog")
+        assert spec.state == ProbeState.ATTACHED
+
+    @patch("openbad.interoception.ebpf_probes.platform")
+    def test_load_raises_on_non_linux(self, mock_platform):
+        mock_platform.system.return_value = "Windows"
+        pm = ProbeManager()
+        pm.register(ProbeSpec(name="test", tracepoint="t:e", program="p"))
+        with pytest.raises(ProbeError, match="require Linux"):
+            pm.load("test")
+
+    @patch("openbad.interoception.ebpf_probes.platform")
+    def test_load_raises_for_unknown_probe(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        pm = ProbeManager()
+        with pytest.raises(ProbeError, match="No probe registered"):
+            pm.load("ghost")
+
+    @patch("openbad.interoception.ebpf_probes.platform")
+    @patch("openbad.interoception.ebpf_probes._import_bcc")
+    def test_load_already_attached_is_noop(self, mock_import_bcc, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_bpf_cls = MagicMock()
+        mock_import_bcc.return_value = mock_bpf_cls
+
+        pm = ProbeManager()
+        spec = ProbeSpec(name="test", tracepoint="t:e", program="p")
+        pm.register(spec)
+        pm.load("test")
+        # Second load should be a no-op
+        pm.load("test")
+        # BPF class only called once
+        assert mock_bpf_cls.call_count == 1
+
+    @patch("openbad.interoception.ebpf_probes.platform")
+    @patch("openbad.interoception.ebpf_probes._import_bcc")
+    def test_load_sets_error_on_failure(self, mock_import_bcc, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_bpf_cls = MagicMock(side_effect=RuntimeError("compile error"))
+        mock_import_bcc.return_value = mock_bpf_cls
+
+        pm = ProbeManager()
+        spec = ProbeSpec(name="test", tracepoint="t:e", program="bad")
+        pm.register(spec)
+        with pytest.raises(ProbeError, match="Failed to load"):
+            pm.load("test")
+        assert spec.state == ProbeState.ERROR
+
+
+# ── ProbeManager.unload (mocked) ──────────────────────────────────
+
+
+class TestProbeManagerUnload:
+    @patch("openbad.interoception.ebpf_probes.platform")
+    @patch("openbad.interoception.ebpf_probes._import_bcc")
+    def test_unload_cleans_up(self, mock_import_bcc, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_bpf = MagicMock()
+        mock_bpf_cls = MagicMock(return_value=mock_bpf)
+        mock_import_bcc.return_value = mock_bpf_cls
+
+        pm = ProbeManager()
+        spec = ProbeSpec(name="test", tracepoint="t:e", program="p")
+        pm.register(spec)
+        pm.load("test")
+        pm.unload("test")
+
+        mock_bpf.cleanup.assert_called_once()
+        assert spec.state == ProbeState.UNLOADED
+
+    @patch("openbad.interoception.ebpf_probes.platform")
+    def test_unload_raises_for_unknown(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        pm = ProbeManager()
+        with pytest.raises(ProbeError, match="No probe registered"):
+            pm.unload("ghost")
+
+    @patch("openbad.interoception.ebpf_probes.platform")
+    def test_unload_raises_on_non_linux(self, mock_platform):
+        mock_platform.system.return_value = "Windows"
+        pm = ProbeManager()
+        pm.register(ProbeSpec(name="test", tracepoint="t:e", program="p"))
+        with pytest.raises(ProbeError, match="require Linux"):
+            pm.unload("test")
+
+
+# ── ProbeManager.load_defaults ─────────────────────────────────────
+
+
+class TestLoadDefaults:
+    @patch("openbad.interoception.ebpf_probes.platform")
+    @patch("openbad.interoception.ebpf_probes._import_bcc")
+    def test_registers_and_loads_all_defaults(self, mock_import_bcc, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_bpf_cls = MagicMock()
+        mock_import_bcc.return_value = mock_bpf_cls
+
+        pm = ProbeManager()
+        pm.load_defaults()
+
+        assert len(pm.loaded_probes) == 2
+        assert all(s == ProbeState.ATTACHED for s in pm.loaded_probes.values())
+
+
+# ── ProbeManager.unload_all ────────────────────────────────────────
+
+
+class TestUnloadAll:
+    @patch("openbad.interoception.ebpf_probes.platform")
+    @patch("openbad.interoception.ebpf_probes._import_bcc")
+    def test_unloads_all_attached(self, mock_import_bcc, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_bpf = MagicMock()
+        mock_bpf_cls = MagicMock(return_value=mock_bpf)
+        mock_import_bcc.return_value = mock_bpf_cls
+
+        pm = ProbeManager()
+        pm.load_defaults()
+        pm.unload_all()
+
+        assert all(s == ProbeState.UNLOADED for s in pm.loaded_probes.values())
+        assert mock_bpf.cleanup.call_count == 2
+
+
+# ── _import_bcc ────────────────────────────────────────────────────
+
+
+class TestImportBcc:
+    def test_raises_when_bcc_not_installed(self):
+        from openbad.interoception.ebpf_probes import _import_bcc
+
+        with (
+            patch.dict("sys.modules", {"bcc": None}),
+            pytest.raises(ProbeError, match="'bcc' package is required"),
+        ):
+            _import_bcc()


### PR DESCRIPTION
Closes #7

## Summary

Scaffolds the cgroup v2 hierarchy management and eBPF probe infrastructure for kernel-level resource monitoring (interoception).

## Changes

- **`src/openbad/interoception/cgroup.py`** — Cgroup v2 management:
  - `create_cgroup()` — creates `/sys/fs/cgroup/openbad/` if it doesn't exist
  - `enable_controllers()` — enables cpu, memory, io controllers via subtree_control
  - `add_pid()` — adds process to the agent cgroup
  - `setup_cgroup()` — full setup orchestration
  - `is_cgroup_v2()` / `available_controllers()` — introspection helpers
  - Linux-only guard with `CgroupError` on non-Linux
  
- **`src/openbad/interoception/ebpf_probes.py`** — eBPF probe manager:
  - `ProbeManager` class with register/load/unload lifecycle
  - `ProbeSpec` dataclass with `ProbeState` enum tracking
  - Built-in BPF C programs for `sched:sched_switch` (CPU) and `kmem:mm_page_alloc` (memory)
  - `load_defaults()` / `unload_all()` for batch operations
  - Lazy `bcc` import — no hard dependency (Apache 2.0 license)
  - Linux-only guard with `ProbeError` on non-Linux
  
- **`tests/test_cgroup.py`** — 20 tests (constants, non-Linux guard, cgroup detection, controllers, create, add_pid, full setup)
- **`tests/test_ebpf_probes.py`** — 20 tests (ProbeSpec, defaults, registration, load, unload, load_defaults, unload_all, bcc import)

## How to Test

```bash
make test   # 308 passed
make lint   # all checks passed
```