### PR TITLE
#6: Configure QoS levels and message retention policies

### DIFF
--- a/config/broker.conf
+++ b/config/broker.conf
@@ -15,6 +15,12 @@ mqtt {
     property_size = 32
     max_topic_alias = 10
     receive_max = 65535
+
+    # Enable persistent sessions for QoS 1+ subscribers.
+    # When a client reconnects with the same client_id, the broker
+    # delivers any queued QoS 1/2 messages that arrived while offline.
+    session_expiry_interval = 3600  # 1 hour
+    max_inflight_window = 32
 }
 
 # Logging

--- a/src/openbad/nervous_system/client.py
+++ b/src/openbad/nervous_system/client.py
@@ -16,6 +16,8 @@ from typing import Any, TypeVar
 import paho.mqtt.client as mqtt
 from google.protobuf.message import DecodeError, Message
 
+from openbad.nervous_system.qos import qos_for, should_retain
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=Message)
@@ -133,10 +135,18 @@ class NervousSystemClient:
         self,
         topic: str,
         message: Message,
-        qos: int = 0,
-        retain: bool = False,
+        qos: int | None = None,
+        retain: bool | None = None,
     ) -> None:
-        """Serialize a protobuf message and publish to *topic*."""
+        """Serialize a protobuf message and publish to *topic*.
+
+        If *qos* or *retain* are not specified, the values are determined
+        automatically from the topic-based QoS/retention policies.
+        """
+        if qos is None:
+            qos = qos_for(topic)
+        if retain is None:
+            retain = should_retain(topic)
         payload = message.SerializeToString()
         info = self._mqtt.publish(topic, payload, qos=qos, retain=retain)
         if info.rc != mqtt.MQTT_ERR_SUCCESS:
@@ -147,12 +157,15 @@ class NervousSystemClient:
         topic: str,
         message_type: type[T],
         callback: Callable[[str, T], Any],
-        qos: int = 0,
+        qos: int | None = None,
     ) -> None:
         """Subscribe to *topic* with typed deserialization.
 
         *callback* receives ``(topic, parsed_message)``.
+        If *qos* is not specified, uses the topic-based QoS policy.
         """
+        if qos is None:
+            qos = qos_for(topic)
         if topic not in self._subscriptions:
             self._subscriptions[topic] = []
             self._mqtt.subscribe(topic, qos=qos)

--- a/src/openbad/nervous_system/qos.py
+++ b/src/openbad/nervous_system/qos.py
@@ -1,0 +1,96 @@
+"""QoS levels and message retention policies for the MQTT nervous system.
+
+Defines per-topic QoS assignments and retained-message policies so that
+every publish/subscribe operation uses the correct delivery guarantee
+without callers needing to specify QoS manually.
+
+QoS Policy
+==========
+
+=========  ===========  ==============================================
+QoS Level  Guarantee    Topics
+=========  ===========  ==============================================
+0          Fire & forget  ``agent/telemetry/*`` (high-frequency metrics)
+1          At-least-once  ``agent/reflex/*/trigger``, ``agent/cognitive/*``,
+                          ``agent/immune/*``, ``agent/proprioception/*``
+2          Exactly-once   ``agent/endocrine/*``, ``agent/memory/*``,
+                          ``agent/sleep/*``
+=========  ===========  ==============================================
+
+Retention Policy
+================
+
+Retained messages are enabled for "state" topics so that late-joining
+subscribers get the latest snapshot immediately:
+
+- ``agent/reflex/state``
+- ``agent/telemetry/*``
+
+Usage::
+
+    from openbad.nervous_system.qos import qos_for, should_retain
+
+    qos = qos_for("agent/telemetry/cpu")     # → 0
+    retain = should_retain("agent/reflex/state")  # → True
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# QoS rules: each entry is (regex_pattern, qos_level).
+# Evaluated in order; first match wins.
+# ---------------------------------------------------------------------------
+_QOS_RULES: list[tuple[re.Pattern[str], int]] = [
+    # QoS 0 — fire-and-forget (high-frequency telemetry)
+    (re.compile(r"^agent/telemetry(/|$)"), 0),
+    # QoS 2 — exactly-once (state transitions)
+    (re.compile(r"^agent/endocrine(/|$)"), 2),
+    (re.compile(r"^agent/memory(/|$)"), 2),
+    (re.compile(r"^agent/sleep(/|$)"), 2),
+    # QoS 1 — at-least-once (critical operational messages)
+    (re.compile(r"^agent/reflex(/|$)"), 1),
+    (re.compile(r"^agent/cognitive(/|$)"), 1),
+    (re.compile(r"^agent/immune(/|$)"), 1),
+    (re.compile(r"^agent/proprioception(/|$)"), 1),
+    (re.compile(r"^agent/sensory(/|$)"), 1),
+]
+
+# Default QoS for topics that don't match any rule
+_DEFAULT_QOS = 1
+
+# ---------------------------------------------------------------------------
+# Retention rules: topics matching these patterns get retain=True.
+# ---------------------------------------------------------------------------
+_RETAIN_RULES: list[re.Pattern[str]] = [
+    re.compile(r"^agent/reflex/state$"),
+    re.compile(r"^agent/telemetry/"),
+]
+
+
+def qos_for(topic: str) -> int:
+    """Return the QoS level for the given topic.
+
+    >>> qos_for("agent/telemetry/cpu")
+    0
+    >>> qos_for("agent/immune/alert")
+    1
+    >>> qos_for("agent/endocrine/cortisol")
+    2
+    """
+    for pattern, qos in _QOS_RULES:
+        if pattern.search(topic):
+            return qos
+    return _DEFAULT_QOS
+
+
+def should_retain(topic: str) -> bool:
+    """Return True if the topic should use MQTT retained messages.
+
+    >>> should_retain("agent/reflex/state")
+    True
+    >>> should_retain("agent/immune/alert")
+    False
+    """
+    return any(pattern.search(topic) for pattern in _RETAIN_RULES)

--- a/tests/test_qos.py
+++ b/tests/test_qos.py
@@ -1,0 +1,170 @@
+"""Tests for openbad.nervous_system.qos — QoS and retention policies."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.nervous_system.qos import qos_for, should_retain
+
+# ── QoS level assignments ─────────────────────────────────────────
+
+
+class TestQosFor:
+    """Verify per-topic QoS assignments match the spec."""
+
+    # -- QoS 0: fire-and-forget (telemetry) -------------------------
+
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            "agent/telemetry/cpu",
+            "agent/telemetry/memory",
+            "agent/telemetry/disk",
+            "agent/telemetry/tokens",
+        ],
+    )
+    def test_telemetry_is_qos0(self, topic: str):
+        assert qos_for(topic) == 0
+
+    # -- QoS 1: at-least-once (operational messages) ----------------
+
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            "agent/reflex/thermal/trigger",
+            "agent/reflex/state",
+            "agent/cognitive/escalation",
+            "agent/cognitive/result",
+            "agent/immune/alert",
+            "agent/immune/quarantine",
+            "agent/proprioception/tool-a/heartbeat",
+            "agent/sensory/vision/cam-1",
+        ],
+    )
+    def test_operational_is_qos1(self, topic: str):
+        assert qos_for(topic) == 1
+
+    # -- QoS 2: exactly-once (state transitions) --------------------
+
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            "agent/endocrine/cortisol",
+            "agent/endocrine/adrenaline",
+            "agent/endocrine/endorphin",
+            "agent/memory/stm/write",
+            "agent/memory/ltm/consolidate",
+            "agent/sleep/rem",
+            "agent/sleep/deep",
+        ],
+    )
+    def test_state_transitions_are_qos2(self, topic: str):
+        assert qos_for(topic) == 2
+
+    # -- Default QoS ------------------------------------------------
+
+    def test_unknown_topic_gets_default_qos1(self):
+        assert qos_for("agent/unknown/something") == 1
+
+    def test_completely_foreign_topic(self):
+        assert qos_for("other/system/topic") == 1
+
+
+# ── Retention policy ──────────────────────────────────────────────
+
+
+class TestShouldRetain:
+    """Verify retained-message policy for state topics."""
+
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            "agent/reflex/state",
+            "agent/telemetry/cpu",
+            "agent/telemetry/memory",
+            "agent/telemetry/disk",
+            "agent/telemetry/tokens",
+        ],
+    )
+    def test_state_topics_are_retained(self, topic: str):
+        assert should_retain(topic) is True
+
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            "agent/reflex/thermal/trigger",
+            "agent/cognitive/escalation",
+            "agent/immune/alert",
+            "agent/endocrine/cortisol",
+            "agent/memory/stm/write",
+            "agent/proprioception/tool-a/heartbeat",
+        ],
+    )
+    def test_non_state_topics_are_not_retained(self, topic: str):
+        assert should_retain(topic) is False
+
+
+# ── Client integration ────────────────────────────────────────────
+
+
+class TestClientAutoQos:
+    """Verify NervousSystemClient uses qos/retention policies automatically."""
+
+    def test_publish_uses_policy_qos(self):
+        from unittest.mock import patch
+
+        from openbad.nervous_system.client import NervousSystemClient
+        from openbad.nervous_system.schemas import CpuTelemetry
+
+        NervousSystemClient.reset_instance()
+        with patch("openbad.nervous_system.client.mqtt.Client"):
+            client = NervousSystemClient.get_instance()
+            msg = CpuTelemetry(usage_percent=50.0)
+
+            client.publish("agent/telemetry/cpu", msg)
+
+            call_args = client._mqtt.publish.call_args
+            # publish(topic, payload, qos=0, retain=True) for telemetry
+            assert call_args.kwargs["qos"] == 0
+            assert call_args.kwargs["retain"] is True
+            NervousSystemClient.reset_instance()
+
+    def test_publish_allows_explicit_qos_override(self):
+        from unittest.mock import patch
+
+        from openbad.nervous_system.client import NervousSystemClient
+        from openbad.nervous_system.schemas import CpuTelemetry
+
+        NervousSystemClient.reset_instance()
+        with patch("openbad.nervous_system.client.mqtt.Client"):
+            client = NervousSystemClient.get_instance()
+            msg = CpuTelemetry(usage_percent=50.0)
+
+            # Override QoS 0 → QoS 2
+            client.publish("agent/telemetry/cpu", msg, qos=2, retain=False)
+
+            call_args = client._mqtt.publish.call_args
+            assert call_args.kwargs["qos"] == 2
+            assert call_args.kwargs["retain"] is False
+            NervousSystemClient.reset_instance()
+
+
+# ── Broker config ─────────────────────────────────────────────────
+
+
+class TestBrokerConfig:
+    """Verify broker config supports persistent sessions."""
+
+    def test_session_expiry_configured(self):
+        from pathlib import Path
+
+        config_path = Path(__file__).resolve().parents[1] / "config" / "broker.conf"
+        content = config_path.read_text()
+        assert "session_expiry_interval" in content
+
+    def test_max_inflight_configured(self):
+        from pathlib import Path
+
+        config_path = Path(__file__).resolve().parents[1] / "config" / "broker.conf"
+        content = config_path.read_text()
+        assert "max_inflight_window" in content


### PR DESCRIPTION
Closes #6

## Summary

Per-topic QoS levels and message retention policies, integrated into the MQTT client wrapper and broker config.

## Changes

- **`src/openbad/nervous_system/qos.py`** — QoS/retention policy module:
  - `qos_for(topic)` — returns QoS 0/1/2 based on regex pattern matching
  - `should_retain(topic)` — returns True for state/telemetry topics
  - QoS 0: `agent/telemetry/*` (fire-and-forget, high-frequency)
  - QoS 1: `agent/reflex/*`, `agent/cognitive/*`, `agent/immune/*`, etc. (at-least-once)
  - QoS 2: `agent/endocrine/*`, `agent/memory/*`, `agent/sleep/*` (exactly-once)
  - Retained: `agent/reflex/state`, `agent/telemetry/*`
  
- **`src/openbad/nervous_system/client.py`** — Updated publish/subscribe:
  - `publish()` and `subscribe()` now default QoS from `qos_for()` policy
  - `publish()` defaults retain from `should_retain()` policy
  - Explicit overrides still accepted
  
- **`config/broker.conf`** — Persistent session support:
  - `session_expiry_interval = 3600` (1 hour)
  - `max_inflight_window = 32`

- **`tests/test_qos.py`** — 36 tests: QoS 0/1/2 assignments, retention rules, client integration, broker config

## How to Test

```bash
make test   # 344 passed
make lint   # all checks passed
```