### PR TITLE
#12: Implement FSM engine with agent operational states

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 dependencies = [
     "protobuf>=5.0",
     "paho-mqtt>=2.0",
+    "transitions>=0.9",
 ]
 
 [project.optional-dependencies]

--- a/src/openbad/reflex_arc/fsm.py
+++ b/src/openbad/reflex_arc/fsm.py
@@ -1,0 +1,181 @@
+"""Finite state machine for agent operational states.
+
+Uses the ``transitions`` library (MIT) to model the agent lifecycle:
+
+    IDLE → ACTIVE → THROTTLED → SLEEP → EMERGENCY
+
+Transitions are triggered by event-bus messages and publish the new
+state to ``agent/reflex/state`` after every transition.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+from transitions import Machine, MachineError  # type: ignore[import-untyped]
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexState
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+STATES = ["IDLE", "ACTIVE", "THROTTLED", "SLEEP", "EMERGENCY"]
+
+TRANSITIONS = [
+    # Normal flow
+    {"trigger": "activate", "source": "IDLE", "dest": "ACTIVE"},
+    {"trigger": "deactivate", "source": "ACTIVE", "dest": "IDLE"},
+    # Throttle
+    {"trigger": "throttle", "source": "ACTIVE", "dest": "THROTTLED"},
+    {"trigger": "throttle", "source": "IDLE", "dest": "THROTTLED"},
+    {"trigger": "recover_throttle", "source": "THROTTLED", "dest": "IDLE"},
+    # Sleep / consolidation
+    {"trigger": "sleep", "source": "ACTIVE", "dest": "SLEEP"},
+    {"trigger": "sleep", "source": "IDLE", "dest": "SLEEP"},
+    {"trigger": "wake", "source": "SLEEP", "dest": "IDLE"},
+    # Emergency
+    {"trigger": "emergency", "source": "*", "dest": "EMERGENCY"},
+    {"trigger": "recover_emergency", "source": "EMERGENCY", "dest": "IDLE"},
+]
+
+# Map event-bus topics/conditions to FSM trigger names.
+TOPIC_TRIGGER_MAP: dict[str, str] = {
+    "agent/endocrine/cortisol": "throttle",
+    "agent/endocrine/adrenaline": "emergency",
+    "agent/endocrine/endorphin": "sleep",
+    "agent/immune/alert": "emergency",
+}
+
+
+# ---------------------------------------------------------------------------
+# AgentFSM
+# ---------------------------------------------------------------------------
+
+
+class AgentFSM:
+    """Thread-safe FSM governing the agent's operational state.
+
+    Parameters
+    ----------
+    client:
+        Optional :class:`NervousSystemClient` used to subscribe to
+        trigger topics and publish state transitions.  When *None*,
+        the FSM works standalone (useful for testing).
+    """
+
+    def __init__(self, client: object | None = None) -> None:
+        self._lock = threading.Lock()
+        self._client = client
+        self.state: str = "IDLE"  # set by transitions library internally
+
+        self._machine = Machine(
+            model=self,
+            states=STATES,
+            transitions=TRANSITIONS,
+            initial="IDLE",
+            send_event=True,
+            after_state_change="on_state_change",
+        )
+
+    # ------------------------------------------------------------------
+    # State-change callback
+    # ------------------------------------------------------------------
+
+    def on_state_change(self, event: object) -> None:
+        """Called by *transitions* after every state change."""
+        # ``event`` is a transitions.EventData instance
+        src = getattr(event, "transition", None)
+        source_name = src.source if src else "?"
+        trigger_name = getattr(event, "event", None)
+        trigger_str = trigger_name.name if trigger_name else "?"
+        logger.info("FSM: %s → %s (trigger=%s)", source_name, self.state, trigger_str)
+
+        if self._client is not None:
+            msg = ReflexState(
+                header=Header(timestamp_unix=time.time()),
+                previous_state=source_name,
+                current_state=self.state,
+                trigger_event=trigger_str,
+            )
+            self._client.publish("agent/reflex/state", msg.SerializeToString())
+
+    # ------------------------------------------------------------------
+    # Thread-safe trigger dispatch
+    # ------------------------------------------------------------------
+
+    def fire(self, trigger_name: str) -> bool:
+        """Fire a named trigger atomically.
+
+        Returns *True* if the transition succeeded, *False* if the
+        transition is invalid for the current state.
+        """
+        with self._lock:
+            try:
+                # Use the machine's event dispatch directly to avoid
+                # shadowing the transitions-generated trigger methods.
+                self._machine.events[trigger_name].trigger(self)
+                return True
+            except (MachineError, AttributeError, KeyError):
+                logger.warning(
+                    "FSM: invalid trigger '%s' in state '%s'",
+                    trigger_name,
+                    self.state,
+                )
+                return False
+
+    # ------------------------------------------------------------------
+    # Event-bus integration
+    # ------------------------------------------------------------------
+
+    def handle_event(self, topic: str, payload: bytes) -> bool:
+        """Route an event-bus message to the correct FSM trigger.
+
+        For ``agent/endocrine/cortisol`` the trigger fires only when
+        the message severity is CRITICAL.  For ``agent/immune/alert``
+        the trigger fires only when severity is CRITICAL.
+
+        Returns *True* if a transition was fired, *False* otherwise.
+        """
+        trigger_name = TOPIC_TRIGGER_MAP.get(topic)
+        if trigger_name is None:
+            return False
+
+        # Severity gating for cortisol and immune/alert
+        if topic in ("agent/endocrine/cortisol", "agent/immune/alert"):
+            severity = self._extract_severity(topic, payload)
+            if severity != 3:  # CRITICAL = 3 in the proto enum
+                return False
+
+        return self.fire(trigger_name)
+
+    @staticmethod
+    def _extract_severity(topic: str, payload: bytes) -> int:
+        """Extract the severity int from the protobuf payload."""
+        from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+        from openbad.nervous_system.schemas.immune_pb2 import ImmuneAlert
+
+        try:
+            if topic.startswith("agent/endocrine/"):
+                msg = EndocrineEvent()
+                msg.ParseFromString(payload)
+                return msg.severity
+            if topic.startswith("agent/immune/"):
+                msg = ImmuneAlert()
+                msg.ParseFromString(payload)
+                return msg.severity
+        except Exception:
+            logger.exception("FSM: failed to parse severity from %s", topic)
+        return 0
+
+    def subscribe_triggers(self) -> None:
+        """Subscribe to all trigger topics via the MQTT client."""
+        if self._client is None:
+            return
+        for topic in TOPIC_TRIGGER_MAP:
+            self._client.subscribe(topic, self.handle_event)

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -1,0 +1,262 @@
+"""Tests for openbad.reflex_arc.fsm — FSM engine with agent operational states."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.nervous_system.schemas.immune_pb2 import ImmuneAlert
+from openbad.reflex_arc.fsm import STATES, TOPIC_TRIGGER_MAP, AgentFSM
+
+
+@pytest.fixture
+def fsm():
+    return AgentFSM()
+
+
+@pytest.fixture
+def client_mock():
+    return MagicMock()
+
+
+@pytest.fixture
+def fsm_with_client(client_mock):
+    return AgentFSM(client=client_mock)
+
+
+# ── States & initial state ────────────────────────────────────────
+
+
+class TestStates:
+    def test_all_states_defined(self):
+        assert STATES == ["IDLE", "ACTIVE", "THROTTLED", "SLEEP", "EMERGENCY"]
+
+    def test_initial_state_idle(self, fsm: AgentFSM):
+        assert fsm.state == "IDLE"
+
+
+# ── Valid transitions ─────────────────────────────────────────────
+
+
+class TestValidTransitions:
+    def test_idle_to_active(self, fsm: AgentFSM):
+        assert fsm.fire("activate")
+        assert fsm.state == "ACTIVE"
+
+    def test_active_to_idle(self, fsm: AgentFSM):
+        fsm.fire("activate")
+        assert fsm.fire("deactivate")
+        assert fsm.state == "IDLE"
+
+    def test_active_to_throttled(self, fsm: AgentFSM):
+        fsm.fire("activate")
+        assert fsm.fire("throttle")
+        assert fsm.state == "THROTTLED"
+
+    def test_idle_to_throttled(self, fsm: AgentFSM):
+        assert fsm.fire("throttle")
+        assert fsm.state == "THROTTLED"
+
+    def test_throttled_to_idle(self, fsm: AgentFSM):
+        fsm.fire("throttle")
+        assert fsm.fire("recover_throttle")
+        assert fsm.state == "IDLE"
+
+    def test_active_to_sleep(self, fsm: AgentFSM):
+        fsm.fire("activate")
+        assert fsm.fire("sleep")
+        assert fsm.state == "SLEEP"
+
+    def test_idle_to_sleep(self, fsm: AgentFSM):
+        assert fsm.fire("sleep")
+        assert fsm.state == "SLEEP"
+
+    def test_sleep_to_idle(self, fsm: AgentFSM):
+        fsm.fire("sleep")
+        assert fsm.fire("wake")
+        assert fsm.state == "IDLE"
+
+    def test_emergency_from_any(self, fsm: AgentFSM):
+        """Emergency transition works from every state."""
+        for setup_triggers, _expected_source in [
+            ([], "IDLE"),
+            (["activate"], "ACTIVE"),
+            (["throttle"], "THROTTLED"),
+            (["sleep"], "SLEEP"),
+        ]:
+            fresh = AgentFSM()
+            for t in setup_triggers:
+                fresh.fire(t)
+            assert fresh.fire("emergency")
+            assert fresh.state == "EMERGENCY"
+
+    def test_emergency_to_idle(self, fsm: AgentFSM):
+        fsm.fire("emergency")
+        assert fsm.fire("recover_emergency")
+        assert fsm.state == "IDLE"
+
+
+# ── Invalid transitions ───────────────────────────────────────────
+
+
+class TestInvalidTransitions:
+    def test_deactivate_from_idle(self, fsm: AgentFSM):
+        assert not fsm.fire("deactivate")
+        assert fsm.state == "IDLE"
+
+    def test_wake_from_idle(self, fsm: AgentFSM):
+        assert not fsm.fire("wake")
+        assert fsm.state == "IDLE"
+
+    def test_recover_throttle_from_idle(self, fsm: AgentFSM):
+        assert not fsm.fire("recover_throttle")
+        assert fsm.state == "IDLE"
+
+    def test_activate_from_throttled(self, fsm: AgentFSM):
+        fsm.fire("throttle")
+        assert not fsm.fire("activate")
+        assert fsm.state == "THROTTLED"
+
+    def test_nonexistent_trigger(self, fsm: AgentFSM):
+        assert not fsm.fire("fly_to_moon")
+        assert fsm.state == "IDLE"
+
+
+# ── Event bus publishing ──────────────────────────────────────────
+
+
+class TestPublishing:
+    def test_publishes_on_transition(self, fsm_with_client: AgentFSM, client_mock):
+        fsm_with_client.fire("activate")
+        client_mock.publish.assert_called_once()
+        topic, payload = client_mock.publish.call_args[0]
+        assert topic == "agent/reflex/state"
+        # Deserialize and verify
+        from openbad.nervous_system.schemas.reflex_pb2 import ReflexState
+
+        msg = ReflexState()
+        msg.ParseFromString(payload)
+        assert msg.previous_state == "IDLE"
+        assert msg.current_state == "ACTIVE"
+        assert msg.trigger_event == "activate"
+
+    def test_no_publish_on_invalid_transition(self, fsm_with_client: AgentFSM, client_mock):
+        fsm_with_client.fire("deactivate")
+        client_mock.publish.assert_not_called()
+
+
+# ── handle_event integration ──────────────────────────────────────
+
+
+def _cortisol_critical() -> bytes:
+    return EndocrineEvent(
+        header=Header(timestamp_unix=1.0),
+        hormone="cortisol",
+        severity=3,  # CRITICAL
+    ).SerializeToString()
+
+
+def _cortisol_warning() -> bytes:
+    return EndocrineEvent(
+        header=Header(timestamp_unix=1.0),
+        hormone="cortisol",
+        severity=2,  # WARNING
+    ).SerializeToString()
+
+
+def _immune_critical() -> bytes:
+    return ImmuneAlert(
+        header=Header(timestamp_unix=1.0),
+        severity=3,
+        threat_type="prompt-injection",
+    ).SerializeToString()
+
+
+def _immune_info() -> bytes:
+    return ImmuneAlert(
+        header=Header(timestamp_unix=1.0),
+        severity=1,
+        threat_type="benign",
+    ).SerializeToString()
+
+
+class TestHandleEvent:
+    def test_cortisol_critical_throttles(self, fsm: AgentFSM):
+        assert fsm.handle_event("agent/endocrine/cortisol", _cortisol_critical())
+        assert fsm.state == "THROTTLED"
+
+    def test_cortisol_warning_no_transition(self, fsm: AgentFSM):
+        assert not fsm.handle_event("agent/endocrine/cortisol", _cortisol_warning())
+        assert fsm.state == "IDLE"
+
+    def test_adrenaline_triggers_emergency(self, fsm: AgentFSM):
+        payload = EndocrineEvent(
+            header=Header(timestamp_unix=1.0),
+            hormone="adrenaline",
+        ).SerializeToString()
+        assert fsm.handle_event("agent/endocrine/adrenaline", payload)
+        assert fsm.state == "EMERGENCY"
+
+    def test_endorphin_triggers_sleep(self, fsm: AgentFSM):
+        payload = EndocrineEvent(
+            header=Header(timestamp_unix=1.0),
+            hormone="endorphin",
+        ).SerializeToString()
+        assert fsm.handle_event("agent/endocrine/endorphin", payload)
+        assert fsm.state == "SLEEP"
+
+    def test_immune_critical_triggers_emergency(self, fsm: AgentFSM):
+        assert fsm.handle_event("agent/immune/alert", _immune_critical())
+        assert fsm.state == "EMERGENCY"
+
+    def test_immune_info_no_transition(self, fsm: AgentFSM):
+        assert not fsm.handle_event("agent/immune/alert", _immune_info())
+        assert fsm.state == "IDLE"
+
+    def test_unknown_topic_ignored(self, fsm: AgentFSM):
+        assert not fsm.handle_event("agent/telemetry/cpu", b"")
+        assert fsm.state == "IDLE"
+
+
+# ── subscribe_triggers ────────────────────────────────────────────
+
+
+class TestSubscribeTriggers:
+    def test_subscribes_all_trigger_topics(self, fsm_with_client: AgentFSM, client_mock):
+        fsm_with_client.subscribe_triggers()
+        subscribed_topics = {c.args[0] for c in client_mock.subscribe.call_args_list}
+        assert subscribed_topics == set(TOPIC_TRIGGER_MAP)
+
+    def test_no_subscribe_without_client(self, fsm: AgentFSM):
+        # Should not raise
+        fsm.subscribe_triggers()
+
+
+# ── Concurrent transitions (atomicity) ────────────────────────────
+
+
+class TestConcurrency:
+    def test_atomic_transitions_under_contention(self):
+        """Fire many triggers concurrently — FSM must remain consistent."""
+        fsm = AgentFSM()
+        errors: list[str] = []
+        barrier = threading.Barrier(10)
+
+        def fire(trigger_name: str) -> None:
+            barrier.wait()
+            fsm.fire(trigger_name)
+            if fsm.state not in STATES:
+                errors.append(f"Invalid state: {fsm.state}")
+
+        threads = [threading.Thread(target=fire, args=("emergency",)) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert fsm.state == "EMERGENCY"


### PR DESCRIPTION
Closes #12

## Summary of Changes
- Added `transitions>=0.9` (MIT) to runtime dependencies
- Created `src/openbad/reflex_arc/fsm.py`:
  - `AgentFSM` class with states: IDLE, ACTIVE, THROTTLED, SLEEP, EMERGENCY
  - Thread-safe `fire()` method with `threading.Lock`
  - `on_state_change` callback publishes `ReflexState` protobuf to `agent/reflex/state`
  - `handle_event()` routes event-bus messages to FSM triggers with severity gating
  - `subscribe_triggers()` subscribes to all trigger topics via MQTT client
  - Supports: cortisol (critical) → THROTTLED, adrenaline → EMERGENCY, endorphin → SLEEP, immune/alert (critical) → EMERGENCY
- Created `tests/test_fsm.py` (29 tests):
  - All valid transitions
  - Invalid transitions rejected cleanly
  - State published to event bus on transition
  - Concurrent transitions under contention (threading.Barrier)
  - handle_event integration with protobuf severity gating
  - subscribe_triggers integration

## How to Test
```bash
pytest tests/test_fsm.py -v
```