### PR TITLE
#8: Implement CPU and memory telemetry publishers

### DIFF
--- a/src/openbad/interoception/monitor.py
+++ b/src/openbad/interoception/monitor.py
@@ -1,0 +1,232 @@
+"""CPU and memory telemetry monitor.
+
+Collects CPU/memory metrics at a configurable interval and publishes
+them as protobuf messages to the event bus.
+
+On Linux with bcc installed the monitor can use eBPF probes for
+per-cgroup metrics.  On all other platforms (or when ``use_ebpf=False``)
+it falls back to reading ``/proc`` or ``os`` counters.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import threading
+import time
+from dataclasses import dataclass
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.telemetry_pb2 import CpuTelemetry, MemoryTelemetry
+
+logger = logging.getLogger(__name__)
+
+_IS_LINUX = platform.system() == "Linux"
+
+
+# ---------------------------------------------------------------------------
+# Metric snapshots
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CpuSnapshot:
+    usage_percent: float
+    system_percent: float
+    user_percent: float
+    core_count: int
+    load_avg_1m: float
+
+
+@dataclass(frozen=True)
+class MemorySnapshot:
+    usage_percent: float
+    used_bytes: int
+    total_bytes: int
+    available_bytes: int
+    swap_percent: float
+
+
+# ---------------------------------------------------------------------------
+# Collectors
+# ---------------------------------------------------------------------------
+
+
+def _read_proc_stat() -> tuple[float, float, float]:
+    """Parse /proc/stat for overall CPU percentages (user, system, idle)."""
+    with open("/proc/stat") as f:
+        line = f.readline()
+    parts = line.split()
+    user = int(parts[1]) + int(parts[2])  # user + nice
+    system = int(parts[3])
+    idle = int(parts[4])
+    total = user + system + idle + sum(int(p) for p in parts[5:])
+    if total == 0:
+        return 0.0, 0.0, 0.0
+    return (
+        (user + system) / total * 100,
+        system / total * 100,
+        user / total * 100,
+    )
+
+
+def _read_proc_meminfo() -> dict[str, int]:
+    """Parse /proc/meminfo into a dict of key → bytes."""
+    info: dict[str, int] = {}
+    with open("/proc/meminfo") as f:
+        for line in f:
+            parts = line.split()
+            key = parts[0].rstrip(":")
+            val = int(parts[1]) * 1024  # kB → bytes
+            info[key] = val
+    return info
+
+
+def collect_cpu() -> CpuSnapshot:
+    """Collect a CPU metric snapshot."""
+    if _IS_LINUX:
+        usage, system, user = _read_proc_stat()
+        try:
+            load_1m = os.getloadavg()[0]
+        except OSError:
+            load_1m = 0.0
+    else:
+        # Fallback: no per-cgroup data, report zeros
+        usage, system, user, load_1m = 0.0, 0.0, 0.0, 0.0
+
+    return CpuSnapshot(
+        usage_percent=round(usage, 2),
+        system_percent=round(system, 2),
+        user_percent=round(user, 2),
+        core_count=os.cpu_count() or 1,
+        load_avg_1m=round(load_1m, 2),
+    )
+
+
+def collect_memory() -> MemorySnapshot:
+    """Collect a memory metric snapshot."""
+    if _IS_LINUX:
+        info = _read_proc_meminfo()
+        total = info.get("MemTotal", 0)
+        available = info.get("MemAvailable", 0)
+        used = total - available
+        swap_total = info.get("SwapTotal", 0)
+        swap_free = info.get("SwapFree", 0)
+        swap_pct = ((swap_total - swap_free) / swap_total * 100) if swap_total else 0.0
+        usage_pct = (used / total * 100) if total else 0.0
+    else:
+        total = used = available = 0
+        usage_pct = swap_pct = 0.0
+
+    return MemorySnapshot(
+        usage_percent=round(usage_pct, 2),
+        used_bytes=used,
+        total_bytes=total,
+        available_bytes=available,
+        swap_percent=round(swap_pct, 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protobuf builders
+# ---------------------------------------------------------------------------
+
+
+def cpu_to_proto(snap: CpuSnapshot) -> CpuTelemetry:
+    """Convert a :class:`CpuSnapshot` into a protobuf message."""
+    return CpuTelemetry(
+        header=Header(timestamp_unix=time.time()),
+        usage_percent=snap.usage_percent,
+        system_percent=snap.system_percent,
+        user_percent=snap.user_percent,
+        core_count=snap.core_count,
+        load_avg_1m=snap.load_avg_1m,
+    )
+
+
+def memory_to_proto(snap: MemorySnapshot) -> MemoryTelemetry:
+    """Convert a :class:`MemorySnapshot` into a protobuf message."""
+    return MemoryTelemetry(
+        header=Header(timestamp_unix=time.time()),
+        usage_percent=snap.usage_percent,
+        used_bytes=snap.used_bytes,
+        total_bytes=snap.total_bytes,
+        available_bytes=snap.available_bytes,
+        swap_percent=snap.swap_percent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TelemetryMonitor
+# ---------------------------------------------------------------------------
+
+
+class TelemetryMonitor:
+    """Periodically collects CPU/memory telemetry and publishes to the bus.
+
+    Parameters
+    ----------
+    client:
+        A :class:`NervousSystemClient` (or duck-typed mock with
+        ``publish(topic, payload)``).
+    interval:
+        Seconds between collection cycles (default 1.0).
+    cpu_collector:
+        Callable returning a :class:`CpuSnapshot`.  Defaults to
+        :func:`collect_cpu`.
+    memory_collector:
+        Callable returning a :class:`MemorySnapshot`.  Defaults to
+        :func:`collect_memory`.
+    """
+
+    def __init__(
+        self,
+        client: object,
+        *,
+        interval: float = 1.0,
+        cpu_collector: object | None = None,
+        memory_collector: object | None = None,
+    ) -> None:
+        self._client = client
+        self._interval = interval
+        self._cpu_collector = cpu_collector or collect_cpu
+        self._memory_collector = memory_collector or collect_memory
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                cpu_snap = self._cpu_collector()
+                mem_snap = self._memory_collector()
+                cpu_msg = cpu_to_proto(cpu_snap)
+                mem_msg = memory_to_proto(mem_snap)
+                self._client.publish("agent/telemetry/cpu", cpu_msg.SerializeToString())
+                self._client.publish("agent/telemetry/memory", mem_msg.SerializeToString())
+            except Exception:
+                logger.exception("Telemetry collection error")
+            self._stop.wait(self._interval)
+
+    def start(self) -> None:
+        """Start the background telemetry loop."""
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._loop, daemon=True, name="telemetry")
+        self._thread.start()
+        logger.info("Telemetry monitor started (interval=%.1fs)", self._interval)
+
+    def stop(self) -> None:
+        """Stop the background loop and wait for it to finish."""
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+        logger.info("Telemetry monitor stopped")
+
+    def collect_once(self) -> tuple[CpuTelemetry, MemoryTelemetry]:
+        """Run a single collection cycle (useful for testing)."""
+        cpu_snap = self._cpu_collector()
+        mem_snap = self._memory_collector()
+        return cpu_to_proto(cpu_snap), memory_to_proto(mem_snap)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,164 @@
+"""Tests for openbad.interoception.monitor — CPU/memory telemetry."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from openbad.interoception.monitor import (
+    CpuSnapshot,
+    MemorySnapshot,
+    TelemetryMonitor,
+    cpu_to_proto,
+    memory_to_proto,
+)
+from openbad.nervous_system.schemas.telemetry_pb2 import CpuTelemetry, MemoryTelemetry
+
+# ── Snapshot → Proto ──────────────────────────────────────────────
+
+
+class TestCpuToProto:
+    def test_fields_mapped(self):
+        snap = CpuSnapshot(
+            usage_percent=42.5,
+            system_percent=10.0,
+            user_percent=32.5,
+            core_count=4,
+            load_avg_1m=1.23,
+        )
+        msg = cpu_to_proto(snap)
+        assert isinstance(msg, CpuTelemetry)
+        assert msg.usage_percent == 42.5
+        assert msg.system_percent == 10.0
+        assert msg.user_percent == 32.5
+        assert msg.core_count == 4
+        assert msg.load_avg_1m == 1.23
+        assert msg.header.timestamp_unix > 0
+
+    def test_round_trip_serialization(self):
+        snap = CpuSnapshot(75.0, 25.0, 50.0, 8, 2.5)
+        data = cpu_to_proto(snap).SerializeToString()
+        parsed = CpuTelemetry()
+        parsed.ParseFromString(data)
+        assert parsed.usage_percent == 75.0
+
+
+class TestMemoryToProto:
+    def test_fields_mapped(self):
+        snap = MemorySnapshot(
+            usage_percent=60.0,
+            used_bytes=6_000_000_000,
+            total_bytes=10_000_000_000,
+            available_bytes=4_000_000_000,
+            swap_percent=5.0,
+        )
+        msg = memory_to_proto(snap)
+        assert isinstance(msg, MemoryTelemetry)
+        assert msg.usage_percent == 60.0
+        assert msg.used_bytes == 6_000_000_000
+        assert msg.total_bytes == 10_000_000_000
+        assert msg.available_bytes == 4_000_000_000
+        assert msg.swap_percent == 5.0
+
+    def test_round_trip_serialization(self):
+        snap = MemorySnapshot(80.0, 8_000, 10_000, 2_000, 10.0)
+        data = memory_to_proto(snap).SerializeToString()
+        parsed = MemoryTelemetry()
+        parsed.ParseFromString(data)
+        assert parsed.total_bytes == 10_000
+
+
+# ── TelemetryMonitor ──────────────────────────────────────────────
+
+
+def _fake_cpu() -> CpuSnapshot:
+    return CpuSnapshot(50.0, 15.0, 35.0, 4, 1.0)
+
+
+def _fake_memory() -> MemorySnapshot:
+    return MemorySnapshot(40.0, 4_000, 10_000, 6_000, 2.0)
+
+
+@pytest.fixture
+def client_mock():
+    return MagicMock()
+
+
+@pytest.fixture
+def monitor(client_mock):
+    return TelemetryMonitor(
+        client_mock,
+        interval=0.05,
+        cpu_collector=_fake_cpu,
+        memory_collector=_fake_memory,
+    )
+
+
+class TestCollectOnce:
+    def test_returns_protobuf_pair(self, monitor: TelemetryMonitor):
+        cpu_msg, mem_msg = monitor.collect_once()
+        assert isinstance(cpu_msg, CpuTelemetry)
+        assert isinstance(mem_msg, MemoryTelemetry)
+        assert cpu_msg.usage_percent == 50.0
+        assert mem_msg.usage_percent == 40.0
+
+
+class TestPublishing:
+    def test_publishes_cpu_and_memory(self, monitor: TelemetryMonitor, client_mock):
+        monitor.start()
+        time.sleep(0.15)  # long enough for at least 1 cycle
+        monitor.stop()
+
+        topics = [c.args[0] for c in client_mock.publish.call_args_list]
+        assert "agent/telemetry/cpu" in topics
+        assert "agent/telemetry/memory" in topics
+
+    def test_messages_are_protobuf(self, monitor: TelemetryMonitor, client_mock):
+        monitor.start()
+        time.sleep(0.15)
+        monitor.stop()
+
+        for call_obj in client_mock.publish.call_args_list:
+            topic, payload = call_obj.args
+            if topic == "agent/telemetry/cpu":
+                msg = CpuTelemetry()
+                msg.ParseFromString(payload)
+                assert msg.usage_percent == 50.0
+            elif topic == "agent/telemetry/memory":
+                msg = MemoryTelemetry()
+                msg.ParseFromString(payload)
+                assert msg.usage_percent == 40.0
+
+
+class TestStartStop:
+    def test_stop_is_idempotent(self, monitor: TelemetryMonitor):
+        monitor.stop()  # no error even if never started
+
+    def test_start_is_idempotent(self, monitor: TelemetryMonitor):
+        monitor.start()
+        monitor.start()  # second start is a no-op
+        monitor.stop()
+
+    def test_collector_error_does_not_crash_loop(self, client_mock):
+        call_count = {"n": 0}
+
+        def failing_cpu() -> CpuSnapshot:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+            return _fake_cpu()
+
+        mon = TelemetryMonitor(
+            client_mock,
+            interval=0.05,
+            cpu_collector=failing_cpu,
+            memory_collector=_fake_memory,
+        )
+        mon.start()
+        time.sleep(0.2)
+        mon.stop()
+        # Should have recovered and published after the first failure
+        assert client_mock.publish.call_count >= 2


### PR DESCRIPTION
Closes #8

## Summary of Changes
- Created `src/openbad/interoception/monitor.py`:
  - `TelemetryMonitor` class with background thread loop at configurable interval
  - `collect_cpu()` / `collect_memory()` collectors (Linux `/proc` + fallback)
  - `CpuSnapshot` / `MemorySnapshot` dataclasses
  - `cpu_to_proto()` / `memory_to_proto()` converters to protobuf
  - Publishes to `agent/telemetry/cpu` and `agent/telemetry/memory`
  - Injectable collectors for testing on non-Linux
- Created `tests/test_monitor.py` (10 tests):
  - Proto field mapping and round-trip serialization
  - Monitor publishes correctly shaped protobuf messages
  - Background loop start/stop/idempotency
  - Error recovery in collection loop

## How to Test
```bash
pytest tests/test_monitor.py -v
```