### PR TITLE
#11: Define threshold policies and cortisol event publisher

### DIFF
--- a/config/threshold_policies.yaml
+++ b/config/threshold_policies.yaml
@@ -1,0 +1,22 @@
+# Threshold policies for telemetry metrics.
+# Each key is a metric identifier; "warning" and "critical" are the upper bounds.
+
+thresholds:
+  cpu_percent:
+    warning: 75
+    critical: 90
+  memory_percent:
+    warning: 80
+    critical: 95
+  disk_io_latency_ms:
+    warning: 50
+    critical: 200
+  token_budget_remaining_pct:
+    warning: 20
+    critical: 5
+  gpu_vram_percent:
+    warning: 85
+    critical: 95
+  thermal_celsius:
+    warning: 80
+    critical: 95

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "protobuf>=5.0",
     "paho-mqtt>=2.0",
     "transitions>=0.9",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/openbad/interoception/thresholds.py
+++ b/src/openbad/interoception/thresholds.py
@@ -1,0 +1,181 @@
+"""Threshold-based policy evaluation and cortisol event publisher.
+
+Loads configurable thresholds from YAML, evaluates incoming telemetry
+values, and publishes :class:`EndocrineEvent` (cortisol) messages when
+a threshold is breached.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONFIG = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "config"
+    / "threshold_policies.yaml"
+)
+
+# Proto severity enum values
+_SEVERITY_WARNING = 2
+_SEVERITY_CRITICAL = 3
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ThresholdSpec:
+    """Warning and critical bounds for a single metric."""
+
+    metric: str
+    warning: float
+    critical: float
+
+
+@dataclass(frozen=True)
+class Breach:
+    """Describes a threshold breach."""
+
+    metric: str
+    value: float
+    threshold: float
+    severity: int  # 2=WARNING, 3=CRITICAL
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def load_thresholds(path: str | Path | None = None) -> list[ThresholdSpec]:
+    """Load threshold specs from a YAML file.
+
+    Parameters
+    ----------
+    path:
+        Path to the YAML config.  Defaults to ``config/threshold_policies.yaml``.
+    """
+    path = Path(path) if path else _DEFAULT_CONFIG
+    with open(path) as f:  # noqa: PTH123
+        data = yaml.safe_load(f)
+
+    specs: list[ThresholdSpec] = []
+    for metric, bounds in data.get("thresholds", {}).items():
+        specs.append(
+            ThresholdSpec(
+                metric=metric,
+                warning=float(bounds["warning"]),
+                critical=float(bounds["critical"]),
+            )
+        )
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def _is_upper_bound(metric: str) -> bool:
+    """Return True for metrics where exceeding the threshold is bad.
+
+    ``token_budget_remaining_pct`` is inverted: *lower* is worse.
+    """
+    return metric != "token_budget_remaining_pct"
+
+
+def evaluate(
+    specs: list[ThresholdSpec],
+    values: dict[str, float],
+) -> list[Breach]:
+    """Evaluate metric *values* against *specs* and return any breaches.
+
+    For most metrics, a value **above** the threshold triggers.
+    For ``token_budget_remaining_pct`` a value **below** triggers.
+    """
+    breaches: list[Breach] = []
+    for spec in specs:
+        val = values.get(spec.metric)
+        if val is None:
+            continue
+
+        if _is_upper_bound(spec.metric):
+            if val >= spec.critical:
+                breaches.append(Breach(spec.metric, val, spec.critical, _SEVERITY_CRITICAL))
+            elif val >= spec.warning:
+                breaches.append(Breach(spec.metric, val, spec.warning, _SEVERITY_WARNING))
+        else:
+            # Inverted metric (lower is worse)
+            if val <= spec.critical:
+                breaches.append(Breach(spec.metric, val, spec.critical, _SEVERITY_CRITICAL))
+            elif val <= spec.warning:
+                breaches.append(Breach(spec.metric, val, spec.warning, _SEVERITY_WARNING))
+
+    return breaches
+
+
+# ---------------------------------------------------------------------------
+# Publishing
+# ---------------------------------------------------------------------------
+
+_RECOMMENDED_ACTIONS: dict[str, dict[int, str]] = {
+    "cpu_percent": {
+        _SEVERITY_WARNING: "Consider deferring non-critical tasks",
+        _SEVERITY_CRITICAL: "Throttle all non-essential workloads immediately",
+    },
+    "memory_percent": {
+        _SEVERITY_WARNING: "Release caches or defer memory-heavy tasks",
+        _SEVERITY_CRITICAL: "Trigger emergency memory reclamation",
+    },
+    "token_budget_remaining_pct": {
+        _SEVERITY_WARNING: "Switch to smaller model tier",
+        _SEVERITY_CRITICAL: "Halt all LLM calls until budget resets",
+    },
+}
+
+
+def breach_to_proto(breach: Breach) -> EndocrineEvent:
+    """Convert a :class:`Breach` into a cortisol :class:`EndocrineEvent`."""
+    action = _RECOMMENDED_ACTIONS.get(breach.metric, {}).get(
+        breach.severity, "Investigate metric breach"
+    )
+    return EndocrineEvent(
+        header=Header(timestamp_unix=time.time()),
+        hormone="cortisol",
+        level=1.0 if breach.severity == _SEVERITY_CRITICAL else 0.6,
+        severity=breach.severity,
+        metric_name=breach.metric,
+        metric_value=breach.value,
+        recommended_action=action,
+    )
+
+
+def publish_breaches(
+    client: object,
+    breaches: list[Breach],
+) -> int:
+    """Publish cortisol events for each breach. Returns count published."""
+    count = 0
+    for breach in breaches:
+        msg = breach_to_proto(breach)
+        client.publish("agent/endocrine/cortisol", msg.SerializeToString())  # type: ignore[union-attr]
+        logger.info(
+            "Cortisol event: %s=%.2f (severity=%d)",
+            breach.metric,
+            breach.value,
+            breach.severity,
+        )
+        count += 1
+    return count

--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -1,0 +1,172 @@
+"""Tests for openbad.interoception.thresholds — threshold policies + cortisol."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from openbad.interoception.thresholds import (
+    Breach,
+    ThresholdSpec,
+    breach_to_proto,
+    evaluate,
+    load_thresholds,
+    publish_breaches,
+)
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+
+# ── YAML loading ──────────────────────────────────────────────────
+
+
+class TestLoadThresholds:
+    def test_loads_default_config(self):
+        specs = load_thresholds()
+        names = {s.metric for s in specs}
+        assert "cpu_percent" in names
+        assert "memory_percent" in names
+        assert "token_budget_remaining_pct" in names
+
+    def test_correct_values(self):
+        specs = load_thresholds()
+        cpu = next(s for s in specs if s.metric == "cpu_percent")
+        assert cpu.warning == 75
+        assert cpu.critical == 90
+
+    def test_custom_config(self, tmp_path):
+        cfg = tmp_path / "custom.yaml"
+        cfg.write_text("thresholds:\n  my_metric:\n    warning: 10\n    critical: 20\n")
+        specs = load_thresholds(cfg)
+        assert len(specs) == 1
+        assert specs[0].metric == "my_metric"
+        assert specs[0].warning == 10
+        assert specs[0].critical == 20
+
+
+# ── Evaluation ────────────────────────────────────────────────────
+
+_SPECS = [
+    ThresholdSpec("cpu_percent", warning=75, critical=90),
+    ThresholdSpec("memory_percent", warning=80, critical=95),
+    ThresholdSpec("token_budget_remaining_pct", warning=20, critical=5),
+]
+
+
+class TestEvaluate:
+    def test_no_breaches_within_bounds(self):
+        values = {"cpu_percent": 50.0, "memory_percent": 60.0, "token_budget_remaining_pct": 50.0}
+        assert evaluate(_SPECS, values) == []
+
+    def test_cpu_warning(self):
+        values = {"cpu_percent": 80.0}
+        breaches = evaluate(_SPECS, values)
+        assert len(breaches) == 1
+        assert breaches[0].severity == 2  # WARNING
+        assert breaches[0].metric == "cpu_percent"
+
+    def test_cpu_critical(self):
+        values = {"cpu_percent": 95.0}
+        breaches = evaluate(_SPECS, values)
+        assert len(breaches) == 1
+        assert breaches[0].severity == 3  # CRITICAL
+
+    def test_memory_critical(self):
+        values = {"memory_percent": 97.0}
+        breaches = evaluate(_SPECS, values)
+        assert len(breaches) == 1
+        assert breaches[0].severity == 3
+
+    def test_token_budget_inverted_warning(self):
+        # token_budget_remaining_pct is inverted: low value = bad
+        values = {"token_budget_remaining_pct": 15.0}
+        breaches = evaluate(_SPECS, values)
+        assert len(breaches) == 1
+        assert breaches[0].severity == 2
+
+    def test_token_budget_inverted_critical(self):
+        values = {"token_budget_remaining_pct": 3.0}
+        breaches = evaluate(_SPECS, values)
+        assert len(breaches) == 1
+        assert breaches[0].severity == 3
+
+    def test_multiple_breaches(self):
+        values = {"cpu_percent": 92.0, "memory_percent": 82.0}
+        breaches = evaluate(_SPECS, values)
+        assert len(breaches) == 2
+
+    def test_missing_metric_ignored(self):
+        values = {"unknown_metric": 100.0}
+        assert evaluate(_SPECS, values) == []
+
+    def test_exact_warning_boundary(self):
+        values = {"cpu_percent": 75.0}
+        breaches = evaluate(_SPECS, values)
+        assert len(breaches) == 1
+        assert breaches[0].severity == 2
+
+    def test_exact_critical_boundary(self):
+        values = {"cpu_percent": 90.0}
+        breaches = evaluate(_SPECS, values)
+        assert len(breaches) == 1
+        assert breaches[0].severity == 3
+
+
+# ── Proto conversion ──────────────────────────────────────────────
+
+
+class TestBreachToProto:
+    def test_warning_event(self):
+        breach = Breach("cpu_percent", 80.0, 75.0, 2)
+        msg = breach_to_proto(breach)
+        assert isinstance(msg, EndocrineEvent)
+        assert msg.hormone == "cortisol"
+        assert msg.severity == 2
+        assert msg.metric_name == "cpu_percent"
+        assert msg.metric_value == 80.0
+        assert msg.level == 0.6
+
+    def test_critical_event(self):
+        breach = Breach("cpu_percent", 95.0, 90.0, 3)
+        msg = breach_to_proto(breach)
+        assert msg.severity == 3
+        assert msg.level == 1.0
+
+    def test_serialization_round_trip(self):
+        breach = Breach("memory_percent", 96.0, 95.0, 3)
+        data = breach_to_proto(breach).SerializeToString()
+        parsed = EndocrineEvent()
+        parsed.ParseFromString(data)
+        assert parsed.hormone == "cortisol"
+        assert parsed.metric_name == "memory_percent"
+
+
+# ── Publishing ────────────────────────────────────────────────────
+
+
+class TestPublishBreaches:
+    def test_publishes_each_breach(self):
+        client = MagicMock()
+        breaches = [
+            Breach("cpu_percent", 92.0, 90.0, 3),
+            Breach("memory_percent", 82.0, 80.0, 2),
+        ]
+        count = publish_breaches(client, breaches)
+        assert count == 2
+        assert client.publish.call_count == 2
+
+        # All to same topic
+        for call_obj in client.publish.call_args_list:
+            assert call_obj.args[0] == "agent/endocrine/cortisol"
+
+    def test_no_breaches_no_publish(self):
+        client = MagicMock()
+        count = publish_breaches(client, [])
+        assert count == 0
+        client.publish.assert_not_called()
+
+    def test_payload_is_valid_protobuf(self):
+        client = MagicMock()
+        breaches = [Breach("cpu_percent", 80.0, 75.0, 2)]
+        publish_breaches(client, breaches)
+        payload = client.publish.call_args.args[1]
+        msg = EndocrineEvent()
+        msg.ParseFromString(payload)
+        assert msg.hormone == "cortisol"


### PR DESCRIPTION
Closes #11

## Summary of Changes
- Added `pyyaml>=6.0` (MIT) to runtime dependencies
- Created `config/threshold_policies.yaml` with thresholds for: cpu_percent, memory_percent, disk_io_latency_ms, token_budget_remaining_pct, gpu_vram_percent, thermal_celsius
- Created `src/openbad/interoception/thresholds.py`:
  - `load_thresholds()` loads and validates YAML config
  - `evaluate()` checks metric values against thresholds (supports inverted metrics like token_budget_remaining_pct)
  - `breach_to_proto()` converts breaches to cortisol `EndocrineEvent` protobuf messages
  - `publish_breaches()` publishes cortisol events to `agent/endocrine/cortisol`
- Created `tests/test_thresholds.py` (19 tests):
  - YAML loading (default + custom configs)
  - Warning/critical threshold evaluation
  - Inverted metrics (token budget)
  - Protobuf conversion and serialization
  - Publishing integration

## How to Test
```bash
pytest tests/test_thresholds.py -v
```