### PR TITLE
#17: Implement proprioception registry and heartbeat protocol

### DIFF
--- a/src/openbad/interoception/thresholds.py
+++ b/src/openbad/interoception/thresholds.py
@@ -20,9 +20,7 @@ from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
 logger = logging.getLogger(__name__)
 
 _DEFAULT_CONFIG = (
-    Path(__file__).resolve().parent.parent.parent.parent
-    / "config"
-    / "threshold_policies.yaml"
+    Path(__file__).resolve().parent.parent.parent.parent / "config" / "threshold_policies.yaml"
 )
 
 # Proto severity enum values

--- a/src/openbad/proprioception/registry.py
+++ b/src/openbad/proprioception/registry.py
@@ -1,0 +1,240 @@
+"""Proprioception registry — live tool/subsystem tracking with heartbeat.
+
+Each registered tool must publish periodic heartbeats.  If a heartbeat is
+not received within the configurable timeout window the tool is marked
+``UNAVAILABLE``.  On every status transition a registry snapshot is
+published to ``agent/proprioception/state``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+HEARTBEAT_TOPIC_PREFIX = "agent/proprioception/"
+HEARTBEAT_TOPIC_SUFFIX = "/heartbeat"
+STATE_TOPIC = "agent/proprioception/state"
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+class HealthStatus(Enum):
+    AVAILABLE = "AVAILABLE"
+    UNAVAILABLE = "UNAVAILABLE"
+
+
+@dataclass
+class ToolStatus:
+    """Live status entry for a single tool / subsystem."""
+
+    name: str
+    status: HealthStatus = HealthStatus.AVAILABLE
+    last_heartbeat: float = field(default_factory=time.time)
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class ToolRegistry:
+    """Thread-safe live tool registry with heartbeat-based liveness.
+
+    Parameters
+    ----------
+    timeout:
+        Seconds after which a tool with no heartbeat is UNAVAILABLE.
+    publish_fn:
+        Optional callable ``(topic, payload)`` used to emit snapshots.
+    """
+
+    def __init__(
+        self,
+        timeout: float = 10.0,
+        publish_fn: Callable[[str, bytes], None] | None = None,
+    ) -> None:
+        self._timeout = timeout
+        self._publish_fn = publish_fn
+        self._lock = threading.Lock()
+        self._tools: dict[str, ToolStatus] = {}
+        self._reaper: _ReaperThread | None = None
+
+    # -- registration -------------------------------------------------------
+
+    def register(
+        self,
+        name: str,
+        metadata: dict[str, str] | None = None,
+    ) -> ToolStatus:
+        """Register a tool/subsystem.  Idempotent for the same *name*."""
+        with self._lock:
+            if name in self._tools:
+                entry = self._tools[name]
+                entry.status = HealthStatus.AVAILABLE
+                entry.last_heartbeat = time.time()
+                if metadata:
+                    entry.metadata.update(metadata)
+            else:
+                entry = ToolStatus(
+                    name=name,
+                    metadata=metadata or {},
+                )
+                self._tools[name] = entry
+        self._emit_snapshot()
+        return entry
+
+    def unregister(self, name: str) -> bool:
+        """Remove a tool.  Returns ``True`` if it existed."""
+        with self._lock:
+            removed = self._tools.pop(name, None) is not None
+        if removed:
+            self._emit_snapshot()
+        return removed
+
+    # -- heartbeat ----------------------------------------------------------
+
+    def heartbeat(self, name: str) -> None:
+        """Record a heartbeat for *name*.
+
+        If the tool was previously UNAVAILABLE it transitions back to
+        AVAILABLE and a snapshot is published.
+        """
+        changed = False
+        with self._lock:
+            entry = self._tools.get(name)
+            if entry is None:
+                return
+            entry.last_heartbeat = time.time()
+            if entry.status is not HealthStatus.AVAILABLE:
+                entry.status = HealthStatus.AVAILABLE
+                changed = True
+        if changed:
+            self._emit_snapshot()
+
+    # -- querying -----------------------------------------------------------
+
+    def get_available_tools(self) -> list[ToolStatus]:
+        """Return tools currently healthy (AVAILABLE)."""
+        with self._lock:
+            return [t for t in self._tools.values() if t.status is HealthStatus.AVAILABLE]
+
+    def get_all_tools(self) -> list[ToolStatus]:
+        """Return all registered tools regardless of status."""
+        with self._lock:
+            return list(self._tools.values())
+
+    # -- staleness reaper ---------------------------------------------------
+
+    def reap_stale(self) -> int:
+        """Mark tools whose heartbeat is older than *timeout* as UNAVAILABLE.
+
+        Returns the number of tools whose status changed.
+        """
+        now = time.time()
+        changed = 0
+        with self._lock:
+            for entry in self._tools.values():
+                if (
+                    entry.status is HealthStatus.AVAILABLE
+                    and now - entry.last_heartbeat > self._timeout
+                ):
+                    entry.status = HealthStatus.UNAVAILABLE
+                    changed += 1
+        if changed:
+            self._emit_snapshot()
+        return changed
+
+    # -- MQTT integration ---------------------------------------------------
+
+    def subscribe_heartbeats(self, client: object) -> None:
+        """Subscribe to heartbeat topics via an MQTT *client*.
+
+        Expects ``client.subscribe(topic, callback)`` where callback
+        receives ``(topic, payload)``.
+        """
+        topic = HEARTBEAT_TOPIC_PREFIX + "+/heartbeat"
+        client.subscribe(topic, self._on_heartbeat_message)  # type: ignore[union-attr]
+
+    def _on_heartbeat_message(self, topic: str, _payload: bytes) -> None:
+        """Handle an incoming heartbeat MQTT message."""
+        # topic: agent/proprioception/<tool_id>/heartbeat
+        parts = topic.split("/")
+        if len(parts) >= 3:  # noqa: PLR2004
+            tool_id = parts[2]
+            self.heartbeat(tool_id)
+
+    # -- background reaper --------------------------------------------------
+
+    def start_reaper(self, interval: float | None = None) -> None:
+        """Start a background daemon thread that calls :meth:`reap_stale`."""
+        if self._reaper is not None:
+            return
+        self._reaper = _ReaperThread(
+            registry=self,
+            interval=interval or self._timeout / 2,
+        )
+        self._reaper.start()
+
+    def stop_reaper(self) -> None:
+        """Stop the background reaper thread."""
+        if self._reaper is not None:
+            self._reaper.stop()
+            self._reaper = None
+
+    # -- snapshot -----------------------------------------------------------
+
+    def snapshot(self) -> list[dict]:
+        """Return a JSON-serialisable snapshot of all tools."""
+        with self._lock:
+            return [
+                {
+                    "name": t.name,
+                    "status": t.status.value,
+                    "last_heartbeat": t.last_heartbeat,
+                    "metadata": t.metadata,
+                }
+                for t in self._tools.values()
+            ]
+
+    def _emit_snapshot(self) -> None:
+        if self._publish_fn is not None:
+            try:
+                data = json.dumps(self.snapshot()).encode()
+                self._publish_fn(STATE_TOPIC, data)
+            except Exception:
+                logger.exception("Failed to publish registry snapshot")
+
+
+# ---------------------------------------------------------------------------
+# Reaper thread
+# ---------------------------------------------------------------------------
+
+
+class _ReaperThread(threading.Thread):
+    """Daemon thread that periodically calls ``registry.reap_stale()``."""
+
+    def __init__(self, registry: ToolRegistry, interval: float) -> None:
+        super().__init__(daemon=True)
+        self._registry = registry
+        self._interval = interval
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        while not self._stop_event.is_set():
+            self._registry.reap_stale()
+            self._stop_event.wait(self._interval)
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self.join(timeout=self._interval * 2)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,232 @@
+"""Tests for openbad.proprioception.registry — tool registry + heartbeat."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from unittest.mock import MagicMock
+
+from openbad.proprioception.registry import (
+    HEARTBEAT_TOPIC_PREFIX,
+    STATE_TOPIC,
+    HealthStatus,
+    ToolRegistry,
+)
+
+# ── Registration / unregistration ─────────────────────────────────
+
+
+class TestRegistration:
+    def test_register_adds_tool(self):
+        reg = ToolRegistry()
+        entry = reg.register("tool_a")
+        assert entry.name == "tool_a"
+        assert entry.status is HealthStatus.AVAILABLE
+
+    def test_register_is_idempotent(self):
+        reg = ToolRegistry()
+        reg.register("tool_a")
+        entry = reg.register("tool_a")
+        assert len(reg.get_all_tools()) == 1
+        assert entry.status is HealthStatus.AVAILABLE
+
+    def test_register_with_metadata(self):
+        reg = ToolRegistry()
+        entry = reg.register("tool_a", metadata={"version": "1.0"})
+        assert entry.metadata["version"] == "1.0"
+
+    def test_unregister_removes_tool(self):
+        reg = ToolRegistry()
+        reg.register("tool_a")
+        assert reg.unregister("tool_a") is True
+        assert reg.get_all_tools() == []
+
+    def test_unregister_missing_returns_false(self):
+        reg = ToolRegistry()
+        assert reg.unregister("nonexistent") is False
+
+
+# ── Heartbeat ─────────────────────────────────────────────────────
+
+
+class TestHeartbeat:
+    def test_heartbeat_updates_timestamp(self):
+        reg = ToolRegistry()
+        entry = reg.register("tool_a")
+        old_ts = entry.last_heartbeat
+        time.sleep(0.01)
+        reg.heartbeat("tool_a")
+        assert entry.last_heartbeat > old_ts
+
+    def test_heartbeat_unknown_tool_noop(self):
+        reg = ToolRegistry()
+        reg.heartbeat("unknown")  # should not raise
+
+    def test_heartbeat_revives_unavailable(self):
+        reg = ToolRegistry(timeout=0.01)
+        reg.register("tool_a")
+        time.sleep(0.05)
+        reg.reap_stale()
+        assert reg.get_available_tools() == []
+        reg.heartbeat("tool_a")
+        assert len(reg.get_available_tools()) == 1
+
+
+# ── Stale detection ───────────────────────────────────────────────
+
+
+class TestStaleDetection:
+    def test_reap_marks_stale_unavailable(self):
+        reg = ToolRegistry(timeout=0.01)
+        reg.register("tool_a")
+        time.sleep(0.05)
+        changed = reg.reap_stale()
+        assert changed == 1
+        assert reg.get_all_tools()[0].status is HealthStatus.UNAVAILABLE
+
+    def test_reap_leaves_fresh_tools(self):
+        reg = ToolRegistry(timeout=10.0)
+        reg.register("tool_a")
+        changed = reg.reap_stale()
+        assert changed == 0
+        assert reg.get_all_tools()[0].status is HealthStatus.AVAILABLE
+
+    def test_reap_already_unavailable_no_double_count(self):
+        reg = ToolRegistry(timeout=0.01)
+        reg.register("tool_a")
+        time.sleep(0.05)
+        reg.reap_stale()
+        # second reap should not count tool_a again
+        assert reg.reap_stale() == 0
+
+
+# ── get_available_tools ───────────────────────────────────────────
+
+
+class TestGetAvailableTools:
+    def test_returns_only_available(self):
+        reg = ToolRegistry(timeout=0.01)
+        reg.register("tool_a")
+        reg.register("tool_b")
+        time.sleep(0.05)
+        reg.heartbeat("tool_b")  # keep b alive
+        reg.reap_stale()
+        available = reg.get_available_tools()
+        assert len(available) == 1
+        assert available[0].name == "tool_b"
+
+
+# ── Snapshot / publish ────────────────────────────────────────────
+
+
+class TestSnapshot:
+    def test_snapshot_format(self):
+        reg = ToolRegistry()
+        reg.register("tool_a", metadata={"v": "1"})
+        snap = reg.snapshot()
+        assert len(snap) == 1
+        assert snap[0]["name"] == "tool_a"
+        assert snap[0]["status"] == "AVAILABLE"
+        assert "last_heartbeat" in snap[0]
+        assert snap[0]["metadata"] == {"v": "1"}
+
+    def test_publishes_on_register(self):
+        published: list[tuple[str, bytes]] = []
+        reg = ToolRegistry(publish_fn=lambda t, p: published.append((t, p)))
+        reg.register("tool_a")
+        assert len(published) == 1
+        assert published[0][0] == STATE_TOPIC
+        snap = json.loads(published[0][1])
+        assert snap[0]["name"] == "tool_a"
+
+    def test_publishes_on_unregister(self):
+        published: list[tuple[str, bytes]] = []
+        reg = ToolRegistry(publish_fn=lambda t, p: published.append((t, p)))
+        reg.register("tool_a")
+        published.clear()
+        reg.unregister("tool_a")
+        assert len(published) == 1
+
+    def test_publishes_on_reap(self):
+        published: list[tuple[str, bytes]] = []
+        reg = ToolRegistry(
+            timeout=0.01,
+            publish_fn=lambda t, p: published.append((t, p)),
+        )
+        reg.register("tool_a")
+        published.clear()
+        time.sleep(0.05)
+        reg.reap_stale()
+        assert len(published) == 1
+
+
+# ── MQTT integration ──────────────────────────────────────────────
+
+
+class TestMQTTIntegration:
+    def test_subscribe_heartbeats(self):
+        reg = ToolRegistry()
+        client = MagicMock()
+        reg.subscribe_heartbeats(client)
+        client.subscribe.assert_called_once()
+        topic = client.subscribe.call_args.args[0]
+        assert topic == HEARTBEAT_TOPIC_PREFIX + "+/heartbeat"
+
+    def test_heartbeat_message_updates_tool(self):
+        reg = ToolRegistry()
+        reg.register("my_tool")
+        entry = reg.get_all_tools()[0]
+        old_ts = entry.last_heartbeat
+        time.sleep(0.01)
+        reg._on_heartbeat_message("agent/proprioception/my_tool/heartbeat", b"")
+        assert entry.last_heartbeat > old_ts
+
+
+# ── Concurrency ───────────────────────────────────────────────────
+
+
+class TestConcurrency:
+    def test_concurrent_register_and_heartbeat(self):
+        reg = ToolRegistry()
+        errors: list[Exception] = []
+
+        def worker(name: str) -> None:
+            try:
+                reg.register(name)
+                for _ in range(50):
+                    reg.heartbeat(name)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(f"t{i}",)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert errors == []
+        assert len(reg.get_all_tools()) == 10
+
+
+# ── Reaper thread ─────────────────────────────────────────────────
+
+
+class TestReaperThread:
+    def test_reaper_marks_stale(self):
+        reg = ToolRegistry(timeout=0.05)
+        reg.register("tool_a")
+        reg.start_reaper(interval=0.02)
+        try:
+            time.sleep(0.2)
+            assert reg.get_all_tools()[0].status is HealthStatus.UNAVAILABLE
+        finally:
+            reg.stop_reaper()
+
+    def test_double_start_is_noop(self):
+        reg = ToolRegistry(timeout=10)
+        reg.start_reaper(interval=1)
+        reaper1 = reg._reaper
+        reg.start_reaper(interval=1)
+        assert reg._reaper is reaper1
+        reg.stop_reaper()


### PR DESCRIPTION
Closes #17

## Summary of Changes
- Created `src/openbad/proprioception/registry.py`:
  - `ToolRegistry` with thread-safe register/unregister, heartbeat tracking, configurable staleness timeout (default 10s)
  - `HealthStatus` enum (AVAILABLE / UNAVAILABLE), `ToolStatus` dataclass
  - `reap_stale()` marks tools UNAVAILABLE when heartbeat exceeds timeout
  - `get_available_tools()` returns only healthy tools
  - `subscribe_heartbeats()` MQTT integration for `agent/proprioception/+/heartbeat`
  - Background `_ReaperThread` daemon for automatic staleness detection
  - JSON snapshot published to `agent/proprioception/state` on every status change
- Created `tests/test_registry.py` (21 tests):
  - Registration / unregistration / idempotency
  - Heartbeat refresh and revive from UNAVAILABLE
  - Stale detection after timeout
  - get_available_tools filtering
  - Snapshot format and publish callbacks
  - MQTT topic subscription and message handling
  - Concurrent access safety (10 threads × 50 heartbeats)
  - Reaper thread lifecycle

## How to Test
```bash
pytest tests/test_registry.py -v
```