### PR TITLE
#14: Implement thermal throttle reflex handler

### DIFF
--- a/src/openbad/reflex_arc/handlers/thermal.py
+++ b/src/openbad/reflex_arc/handlers/thermal.py
@@ -1,0 +1,116 @@
+"""Thermal throttle reflex handler.
+
+Subscribes to ``agent/endocrine/cortisol`` and reacts to **critical**
+cortisol events whose metric is CPU or thermal related.  On trigger the
+handler:
+
+1. Publishes a suspend directive to ``agent/reflex/thermal/suspend``.
+2. Publishes a cognitive downgrade directive (SLM-only) to
+   ``agent/cognitive/routing/directive``.
+3. Publishes a :class:`ReflexResult` to ``agent/reflex/thermal/result``.
+
+Pure Python — no LLM calls, no external service dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult
+
+logger = logging.getLogger(__name__)
+
+# Topics
+CORTISOL_TOPIC = "agent/endocrine/cortisol"
+SUSPEND_TOPIC = "agent/reflex/thermal/suspend"
+COGNITIVE_DIRECTIVE_TOPIC = "agent/cognitive/routing/directive"
+RESULT_TOPIC = "agent/reflex/thermal/result"
+
+# Metrics this handler cares about
+_THERMAL_METRICS = frozenset({"cpu_percent", "thermal_celsius"})
+
+# Severity threshold — only react to CRITICAL (3)
+_CRITICAL = 3
+
+
+def handle_cortisol(payload: bytes, publish_fn: callable) -> bool:  # type: ignore[valid-type]
+    """Evaluate a cortisol event and fire thermal throttle if warranted.
+
+    Parameters
+    ----------
+    payload:
+        Serialised :class:`EndocrineEvent` protobuf bytes.
+    publish_fn:
+        Callable ``(topic: str, data: bytes) -> None`` used to publish
+        outgoing directives.
+
+    Returns
+    -------
+    bool
+        ``True`` if the handler fired (critical thermal event), else ``False``.
+    """
+    event = EndocrineEvent()
+    event.ParseFromString(payload)
+
+    if event.severity != _CRITICAL:
+        return False
+
+    if event.metric_name not in _THERMAL_METRICS:
+        return False
+
+    _fire(event, publish_fn)
+    return True
+
+
+def _fire(event: EndocrineEvent, publish_fn: callable) -> None:  # type: ignore[valid-type]
+    """Execute the thermal throttle response."""
+    now = time.time()
+
+    # 1. Suspend background tasks
+    publish_fn(
+        SUSPEND_TOPIC,
+        b'{"action": "suspend", "reason": "thermal_throttle"}',
+    )
+
+    # 2. Downgrade cognitive routing to SLM-only
+    publish_fn(
+        COGNITIVE_DIRECTIVE_TOPIC,
+        b'{"mode": "slm_only", "reason": "thermal_throttle"}',
+    )
+
+    # 3. Publish reflex result
+    result = ReflexResult(
+        header=Header(timestamp_unix=now),
+        reflex_id="thermal_throttle",
+        handled=True,
+        action_taken=(
+            f"Suspended background tasks; routed to SLM-only "
+            f"(metric={event.metric_name}, value={event.metric_value})"
+        ),
+    )
+    publish_fn(RESULT_TOPIC, result.SerializeToString())
+
+    logger.info(
+        "Thermal throttle fired: %s=%.2f",
+        event.metric_name,
+        event.metric_value,
+    )
+
+
+def subscribe(client: object) -> None:
+    """Subscribe the thermal throttle handler to the cortisol topic.
+
+    Parameters
+    ----------
+    client:
+        MQTT client with ``subscribe(topic, callback)`` and
+        ``publish(topic, data)`` methods.
+    """
+
+    def _callback(topic: str, payload: bytes) -> None:
+        handle_cortisol(payload, client.publish)  # type: ignore[union-attr]
+
+    client.subscribe(CORTISOL_TOPIC, _callback)  # type: ignore[union-attr]

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -1,0 +1,159 @@
+"""Tests for openbad.reflex_arc.handlers.thermal — thermal throttle reflex."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult
+from openbad.reflex_arc.handlers.thermal import (
+    COGNITIVE_DIRECTIVE_TOPIC,
+    CORTISOL_TOPIC,
+    RESULT_TOPIC,
+    SUSPEND_TOPIC,
+    handle_cortisol,
+    subscribe,
+)
+
+# ── helpers ───────────────────────────────────────────────────────
+
+
+def _make_event(
+    metric: str = "cpu_percent",
+    value: float = 95.0,
+    severity: int = 3,
+) -> bytes:
+    return EndocrineEvent(
+        header=Header(timestamp_unix=time.time()),
+        hormone="cortisol",
+        level=1.0,
+        severity=severity,
+        metric_name=metric,
+        metric_value=value,
+        recommended_action="test",
+    ).SerializeToString()
+
+
+# ── handler fires on critical CPU/thermal ─────────────────────────
+
+
+class TestHandlerFires:
+    def test_fires_on_critical_cpu(self):
+        published: list[tuple[str, bytes]] = []
+        payload = _make_event("cpu_percent", 95.0, severity=3)
+        result = handle_cortisol(payload, lambda t, d: published.append((t, d)))
+        assert result is True
+        assert len(published) == 3
+
+    def test_fires_on_critical_thermal(self):
+        published: list[tuple[str, bytes]] = []
+        payload = _make_event("thermal_celsius", 100.0, severity=3)
+        result = handle_cortisol(payload, lambda t, d: published.append((t, d)))
+        assert result is True
+
+
+# ── handler ignores non-critical ──────────────────────────────────
+
+
+class TestHandlerIgnores:
+    def test_ignores_warning_severity(self):
+        published: list[tuple[str, bytes]] = []
+        payload = _make_event("cpu_percent", 80.0, severity=2)
+        result = handle_cortisol(payload, lambda t, d: published.append((t, d)))
+        assert result is False
+        assert published == []
+
+    def test_ignores_info_severity(self):
+        published: list[tuple[str, bytes]] = []
+        payload = _make_event("cpu_percent", 50.0, severity=1)
+        result = handle_cortisol(payload, lambda t, d: published.append((t, d)))
+        assert result is False
+
+    def test_ignores_non_thermal_metric(self):
+        published: list[tuple[str, bytes]] = []
+        payload = _make_event("memory_percent", 97.0, severity=3)
+        result = handle_cortisol(payload, lambda t, d: published.append((t, d)))
+        assert result is False
+
+
+# ── directives published correctly ────────────────────────────────
+
+
+class TestDirectives:
+    def test_suspend_directive(self):
+        published: list[tuple[str, bytes]] = []
+        handle_cortisol(
+            _make_event("cpu_percent", 95.0, severity=3),
+            lambda t, d: published.append((t, d)),
+        )
+        topics = [t for t, _ in published]
+        assert SUSPEND_TOPIC in topics
+
+    def test_cognitive_downgrade_directive(self):
+        published: list[tuple[str, bytes]] = []
+        handle_cortisol(
+            _make_event("cpu_percent", 95.0, severity=3),
+            lambda t, d: published.append((t, d)),
+        )
+        topics = [t for t, _ in published]
+        assert COGNITIVE_DIRECTIVE_TOPIC in topics
+
+    def test_reflex_result_published(self):
+        published: list[tuple[str, bytes]] = []
+        handle_cortisol(
+            _make_event("cpu_percent", 95.0, severity=3),
+            lambda t, d: published.append((t, d)),
+        )
+        result_msgs = [(t, d) for t, d in published if t == RESULT_TOPIC]
+        assert len(result_msgs) == 1
+        msg = ReflexResult()
+        msg.ParseFromString(result_msgs[0][1])
+        assert msg.reflex_id == "thermal_throttle"
+        assert msg.handled is True
+
+    def test_suspend_payload_json(self):
+        published: list[tuple[str, bytes]] = []
+        handle_cortisol(
+            _make_event("cpu_percent", 95.0, severity=3),
+            lambda t, d: published.append((t, d)),
+        )
+        suspend_msgs = [(t, d) for t, d in published if t == SUSPEND_TOPIC]
+        assert b"suspend" in suspend_msgs[0][1]
+        assert b"thermal_throttle" in suspend_msgs[0][1]
+
+    def test_cognitive_payload_json(self):
+        published: list[tuple[str, bytes]] = []
+        handle_cortisol(
+            _make_event("cpu_percent", 95.0, severity=3),
+            lambda t, d: published.append((t, d)),
+        )
+        cog_msgs = [(t, d) for t, d in published if t == COGNITIVE_DIRECTIVE_TOPIC]
+        assert b"slm_only" in cog_msgs[0][1]
+
+
+# ── performance ───────────────────────────────────────────────────
+
+
+class TestPerformance:
+    def test_executes_under_1ms(self):
+        payload = _make_event("cpu_percent", 99.0, severity=3)
+        noop = lambda t, d: None  # noqa: E731
+        # warm up
+        handle_cortisol(payload, noop)
+        start = time.perf_counter_ns()
+        handle_cortisol(payload, noop)
+        elapsed_ms = (time.perf_counter_ns() - start) / 1_000_000
+        assert elapsed_ms < 1.0, f"Handler took {elapsed_ms:.3f}ms"
+
+
+# ── MQTT subscribe integration ────────────────────────────────────
+
+
+class TestSubscribe:
+    def test_subscribe_registers_callback(self):
+        client = MagicMock()
+        subscribe(client)
+        client.subscribe.assert_called_once()
+        assert client.subscribe.call_args.args[0] == CORTISOL_TOPIC


### PR DESCRIPTION
Closes #14

## Summary of Changes
- Created `src/openbad/reflex_arc/handlers/thermal.py`:
  - `handle_cortisol(payload, publish_fn)` — evaluates cortisol events, fires only on CRITICAL severity for cpu_percent or thermal_celsius metrics
  - On trigger: publishes suspend directive, cognitive SLM-only downgrade directive, and ReflexResult
  - `subscribe(client)` — MQTT integration helper
  - Pure Python, no LLM calls
- Created `tests/test_thermal.py` (12 tests):
  - Fires on critical CPU and thermal events
  - Ignores warning/info severity and non-thermal metrics
  - Verifies all three published directives (suspend, cognitive, reflex result)
  - Performance test: handler executes in < 1ms
  - MQTT subscribe integration

## How to Test
```bash
pytest tests/test_thermal.py -v
```