### PR TITLE
#15: Implement budget exhaustion reflex handler

### DIFF
--- a/src/openbad/reflex_arc/handlers/budget.py
+++ b/src/openbad/reflex_arc/handlers/budget.py
@@ -1,0 +1,151 @@
+"""Budget exhaustion reflex handler.
+
+Subscribes to ``agent/endocrine/cortisol`` and reacts to **critical**
+cortisol events whose metric is ``token_budget_remaining_pct``.
+
+On trigger the handler:
+
+1. Sets a thread-safe *blocked* flag that prevents new LLM API calls.
+2. Fires the ``throttle`` trigger on the FSM to enter THROTTLED state.
+3. Publishes a :class:`ReflexResult` to ``agent/reflex/budget/result``.
+
+A recovery path clears the block when the budget is available again.
+
+Pure Python — no LLM calls, no external service dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult
+
+logger = logging.getLogger(__name__)
+
+# Topics
+CORTISOL_TOPIC = "agent/endocrine/cortisol"
+RESULT_TOPIC = "agent/reflex/budget/result"
+
+# Only react to this metric
+_BUDGET_METRIC = "token_budget_remaining_pct"
+
+# Severity
+_CRITICAL = 3
+
+
+class BudgetGuard:
+    """Thread-safe gate that blocks new API calls when the budget is exhausted.
+
+    Parameters
+    ----------
+    fsm:
+        Optional :class:`AgentFSM` instance.  If provided, the guard will
+        fire the ``throttle`` trigger on exhaustion and ``recover`` on
+        recovery.
+    publish_fn:
+        Optional callable ``(topic, data)`` for publishing results.
+    """
+
+    def __init__(
+        self,
+        fsm: object | None = None,
+        publish_fn: callable | None = None,  # type: ignore[valid-type]
+    ) -> None:
+        self._lock = threading.Lock()
+        self._blocked = False
+        self._fsm = fsm
+        self._publish_fn = publish_fn
+
+    # -- public API ---------------------------------------------------------
+
+    @property
+    def blocked(self) -> bool:
+        """Return ``True`` if new API calls are currently blocked."""
+        return self._blocked
+
+    def is_call_allowed(self) -> bool:
+        """Check whether a new LLM API call is permitted."""
+        return not self._blocked
+
+    def handle_cortisol(self, payload: bytes) -> bool:
+        """Evaluate a cortisol event and block if budget is exhausted.
+
+        Returns ``True`` if the handler fired.
+        """
+        event = EndocrineEvent()
+        event.ParseFromString(payload)
+
+        if event.severity != _CRITICAL:
+            return False
+        if event.metric_name != _BUDGET_METRIC:
+            return False
+
+        self._exhaust(event)
+        return True
+
+    def recover(self) -> bool:
+        """Clear the block and resume API calls.
+
+        Returns ``True`` if state actually changed (was blocked).
+        """
+        with self._lock:
+            if not self._blocked:
+                return False
+            self._blocked = False
+
+        if self._fsm is not None:
+            try:
+                self._fsm.fire("recover")  # type: ignore[union-attr]
+            except Exception:
+                logger.exception("FSM recover trigger failed")
+
+        logger.info("Budget guard: API calls resumed")
+        return True
+
+    # -- MQTT integration ---------------------------------------------------
+
+    def subscribe(self, client: object) -> None:
+        """Subscribe to cortisol events via an MQTT *client*."""
+
+        def _callback(_topic: str, payload: bytes) -> None:
+            self.handle_cortisol(payload)
+
+        client.subscribe(CORTISOL_TOPIC, _callback)  # type: ignore[union-attr]
+
+    # -- internals ----------------------------------------------------------
+
+    def _exhaust(self, event: EndocrineEvent) -> None:
+        with self._lock:
+            if self._blocked:
+                return  # already in exhaustion mode
+            self._blocked = True
+
+        # Transition FSM to THROTTLED
+        if self._fsm is not None:
+            try:
+                self._fsm.fire("throttle")  # type: ignore[union-attr]
+            except Exception:
+                logger.exception("FSM throttle trigger failed")
+
+        # Publish result
+        if self._publish_fn is not None:
+            result = ReflexResult(
+                header=Header(timestamp_unix=time.time()),
+                reflex_id="budget_exhaustion",
+                handled=True,
+                action_taken=(f"Blocked new API calls (budget_remaining={event.metric_value}%)"),
+            )
+            try:
+                self._publish_fn(RESULT_TOPIC, result.SerializeToString())
+            except Exception:
+                logger.exception("Failed to publish budget result")
+
+        logger.info(
+            "Budget exhaustion handler fired: %s=%.2f",
+            event.metric_name,
+            event.metric_value,
+        )

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,161 @@
+"""Tests for openbad.reflex_arc.handlers.budget — budget exhaustion reflex."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult
+from openbad.reflex_arc.handlers.budget import (
+    CORTISOL_TOPIC,
+    RESULT_TOPIC,
+    BudgetGuard,
+)
+
+# ── helpers ───────────────────────────────────────────────────────
+
+
+def _make_event(
+    metric: str = "token_budget_remaining_pct",
+    value: float = 3.0,
+    severity: int = 3,
+) -> bytes:
+    return EndocrineEvent(
+        header=Header(timestamp_unix=time.time()),
+        hormone="cortisol",
+        level=1.0,
+        severity=severity,
+        metric_name=metric,
+        metric_value=value,
+        recommended_action="test",
+    ).SerializeToString()
+
+
+# ── handler fires on critical budget ──────────────────────────────
+
+
+class TestHandlerFires:
+    def test_fires_on_critical_budget(self):
+        guard = BudgetGuard()
+        result = guard.handle_cortisol(_make_event(severity=3))
+        assert result is True
+        assert guard.blocked is True
+
+    def test_blocks_api_calls(self):
+        guard = BudgetGuard()
+        assert guard.is_call_allowed() is True
+        guard.handle_cortisol(_make_event(severity=3))
+        assert guard.is_call_allowed() is False
+
+
+# ── handler ignores non-matching events ───────────────────────────
+
+
+class TestHandlerIgnores:
+    def test_ignores_warning_severity(self):
+        guard = BudgetGuard()
+        result = guard.handle_cortisol(_make_event(severity=2))
+        assert result is False
+        assert guard.blocked is False
+
+    def test_ignores_non_budget_metric(self):
+        guard = BudgetGuard()
+        result = guard.handle_cortisol(_make_event(metric="cpu_percent", severity=3))
+        assert result is False
+        assert guard.blocked is False
+
+
+# ── FSM integration ───────────────────────────────────────────────
+
+
+class TestFSMIntegration:
+    def test_triggers_throttle_on_fsm(self):
+        fsm = MagicMock()
+        guard = BudgetGuard(fsm=fsm)
+        guard.handle_cortisol(_make_event(severity=3))
+        fsm.fire.assert_called_once_with("throttle")
+
+    def test_triggers_recover_on_fsm(self):
+        fsm = MagicMock()
+        guard = BudgetGuard(fsm=fsm)
+        guard.handle_cortisol(_make_event(severity=3))
+        fsm.fire.reset_mock()
+        guard.recover()
+        fsm.fire.assert_called_once_with("recover")
+
+
+# ── Publishing ────────────────────────────────────────────────────
+
+
+class TestPublishing:
+    def test_publishes_result(self):
+        published: list[tuple[str, bytes]] = []
+        guard = BudgetGuard(publish_fn=lambda t, d: published.append((t, d)))
+        guard.handle_cortisol(_make_event(severity=3))
+        assert len(published) == 1
+        assert published[0][0] == RESULT_TOPIC
+        msg = ReflexResult()
+        msg.ParseFromString(published[0][1])
+        assert msg.reflex_id == "budget_exhaustion"
+        assert msg.handled is True
+
+    def test_no_publish_when_no_fn(self):
+        guard = BudgetGuard()
+        guard.handle_cortisol(_make_event(severity=3))
+        # should not raise
+
+
+# ── Recovery ──────────────────────────────────────────────────────
+
+
+class TestRecovery:
+    def test_recover_clears_block(self):
+        guard = BudgetGuard()
+        guard.handle_cortisol(_make_event(severity=3))
+        assert guard.blocked is True
+        result = guard.recover()
+        assert result is True
+        assert guard.blocked is False
+        assert guard.is_call_allowed() is True
+
+    def test_recover_noop_when_not_blocked(self):
+        guard = BudgetGuard()
+        assert guard.recover() is False
+
+    def test_idempotent_exhaustion(self):
+        guard = BudgetGuard()
+        guard.handle_cortisol(_make_event(severity=3))
+        guard.handle_cortisol(_make_event(severity=3))
+        assert guard.blocked is True
+        guard.recover()
+        assert guard.blocked is False
+
+
+# ── MQTT subscribe ────────────────────────────────────────────────
+
+
+class TestSubscribe:
+    def test_subscribe_registers_callback(self):
+        guard = BudgetGuard()
+        client = MagicMock()
+        guard.subscribe(client)
+        client.subscribe.assert_called_once()
+        assert client.subscribe.call_args.args[0] == CORTISOL_TOPIC
+
+
+# ── Performance ───────────────────────────────────────────────────
+
+
+class TestPerformance:
+    def test_handle_under_1ms(self):
+        guard = BudgetGuard()
+        payload = _make_event(severity=3)
+        # warm up
+        guard.handle_cortisol(payload)
+        guard.recover()
+        start = time.perf_counter_ns()
+        guard.handle_cortisol(payload)
+        elapsed_ms = (time.perf_counter_ns() - start) / 1_000_000
+        assert elapsed_ms < 1.0, f"Handler took {elapsed_ms:.3f}ms"


### PR DESCRIPTION
Closes #15

## Summary of Changes
- Created `src/openbad/reflex_arc/handlers/budget.py`:
  - `BudgetGuard` class with thread-safe blocked flag for API call gating
  - `handle_cortisol()` — fires on critical severity for `token_budget_remaining_pct` metric
  - `is_call_allowed()` — check if new LLM API calls are permitted
  - FSM integration: fires `throttle` trigger on exhaustion, `recover` on recovery
  - `recover()` — clears the block and resumes API calls
  - `subscribe()` — MQTT integration helper
  - Pure Python, no LLM calls
- Created `tests/test_budget.py` (13 tests):
  - Fires on critical budget events, blocks API calls
  - Ignores warning severity and non-budget metrics
  - FSM throttle/recover trigger verification
  - Publishing result with valid protobuf
  - Recovery path clears block correctly
  - Idempotent exhaustion handling
  - Performance test: handler executes in < 1ms

## How to Test
```bash
pytest tests/test_budget.py -v
```