### PR TITLE
#16: Implement security lockdown reflex handler

### DIFF
--- a/src/openbad/reflex_arc/handlers/security.py
+++ b/src/openbad/reflex_arc/handlers/security.py
@@ -1,0 +1,154 @@
+"""Security lockdown reflex handler.
+
+Subscribes to ``agent/immune/alert`` and reacts to **critical** immune
+alerts by isolating the flagged subsystem, blocking external tool
+invocations, transitioning the FSM to EMERGENCY, and publishing a
+:class:`ReflexResult`.
+
+Recovery requires explicit operator clearance — the handler cannot
+auto-recover.
+
+Pure Python — no LLM calls, no external service dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.immune_pb2 import ImmuneAlert
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult
+
+logger = logging.getLogger(__name__)
+
+# Topics
+IMMUNE_ALERT_TOPIC = "agent/immune/alert"
+RESULT_TOPIC = "agent/reflex/security/result"
+
+# Severity enum value for CRITICAL in the proto
+_CRITICAL = 3
+
+
+class SecurityGuard:
+    """Thread-safe security lockdown controller.
+
+    Parameters
+    ----------
+    fsm:
+        Optional :class:`AgentFSM` instance — fires ``emergency`` trigger.
+    publish_fn:
+        Optional callable ``(topic, data)`` for publishing results.
+    """
+
+    def __init__(
+        self,
+        fsm: object | None = None,
+        publish_fn: callable | None = None,  # type: ignore[valid-type]
+    ) -> None:
+        self._lock = threading.Lock()
+        self._locked_down = False
+        self._isolated_sources: set[str] = set()
+        self._fsm = fsm
+        self._publish_fn = publish_fn
+
+    # -- public state -------------------------------------------------------
+
+    @property
+    def locked_down(self) -> bool:
+        return self._locked_down
+
+    @property
+    def isolated_sources(self) -> frozenset[str]:
+        with self._lock:
+            return frozenset(self._isolated_sources)
+
+    def is_tool_allowed(self, source_id: str | None = None) -> bool:
+        """Return ``False`` if external tool invocations are blocked.
+
+        If *source_id* is given, also checks whether that specific
+        subsystem is isolated.
+        """
+        if self._locked_down:
+            return False
+        return not (source_id and source_id in self._isolated_sources)
+
+    # -- event handling -----------------------------------------------------
+
+    def handle_alert(self, payload: bytes) -> bool:
+        """Evaluate an immune alert and trigger lockdown if critical.
+
+        Returns ``True`` if the handler fired.
+        """
+        alert = ImmuneAlert()
+        alert.ParseFromString(payload)
+
+        if alert.severity != _CRITICAL:
+            return False
+
+        self._lockdown(alert)
+        return True
+
+    # -- recovery -----------------------------------------------------------
+
+    def clear(self, operator: str = "operator") -> bool:
+        """Explicit operator clearance required to lift the lockdown.
+
+        Returns ``True`` if state actually changed.
+        """
+        with self._lock:
+            if not self._locked_down:
+                return False
+            self._locked_down = False
+            self._isolated_sources.clear()
+
+        logger.info("Security lockdown cleared by %s", operator)
+        return True
+
+    # -- MQTT integration ---------------------------------------------------
+
+    def subscribe(self, client: object) -> None:
+        """Subscribe to immune alert events via an MQTT *client*."""
+
+        def _callback(_topic: str, payload: bytes) -> None:
+            self.handle_alert(payload)
+
+        client.subscribe(IMMUNE_ALERT_TOPIC, _callback)  # type: ignore[union-attr]
+
+    # -- internals ----------------------------------------------------------
+
+    def _lockdown(self, alert: ImmuneAlert) -> None:
+        with self._lock:
+            self._locked_down = True
+            if alert.source_id:
+                self._isolated_sources.add(alert.source_id)
+
+        # FSM → EMERGENCY
+        if self._fsm is not None:
+            try:
+                self._fsm.fire("emergency")  # type: ignore[union-attr]
+            except Exception:
+                logger.exception("FSM emergency trigger failed")
+
+        # Publish result
+        if self._publish_fn is not None:
+            result = ReflexResult(
+                header=Header(timestamp_unix=time.time()),
+                reflex_id="security_lockdown",
+                handled=True,
+                action_taken=(
+                    f"Locked down: isolated source={alert.source_id!r}, "
+                    f"threat={alert.threat_type!r}"
+                ),
+            )
+            try:
+                self._publish_fn(RESULT_TOPIC, result.SerializeToString())
+            except Exception:
+                logger.exception("Failed to publish security result")
+
+        logger.warning(
+            "Security lockdown: source=%s threat=%s",
+            alert.source_id,
+            alert.threat_type,
+        )

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,174 @@
+"""Tests for openbad.reflex_arc.handlers.security — security lockdown reflex."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.immune_pb2 import ImmuneAlert
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult
+from openbad.reflex_arc.handlers.security import (
+    IMMUNE_ALERT_TOPIC,
+    RESULT_TOPIC,
+    SecurityGuard,
+)
+
+# ── helpers ───────────────────────────────────────────────────────
+
+
+def _make_alert(
+    severity: int = 3,
+    source_id: str = "rogue_tool",
+    threat_type: str = "prompt-injection",
+) -> bytes:
+    return ImmuneAlert(
+        header=Header(timestamp_unix=time.time()),
+        severity=severity,
+        threat_type=threat_type,
+        source_id=source_id,
+        detail="test alert",
+    ).SerializeToString()
+
+
+# ── handler fires on critical immune alert ────────────────────────
+
+
+class TestHandlerFires:
+    def test_fires_on_critical(self):
+        guard = SecurityGuard()
+        result = guard.handle_alert(_make_alert(severity=3))
+        assert result is True
+        assert guard.locked_down is True
+
+    def test_blocks_tool_invocations(self):
+        guard = SecurityGuard()
+        assert guard.is_tool_allowed() is True
+        guard.handle_alert(_make_alert(severity=3))
+        assert guard.is_tool_allowed() is False
+
+
+# ── handler ignores non-critical ──────────────────────────────────
+
+
+class TestHandlerIgnores:
+    def test_ignores_warning(self):
+        guard = SecurityGuard()
+        result = guard.handle_alert(_make_alert(severity=2))
+        assert result is False
+        assert guard.locked_down is False
+
+    def test_ignores_info(self):
+        guard = SecurityGuard()
+        result = guard.handle_alert(_make_alert(severity=1))
+        assert result is False
+
+
+# ── subsystem isolation ───────────────────────────────────────────
+
+
+class TestIsolation:
+    def test_isolates_source(self):
+        guard = SecurityGuard()
+        guard.handle_alert(_make_alert(source_id="bad_tool"))
+        assert "bad_tool" in guard.isolated_sources
+
+    def test_tool_not_allowed_when_isolated(self):
+        guard = SecurityGuard()
+        guard.handle_alert(_make_alert(source_id="bad_tool"))
+        assert guard.is_tool_allowed("bad_tool") is False
+
+    def test_other_tool_also_blocked_during_lockdown(self):
+        guard = SecurityGuard()
+        guard.handle_alert(_make_alert(source_id="bad_tool"))
+        # Lockdown blocks ALL tools
+        assert guard.is_tool_allowed("good_tool") is False
+
+    def test_multiple_alerts_accumulate_sources(self):
+        guard = SecurityGuard()
+        guard.handle_alert(_make_alert(source_id="tool_a"))
+        guard.handle_alert(_make_alert(source_id="tool_b"))
+        assert "tool_a" in guard.isolated_sources
+        assert "tool_b" in guard.isolated_sources
+
+
+# ── FSM integration ───────────────────────────────────────────────
+
+
+class TestFSMIntegration:
+    def test_triggers_emergency(self):
+        fsm = MagicMock()
+        guard = SecurityGuard(fsm=fsm)
+        guard.handle_alert(_make_alert(severity=3))
+        fsm.fire.assert_called_once_with("emergency")
+
+
+# ── recovery requires explicit clearance ──────────────────────────
+
+
+class TestRecovery:
+    def test_clear_lifts_lockdown(self):
+        guard = SecurityGuard()
+        guard.handle_alert(_make_alert(severity=3))
+        result = guard.clear(operator="admin")
+        assert result is True
+        assert guard.locked_down is False
+        assert guard.isolated_sources == frozenset()
+
+    def test_clear_noop_when_not_locked(self):
+        guard = SecurityGuard()
+        assert guard.clear() is False
+
+    def test_no_auto_recovery(self):
+        """Lockdown persists until explicit clear — no automatic reset."""
+        guard = SecurityGuard()
+        guard.handle_alert(_make_alert(severity=3))
+        # No recover/timeout mechanism exists
+        assert guard.locked_down is True
+        assert guard.is_tool_allowed() is False
+
+
+# ── publishing ────────────────────────────────────────────────────
+
+
+class TestPublishing:
+    def test_publishes_result(self):
+        published: list[tuple[str, bytes]] = []
+        guard = SecurityGuard(
+            publish_fn=lambda t, d: published.append((t, d)),
+        )
+        guard.handle_alert(_make_alert(severity=3))
+        assert len(published) == 1
+        assert published[0][0] == RESULT_TOPIC
+        msg = ReflexResult()
+        msg.ParseFromString(published[0][1])
+        assert msg.reflex_id == "security_lockdown"
+        assert msg.handled is True
+
+
+# ── MQTT subscribe ────────────────────────────────────────────────
+
+
+class TestSubscribe:
+    def test_subscribe_registers_callback(self):
+        guard = SecurityGuard()
+        client = MagicMock()
+        guard.subscribe(client)
+        client.subscribe.assert_called_once()
+        assert client.subscribe.call_args.args[0] == IMMUNE_ALERT_TOPIC
+
+
+# ── performance ───────────────────────────────────────────────────
+
+
+class TestPerformance:
+    def test_handle_under_1ms(self):
+        guard = SecurityGuard()
+        payload = _make_alert(severity=3)
+        # warm up
+        guard.handle_alert(payload)
+        guard.clear()
+        start = time.perf_counter_ns()
+        guard.handle_alert(payload)
+        elapsed_ms = (time.perf_counter_ns() - start) / 1_000_000
+        assert elapsed_ms < 1.0, f"Handler took {elapsed_ms:.3f}ms"


### PR DESCRIPTION
Closes #16

## Summary of Changes
- Created `src/openbad/reflex_arc/handlers/security.py`:
  - `SecurityGuard` class with thread-safe lockdown state and source isolation tracking
  - `handle_alert()` — fires on critical immune alerts, isolates the flagged source_id
  - `is_tool_allowed()` — gate for external tool invocations (blocked during lockdown)
  - FSM integration: fires `emergency` trigger on lockdown
  - `clear(operator)` — explicit operator clearance required to lift lockdown (no auto-recovery)
  - `subscribe()` — MQTT integration for `agent/immune/alert`
  - Pure Python, no LLM calls
- Created `tests/test_security.py` (15 tests):
  - Fires on critical, ignores warning/info
  - Tool invocation blocking
  - Subsystem isolation with source tracking
  - Multiple alerts accumulate isolated sources
  - FSM emergency trigger
  - Explicit clearance required (no auto-recovery)
  - Publishing result
  - Performance: < 1ms

## How to Test
```bash
pytest tests/test_security.py -v
```