### PR TITLE
#19: Implement escalation gateway (System 1 → System 2)

### DIFF
--- a/src/openbad/reflex_arc/escalation.py
+++ b/src/openbad/reflex_arc/escalation.py
@@ -1,0 +1,164 @@
+"""Escalation gateway — System 1 (reflex) → System 2 (cognitive).
+
+Routes problems that deterministic reflex handlers cannot resolve to the
+cognitive engine.  Each escalation carries a unique correlation ID, full
+context, and state-flap detection.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+
+from openbad.nervous_system.schemas.cognitive_pb2 import EscalationRequest
+from openbad.nervous_system.schemas.common_pb2 import Header
+
+logger = logging.getLogger(__name__)
+
+ESCALATION_TOPIC = "agent/cognitive/escalation"
+
+# Default flap detection: N transitions in T seconds
+_DEFAULT_FLAP_THRESHOLD = 3
+_DEFAULT_FLAP_WINDOW = 10.0
+
+
+@dataclass(frozen=True)
+class EscalationContext:
+    """Context bundle sent with each escalation."""
+
+    correlation_id: str
+    event_topic: str
+    event_payload: bytes
+    reason: str
+    reflex_id: str
+    current_state: str
+    telemetry_snapshot: dict = field(default_factory=dict)
+
+
+class EscalationGateway:
+    """Routes unresolved reflex events to the cognitive engine.
+
+    Parameters
+    ----------
+    publish_fn:
+        Callable ``(topic, data)`` used to publish escalation messages.
+    flap_threshold:
+        Number of state transitions within *flap_window* that triggers
+        a flap-based escalation.
+    flap_window:
+        Time window in seconds for flap detection.
+    """
+
+    def __init__(
+        self,
+        publish_fn: callable | None = None,  # type: ignore[valid-type]
+        flap_threshold: int = _DEFAULT_FLAP_THRESHOLD,
+        flap_window: float = _DEFAULT_FLAP_WINDOW,
+    ) -> None:
+        self._publish_fn = publish_fn
+        self._flap_threshold = flap_threshold
+        self._flap_window = flap_window
+        self._lock = threading.Lock()
+        self._transitions: deque[float] = deque()
+        self._escalation_log: list[EscalationContext] = []
+
+    # -- public API ---------------------------------------------------------
+
+    def escalate(
+        self,
+        event_topic: str,
+        event_payload: bytes,
+        reason: str,
+        reflex_id: str = "",
+        current_state: str = "",
+        telemetry_snapshot: dict | None = None,
+        priority: int = 0,
+    ) -> EscalationContext:
+        """Create and publish an escalation request.
+
+        Returns the :class:`EscalationContext` with its unique
+        ``correlation_id``.
+        """
+        ctx = EscalationContext(
+            correlation_id=str(uuid.uuid4()),
+            event_topic=event_topic,
+            event_payload=event_payload,
+            reason=reason,
+            reflex_id=reflex_id,
+            current_state=current_state,
+            telemetry_snapshot=telemetry_snapshot or {},
+        )
+
+        # Build protobuf
+        envelope = json.dumps(
+            {
+                "correlation_id": ctx.correlation_id,
+                "telemetry_snapshot": ctx.telemetry_snapshot,
+                "current_state": ctx.current_state,
+            }
+        ).encode()
+
+        msg = EscalationRequest(
+            header=Header(timestamp_unix=time.time()),
+            event_topic=ctx.event_topic,
+            event_payload=envelope,
+            reason=ctx.reason,
+            priority=priority,
+            reflex_id=ctx.reflex_id,
+        )
+
+        if self._publish_fn is not None:
+            try:
+                self._publish_fn(ESCALATION_TOPIC, msg.SerializeToString())
+            except Exception:
+                logger.exception("Failed to publish escalation")
+
+        with self._lock:
+            self._escalation_log.append(ctx)
+
+        logger.info(
+            "Escalation %s: %s (reflex=%s)",
+            ctx.correlation_id,
+            ctx.reason,
+            ctx.reflex_id,
+        )
+        return ctx
+
+    # -- flap detection -----------------------------------------------------
+
+    def record_transition(self, state_from: str, state_to: str) -> bool:
+        """Record an FSM state transition. Returns True if flapping detected.
+
+        If flapping is detected, an escalation is automatically published.
+        """
+        now = time.time()
+        with self._lock:
+            self._transitions.append(now)
+            # Trim old entries outside the window
+            cutoff = now - self._flap_window
+            while self._transitions and self._transitions[0] < cutoff:
+                self._transitions.popleft()
+            count = len(self._transitions)
+
+        if count >= self._flap_threshold:
+            self.escalate(
+                event_topic="agent/reflex/state",
+                event_payload=json.dumps({"from": state_from, "to": state_to}).encode(),
+                reason=(f"State flapping detected: {count} transitions in {self._flap_window}s"),
+                reflex_id="flap_detector",
+                current_state=state_to,
+            )
+            return True
+        return False
+
+    # -- introspection ------------------------------------------------------
+
+    @property
+    def escalation_log(self) -> list[EscalationContext]:
+        with self._lock:
+            return list(self._escalation_log)

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -1,0 +1,194 @@
+"""Tests for openbad.reflex_arc.escalation — escalation gateway."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from openbad.nervous_system.schemas.cognitive_pb2 import EscalationRequest
+from openbad.reflex_arc.escalation import (
+    ESCALATION_TOPIC,
+    EscalationGateway,
+)
+
+# ── helpers ───────────────────────────────────────────────────────
+
+
+def _collect_gateway():
+    """Return a gateway and a list that captures published messages."""
+    messages: list[tuple[str, bytes]] = []
+    gw = EscalationGateway(publish_fn=lambda t, d: messages.append((t, d)))
+    return gw, messages
+
+
+# ── escalation message context ────────────────────────────────────
+
+
+class TestEscalationContext:
+    def test_contains_all_required_fields(self):
+        gw, _ = _collect_gateway()
+        ctx = gw.escalate(
+            event_topic="agent/telemetry/cpu",
+            event_payload=b"raw",
+            reason="no handler matched",
+            reflex_id="thermal_throttle",
+            current_state="THROTTLED",
+            telemetry_snapshot={"cpu_percent": 95.0},
+        )
+        assert ctx.event_topic == "agent/telemetry/cpu"
+        assert ctx.event_payload == b"raw"
+        assert ctx.reason == "no handler matched"
+        assert ctx.reflex_id == "thermal_throttle"
+        assert ctx.current_state == "THROTTLED"
+        assert ctx.telemetry_snapshot == {"cpu_percent": 95.0}
+
+    def test_has_correlation_id(self):
+        gw, _ = _collect_gateway()
+        ctx = gw.escalate(
+            event_topic="t",
+            event_payload=b"",
+            reason="r",
+        )
+        assert ctx.correlation_id
+        assert len(ctx.correlation_id) == 36  # UUID4 string
+
+    def test_default_telemetry_snapshot_empty(self):
+        gw, _ = _collect_gateway()
+        ctx = gw.escalate(
+            event_topic="t",
+            event_payload=b"",
+            reason="r",
+        )
+        assert ctx.telemetry_snapshot == {}
+
+
+# ── unique correlation IDs ────────────────────────────────────────
+
+
+class TestCorrelationID:
+    def test_unique_across_calls(self):
+        gw, _ = _collect_gateway()
+        ids = set()
+        for _ in range(100):
+            ctx = gw.escalate(
+                event_topic="t",
+                event_payload=b"",
+                reason="r",
+            )
+            ids.add(ctx.correlation_id)
+        assert len(ids) == 100
+
+
+# ── publishing ────────────────────────────────────────────────────
+
+
+class TestPublishing:
+    def test_publishes_to_correct_topic(self):
+        gw, messages = _collect_gateway()
+        gw.escalate(
+            event_topic="agent/telemetry/cpu",
+            event_payload=b"raw",
+            reason="test",
+        )
+        assert len(messages) == 1
+        assert messages[0][0] == ESCALATION_TOPIC
+
+    def test_published_proto_deserialises(self):
+        gw, messages = _collect_gateway()
+        gw.escalate(
+            event_topic="agent/telemetry/cpu",
+            event_payload=b"payload",
+            reason="test reason",
+            reflex_id="test_reflex",
+        )
+        msg = EscalationRequest()
+        msg.ParseFromString(messages[0][1])
+        assert msg.event_topic == "agent/telemetry/cpu"
+        assert msg.reason == "test reason"
+        assert msg.reflex_id == "test_reflex"
+
+    def test_envelope_contains_correlation_id(self):
+        gw, messages = _collect_gateway()
+        ctx = gw.escalate(
+            event_topic="t",
+            event_payload=b"",
+            reason="r",
+            telemetry_snapshot={"mem": 80},
+            current_state="ACTIVE",
+        )
+        msg = EscalationRequest()
+        msg.ParseFromString(messages[0][1])
+        envelope = json.loads(msg.event_payload)
+        assert envelope["correlation_id"] == ctx.correlation_id
+        assert envelope["telemetry_snapshot"] == {"mem": 80}
+        assert envelope["current_state"] == "ACTIVE"
+
+    def test_no_publish_fn_ok(self):
+        gw = EscalationGateway(publish_fn=None)
+        ctx = gw.escalate(
+            event_topic="t",
+            event_payload=b"",
+            reason="r",
+        )
+        assert ctx.correlation_id
+
+
+# ── flap detection ────────────────────────────────────────────────
+
+
+class TestFlapDetection:
+    def test_no_flap_below_threshold(self):
+        gw, messages = _collect_gateway()
+        assert gw.record_transition("IDLE", "ACTIVE") is False
+        assert gw.record_transition("ACTIVE", "THROTTLED") is False
+        assert len(messages) == 0
+
+    def test_flap_at_threshold(self):
+        gw = EscalationGateway(
+            publish_fn=lambda t, d: None,
+            flap_threshold=3,
+            flap_window=10.0,
+        )
+        gw.record_transition("IDLE", "ACTIVE")
+        gw.record_transition("ACTIVE", "THROTTLED")
+        result = gw.record_transition("THROTTLED", "ACTIVE")
+        assert result is True
+
+    def test_flap_publishes_escalation(self):
+        gw, messages = _collect_gateway()
+        gw._flap_threshold = 2
+        gw.record_transition("IDLE", "ACTIVE")
+        gw.record_transition("ACTIVE", "THROTTLED")
+        assert len(messages) == 1
+        msg = EscalationRequest()
+        msg.ParseFromString(messages[0][1])
+        assert "flapping" in msg.reason.lower()
+
+    def test_flap_window_expires(self):
+        gw, messages = _collect_gateway()
+        gw._flap_threshold = 3
+        gw._flap_window = 0.05  # 50ms window
+        gw.record_transition("IDLE", "ACTIVE")
+        gw.record_transition("ACTIVE", "IDLE")
+        time.sleep(0.1)  # wait out the window
+        result = gw.record_transition("IDLE", "ACTIVE")
+        assert result is False
+        assert len(messages) == 0
+
+
+# ── escalation log ────────────────────────────────────────────────
+
+
+class TestEscalationLog:
+    def test_log_records_all(self):
+        gw, _ = _collect_gateway()
+        gw.escalate(event_topic="t", event_payload=b"", reason="a")
+        gw.escalate(event_topic="t", event_payload=b"", reason="b")
+        assert len(gw.escalation_log) == 2
+
+    def test_log_is_defensive_copy(self):
+        gw, _ = _collect_gateway()
+        gw.escalate(event_topic="t", event_payload=b"", reason="a")
+        log = gw.escalation_log
+        log.clear()
+        assert len(gw.escalation_log) == 1


### PR DESCRIPTION
Closes #19

## Summary of Changes
- Created `src/openbad/reflex_arc/escalation.py`:
  - `EscalationGateway` class — routes unresolved reflex events to the cognitive engine
  - `escalate()` — packages context (trigger event, state, telemetry snapshot) into an `EscalationRequest` proto and publishes to `agent/cognitive/escalation`
  - Each escalation carries a unique UUID4 correlation ID (embedded in the event_payload envelope)
  - State flap detection: `record_transition()` tracks FSM transitions and auto-escalates when threshold exceeded (default: 3 transitions in 10s)
  - `EscalationContext` frozen dataclass for structured escalation records
  - Thread-safe escalation log for introspection
- Created `tests/test_escalation.py` (14 tests):
  - Escalation message contains all required context fields
  - Correlation ID is unique (100 calls → 100 unique IDs)
  - Publishes to correct topic with valid proto
  - Envelope carries correlation_id + telemetry_snapshot + current_state
  - Flap detection: below threshold → no escalation; at threshold → escalation fires
  - Flap window expiration works correctly
  - Escalation log records all events, returns defensive copy

## How to Test
```bash
pytest tests/test_escalation.py -v
```