### PR TITLE
#18: Implement proprioceptive block reflex handler

### DIFF
--- a/src/openbad/reflex_arc/handlers/proprioceptive.py
+++ b/src/openbad/reflex_arc/handlers/proprioceptive.py
@@ -1,0 +1,159 @@
+"""Proprioceptive block reflex handler.
+
+Fires when a tool/subsystem becomes UNAVAILABLE during an active task.
+Mission-critical tool loss transitions the FSM to THROTTLED; non-critical
+losses log a warning.  Graceful degradation suggests alternative tools
+via the event bus.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable
+
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult
+
+logger = logging.getLogger(__name__)
+
+STATE_TOPIC = "agent/proprioception/state"
+RESULT_TOPIC = "agent/reflex/proprioceptive/result"
+DEGRADATION_TOPIC = "agent/reflex/proprioceptive/degradation"
+
+
+class ProprioceptiveHandler:
+    """Reacts to proprioceptive state changes (tool availability).
+
+    Parameters
+    ----------
+    critical_tools:
+        Set of tool names whose loss triggers FSM throttle.
+    alternatives:
+        Mapping of ``tool_name → [fallback_tool, ...]`` for graceful
+        degradation.
+    fsm:
+        Object with ``fire(trigger_name)`` method for FSM integration.
+    publish_fn:
+        Callable ``(topic, data)`` for event publishing.
+    """
+
+    def __init__(
+        self,
+        critical_tools: set[str] | None = None,
+        alternatives: dict[str, list[str]] | None = None,
+        fsm: object | None = None,
+        publish_fn: Callable[[str, bytes], None] | None = None,
+    ) -> None:
+        self._critical_tools: set[str] = critical_tools or set()
+        self._alternatives: dict[str, list[str]] = alternatives or {}
+        self._fsm = fsm
+        self._publish_fn = publish_fn
+        self._lock = threading.Lock()
+        self._aborted: set[str] = set()
+
+    # -- public API ---------------------------------------------------------
+
+    def handle_state_change(self, payload: bytes) -> bool:
+        """Process a proprioceptive state snapshot.
+
+        Returns ``True`` if a reflex action was taken, ``False`` otherwise.
+        """
+        try:
+            snapshot = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Invalid proprioceptive state payload")
+            return False
+
+        acted = False
+        for tool_name, info in snapshot.items():
+            status = info if isinstance(info, str) else info.get("status", "")
+            if status != "UNAVAILABLE":
+                continue
+
+            is_critical = tool_name in self._critical_tools
+
+            with self._lock:
+                self._aborted.add(tool_name)
+
+            if is_critical:
+                logger.warning(
+                    "Mission-critical tool %s lost — throttling",
+                    tool_name,
+                )
+                if self._fsm is not None:
+                    try:
+                        self._fsm.fire("throttle")
+                    except Exception:
+                        logger.exception("FSM throttle failed")
+            else:
+                logger.warning(
+                    "Non-critical tool %s unavailable",
+                    tool_name,
+                )
+
+            self._publish_result(tool_name, is_critical)
+
+            # Graceful degradation
+            alts = self._alternatives.get(tool_name, [])
+            if alts:
+                self._publish_degradation(tool_name, alts)
+
+            acted = True
+
+        return acted
+
+    @property
+    def aborted_tools(self) -> frozenset[str]:
+        """Tools whose in-flight actions have been aborted."""
+        with self._lock:
+            return frozenset(self._aborted)
+
+    def clear_aborted(self, tool_name: str) -> None:
+        """Clear abort status when a tool recovers."""
+        with self._lock:
+            self._aborted.discard(tool_name)
+
+    # -- MQTT integration ---------------------------------------------------
+
+    def subscribe(self, client: object) -> None:
+        """Subscribe to proprioceptive state changes."""
+        client.subscribe(STATE_TOPIC, self.handle_state_change)  # type: ignore[attr-defined]
+
+    # -- internal -----------------------------------------------------------
+
+    def _publish_result(self, tool_name: str, is_critical: bool) -> None:
+        if self._publish_fn is None:
+            return
+        action = (
+            f"ABORT in-flight for {tool_name}; FSM → THROTTLED"
+            if is_critical
+            else f"ABORT in-flight for {tool_name}; logged warning"
+        )
+        msg = ReflexResult(
+            header=Header(timestamp_unix=time.time()),
+            reflex_id="proprioceptive_block",
+            handled=True,
+            action_taken=action,
+        )
+        try:
+            self._publish_fn(RESULT_TOPIC, msg.SerializeToString())
+        except Exception:
+            logger.exception("Failed to publish reflex result")
+
+    def _publish_degradation(
+        self,
+        lost_tool: str,
+        alternatives: list[str],
+    ) -> None:
+        if self._publish_fn is None:
+            return
+        payload = json.dumps(
+            {"lost_tool": lost_tool, "alternatives": alternatives},
+        ).encode()
+        try:
+            self._publish_fn(DEGRADATION_TOPIC, payload)
+        except Exception:
+            logger.exception("Failed to publish degradation notice")

--- a/tests/test_proprioceptive.py
+++ b/tests/test_proprioceptive.py
@@ -1,0 +1,171 @@
+"""Tests for openbad.reflex_arc.handlers.proprioceptive."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult
+from openbad.reflex_arc.handlers.proprioceptive import (
+    DEGRADATION_TOPIC,
+    RESULT_TOPIC,
+    STATE_TOPIC,
+    ProprioceptiveHandler,
+)
+
+# ── helpers ───────────────────────────────────────────────────────
+
+
+def _state_payload(tools: dict[str, str]) -> bytes:
+    """Build a proprioceptive state snapshot payload."""
+    return json.dumps({name: {"status": status} for name, status in tools.items()}).encode()
+
+
+def _handler_with_publish(
+    critical: set[str] | None = None,
+    alternatives: dict[str, list[str]] | None = None,
+    fsm: object | None = None,
+):
+    messages: list[tuple[str, bytes]] = []
+    h = ProprioceptiveHandler(
+        critical_tools=critical,
+        alternatives=alternatives,
+        fsm=fsm,
+        publish_fn=lambda t, d: messages.append((t, d)),
+    )
+    return h, messages
+
+
+# ── fires on UNAVAILABLE ─────────────────────────────────────────
+
+
+class TestFiresOnUnavailable:
+    def test_fires_when_tool_unavailable(self):
+        h, _ = _handler_with_publish()
+        result = h.handle_state_change(
+            _state_payload({"my_tool": "UNAVAILABLE"}),
+        )
+        assert result is True
+
+    def test_does_not_fire_for_available(self):
+        h, _ = _handler_with_publish()
+        result = h.handle_state_change(
+            _state_payload({"my_tool": "AVAILABLE"}),
+        )
+        assert result is False
+
+
+# ── non-critical tool changes ─────────────────────────────────────
+
+
+class TestNonCritical:
+    def test_no_fsm_transition(self):
+        fsm = MagicMock()
+        h, _ = _handler_with_publish(
+            critical={"important_tool"},
+            fsm=fsm,
+        )
+        h.handle_state_change(
+            _state_payload({"unimportant": "UNAVAILABLE"}),
+        )
+        fsm.fire.assert_not_called()
+
+    def test_publishes_result(self):
+        h, messages = _handler_with_publish()
+        h.handle_state_change(
+            _state_payload({"tool_a": "UNAVAILABLE"}),
+        )
+        assert any(t == RESULT_TOPIC for t, _ in messages)
+
+
+# ── mission-critical tool loss → FSM THROTTLED ───────────────────
+
+
+class TestCriticalToolLoss:
+    def test_fsm_throttle(self):
+        fsm = MagicMock()
+        h, _ = _handler_with_publish(critical={"llm_api"}, fsm=fsm)
+        h.handle_state_change(_state_payload({"llm_api": "UNAVAILABLE"}))
+        fsm.fire.assert_called_once_with("throttle")
+
+    def test_result_mentions_throttle(self):
+        h, messages = _handler_with_publish(critical={"llm_api"})
+        h.handle_state_change(_state_payload({"llm_api": "UNAVAILABLE"}))
+        result_msgs = [(t, d) for t, d in messages if t == RESULT_TOPIC]
+        assert len(result_msgs) == 1
+        msg = ReflexResult()
+        msg.ParseFromString(result_msgs[0][1])
+        assert "THROTTLED" in msg.action_taken
+
+
+# ── graceful degradation ─────────────────────────────────────────
+
+
+class TestGracefulDegradation:
+    def test_publishes_alternatives(self):
+        h, messages = _handler_with_publish(
+            alternatives={"tool_a": ["tool_b", "tool_c"]},
+        )
+        h.handle_state_change(_state_payload({"tool_a": "UNAVAILABLE"}))
+        deg = [(t, d) for t, d in messages if t == DEGRADATION_TOPIC]
+        assert len(deg) == 1
+        payload = json.loads(deg[0][1])
+        assert payload["lost_tool"] == "tool_a"
+        assert payload["alternatives"] == ["tool_b", "tool_c"]
+
+    def test_no_alternatives_no_degradation(self):
+        h, messages = _handler_with_publish()
+        h.handle_state_change(_state_payload({"tool_a": "UNAVAILABLE"}))
+        assert not any(t == DEGRADATION_TOPIC for t, _ in messages)
+
+
+# ── abort tracking ────────────────────────────────────────────────
+
+
+class TestAbortTracking:
+    def test_aborted_tools_tracked(self):
+        h, _ = _handler_with_publish()
+        h.handle_state_change(_state_payload({"tool_x": "UNAVAILABLE"}))
+        assert "tool_x" in h.aborted_tools
+
+    def test_clear_aborted(self):
+        h, _ = _handler_with_publish()
+        h.handle_state_change(_state_payload({"tool_x": "UNAVAILABLE"}))
+        h.clear_aborted("tool_x")
+        assert "tool_x" not in h.aborted_tools
+
+
+# ── MQTT subscribe ────────────────────────────────────────────────
+
+
+class TestSubscribe:
+    def test_subscribe_registers_callback(self):
+        h, _ = _handler_with_publish()
+        client = MagicMock()
+        h.subscribe(client)
+        client.subscribe.assert_called_once()
+        assert client.subscribe.call_args.args[0] == STATE_TOPIC
+
+
+# ── invalid payload ───────────────────────────────────────────────
+
+
+class TestInvalidPayload:
+    def test_bad_json(self):
+        h, _ = _handler_with_publish()
+        result = h.handle_state_change(b"not json")
+        assert result is False
+
+
+# ── performance ───────────────────────────────────────────────────
+
+
+class TestPerformance:
+    def test_handle_under_100ms(self):
+        h, _ = _handler_with_publish(critical={"tool"})
+        payload = _state_payload({"tool": "UNAVAILABLE"})
+        start = time.perf_counter_ns()
+        h.handle_state_change(payload)
+        elapsed_ms = (time.perf_counter_ns() - start) / 1_000_000
+        assert elapsed_ms < 100.0, f"Handler took {elapsed_ms:.3f}ms"


### PR DESCRIPTION
Closes #18

## Summary of Changes
- Created `src/openbad/reflex_arc/handlers/proprioceptive.py`:
  - `ProprioceptiveHandler` — reacts to tool/subsystem availability changes
  - Subscribes to `agent/proprioception/state` for snapshots
  - On UNAVAILABLE: aborts in-flight actions, publishes `ReflexResult` to `agent/reflex/proprioceptive/result`
  - Mission-critical tool loss triggers FSM `throttle` transition
  - Non-critical tool loss logs warning only
  - Graceful degradation: publishes alternative tool suggestions to `agent/reflex/proprioceptive/degradation`
  - Thread-safe abort tracking with `aborted_tools` / `clear_aborted()`
- Created `tests/test_proprioceptive.py` (13 tests):
  - Fires on UNAVAILABLE, ignores AVAILABLE
  - Non-critical: no FSM transition, still publishes result
  - Critical: FSM `throttle` fired, action_taken mentions THROTTLED
  - Graceful degradation publishes alternatives
  - Abort tracking and cleanup
  - MQTT subscribe registration
  - Invalid payload handling
  - Performance: < 100ms

## How to Test
```bash
pytest tests/test_proprioceptive.py -v
```