### PR TITLE
#44: PipeWire ScreenCast screen capture service

### DIFF
--- a/config/sensory_vision.yaml
+++ b/config/sensory_vision.yaml
@@ -1,0 +1,17 @@
+# Vision capture configuration — Phase 2
+# See src/openbad/sensory/vision/config.py for field descriptions.
+
+vision:
+  fps_idle: 1.0
+  fps_active: 5.0
+  output_format: jpeg       # raw_rgb | jpeg | png
+  jpeg_quality: 85
+  match_source_resolution: true
+  max_width: 1920
+  max_height: 1080
+  portal_backend: ""         # wlr | gnome | "" (auto-detect)
+
+  attention:
+    ssim_threshold: 0.05     # Minimum SSIM delta to forward a frame
+    cooldown_ms: 500         # Min interval between attention triggers (ms)
+    roi_enabled: false       # Enable region-of-interest tracking

--- a/src/openbad/sensory/vision/capture.py
+++ b/src/openbad/sensory/vision/capture.py
@@ -1,0 +1,322 @@
+"""PipeWire ScreenCast portal integration for window capture.
+
+This module connects to the ``org.freedesktop.portal.ScreenCast`` D-Bus
+interface on Linux/Wayland to capture individual application windows.
+On unsupported platforms the module logs a clear error and exposes a
+no-op fallback so the rest of the stack can load without crashing.
+
+Runtime requirements (Linux only):
+  - Wayland compositor (Sway, Hyprland, GNOME Wayland)
+  - PipeWire running as multimedia daemon
+  - ``xdg-desktop-portal`` with an appropriate backend
+  - ``dbus-next`` (MIT) Python package
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import platform
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from openbad.nervous_system.schemas import Header, VisionFrame
+from openbad.nervous_system.schemas.sensory_pb2 import FrameFormat
+from openbad.nervous_system.topics import SENSORY_VISION, topic_for
+from openbad.sensory.vision.config import VisionConfig
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Platform guard
+# ---------------------------------------------------------------------------
+_IS_LINUX = platform.system() == "Linux"
+
+PORTAL_BUS_NAME = "org.freedesktop.portal.Desktop"
+PORTAL_OBJECT_PATH = "/org/freedesktop/portal/desktop"
+PORTAL_SCREENCAST_IFACE = "org.freedesktop.portal.ScreenCast"
+PORTAL_REQUEST_IFACE = "org.freedesktop.portal.Request"
+
+# ScreenCast source type flags
+SOURCE_TYPE_MONITOR = 1
+SOURCE_TYPE_WINDOW = 2
+
+_FORMAT_MAP = {
+    "raw_rgb": FrameFormat.RAW_RGB,
+    "jpeg": FrameFormat.JPEG,
+    "png": FrameFormat.PNG,
+}
+
+
+@dataclass
+class CapturedFrame:
+    """A single captured frame with metadata."""
+
+    source_id: str
+    window_title: str
+    width: int
+    height: int
+    data: bytes
+    format: FrameFormat
+    fps: float
+    timestamp: float = field(default_factory=time.time)
+
+    def to_proto(self) -> VisionFrame:
+        """Serialise to a ``VisionFrame`` protobuf message."""
+        return VisionFrame(
+            header=Header(
+                timestamp_unix=self.timestamp,
+                source_module="sensory.vision.capture",
+                schema_version=1,
+            ),
+            source_id=self.source_id,
+            window_title=self.window_title,
+            width=self.width,
+            height=self.height,
+            format=self.format,
+            frame_data=self.data,
+            fps=self.fps,
+        )
+
+    def mqtt_topic(self) -> str:
+        """Return the MQTT topic for this frame."""
+        return topic_for(SENSORY_VISION, source_id=self.source_id)
+
+
+# ---------------------------------------------------------------------------
+# Portal session management (Linux / Wayland only)
+# ---------------------------------------------------------------------------
+
+
+class ScreenCastPortal:
+    """Async wrapper around the xdg-desktop-portal ScreenCast API.
+
+    Parameters
+    ----------
+    config : VisionConfig
+        Capture configuration (FPS, format, resolution).
+    publish_fn : callable | None
+        Optional async callback ``(topic, payload) -> None`` to publish
+        frames to the event bus.  When *None*, captured frames are
+        silently discarded (useful for testing).
+    """
+
+    def __init__(
+        self,
+        config: VisionConfig | None = None,
+        publish_fn: Any | None = None,
+    ) -> None:
+        self._config = config or VisionConfig()
+        self._publish = publish_fn
+        self._running = False
+        self._session_handle: str | None = None
+        self._bus: Any | None = None  # dbus_next.aio.MessageBus
+        self._portal: Any | None = None  # dbus_next proxy interface
+        self._active_fps: float = self._config.fps_idle
+        self._frame_format = _FORMAT_MAP.get(
+            self._config.output_format, FrameFormat.JPEG
+        )
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    @property
+    def current_fps(self) -> float:
+        return self._active_fps
+
+    def set_active(self, active: bool) -> None:
+        """Switch between idle and active FPS."""
+        self._active_fps = (
+            self._config.fps_active if active else self._config.fps_idle
+        )
+
+    # -- Portal negotiation --------------------------------------------------
+
+    async def _connect_bus(self) -> Any:
+        """Connect to the session D-Bus."""
+        if not _IS_LINUX:
+            msg = "ScreenCast portal requires a Linux Wayland session"
+            raise RuntimeError(msg)
+
+        try:
+            from dbus_next.aio import MessageBus  # type: ignore[import-untyped]
+        except ImportError:
+            msg = (
+                "dbus-next is required for PipeWire screen capture. "
+                "Install with: pip install dbus-next"
+            )
+            raise RuntimeError(msg) from None
+
+        bus = await MessageBus().connect()
+        return bus
+
+    async def _get_portal_interface(self, bus: Any) -> Any:
+        """Obtain the ScreenCast portal proxy."""
+        introspection = await bus.introspect(PORTAL_BUS_NAME, PORTAL_OBJECT_PATH)
+        proxy = bus.get_proxy_object(
+            PORTAL_BUS_NAME, PORTAL_OBJECT_PATH, introspection
+        )
+        return proxy.get_interface(PORTAL_SCREENCAST_IFACE)
+
+    async def create_session(self) -> str:
+        """Negotiate a ScreenCast session (D-Bus → PipeWire stream).
+
+        Returns the PipeWire node ID as a string.
+
+        Raises
+        ------
+        RuntimeError
+            If the platform is unsupported or any D-Bus call fails.
+        """
+        self._bus = await self._connect_bus()
+        self._portal = await self._get_portal_interface(self._bus)
+
+        # CreateSession
+        session_result = await self._portal.call_create_session(
+            {"session_handle_token": ("s", "openbad_vision")}
+        )
+        self._session_handle = session_result
+
+        # SelectSources — request WINDOW only
+        await self._portal.call_select_sources(
+            self._session_handle,
+            {
+                "types": ("u", SOURCE_TYPE_WINDOW),
+                "multiple": ("b", False),
+            },
+        )
+
+        # Start — user will see the window picker
+        start_result = await self._portal.call_start(
+            self._session_handle, ""
+        )
+        return str(start_result)
+
+    # -- Frame consumption ---------------------------------------------------
+
+    @staticmethod
+    def _parse_raw_frame(
+        raw: bytes, width: int, height: int
+    ) -> bytes:
+        """Validate and return raw RGB frame data."""
+        expected = width * height * 4  # BGRA
+        if len(raw) < expected:
+            msg = f"Frame too small: got {len(raw)}, expected {expected}"
+            raise ValueError(msg)
+        return raw[:expected]
+
+    @staticmethod
+    def _encode_jpeg(raw_bgra: bytes, width: int, height: int, quality: int) -> bytes:
+        """Encode raw BGRA bytes to JPEG. Requires *Pillow* at runtime."""
+        try:
+            from PIL import Image  # type: ignore[import-untyped]
+        except ImportError:
+            msg = "Pillow is required for JPEG encoding: pip install Pillow"
+            raise RuntimeError(msg) from None
+
+        img = Image.frombytes("RGBA", (width, height), raw_bgra)
+        rgb = img.convert("RGB")
+        import io
+
+        buf = io.BytesIO()
+        rgb.save(buf, format="JPEG", quality=quality)
+        return buf.getvalue()
+
+    @staticmethod
+    def _encode_png(raw_bgra: bytes, width: int, height: int) -> bytes:
+        """Encode raw BGRA bytes to PNG."""
+        try:
+            from PIL import Image  # type: ignore[import-untyped]
+        except ImportError:
+            msg = "Pillow is required for PNG encoding: pip install Pillow"
+            raise RuntimeError(msg) from None
+
+        img = Image.frombytes("RGBA", (width, height), raw_bgra)
+        import io
+
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        return buf.getvalue()
+
+    def encode_frame(
+        self,
+        raw_bgra: bytes,
+        width: int,
+        height: int,
+    ) -> tuple[bytes, FrameFormat]:
+        """Encode raw BGRA frame to the configured format."""
+        if self._frame_format == FrameFormat.JPEG:
+            return (
+                self._encode_jpeg(raw_bgra, width, height, self._config.jpeg_quality),
+                FrameFormat.JPEG,
+            )
+        if self._frame_format == FrameFormat.PNG:
+            return self._encode_png(raw_bgra, width, height), FrameFormat.PNG
+        # RAW_RGB — strip alpha channel
+        rgb = bytearray()
+        for i in range(0, len(raw_bgra), 4):
+            rgb.extend(raw_bgra[i + 2 : i + 3])  # R
+            rgb.extend(raw_bgra[i + 1 : i + 2])  # G
+            rgb.extend(raw_bgra[i : i + 1])  # B
+        return bytes(rgb), FrameFormat.RAW_RGB
+
+    async def capture_loop(
+        self,
+        source_id: str,
+        window_title: str,
+        frame_provider: Any,
+    ) -> None:
+        """Run the capture loop, encoding and publishing frames.
+
+        Parameters
+        ----------
+        source_id : str
+            Identifier for the capture source.
+        window_title : str
+            Title of the captured window.
+        frame_provider : async iterable
+            Yields ``(raw_bytes, width, height)`` tuples.
+        """
+        self._running = True
+        try:
+            async for raw, width, height in frame_provider:
+                if not self._running:
+                    break
+
+                encoded, fmt = self.encode_frame(raw, width, height)
+                frame = CapturedFrame(
+                    source_id=source_id,
+                    window_title=window_title,
+                    width=width,
+                    height=height,
+                    data=encoded,
+                    format=fmt,
+                    fps=self._active_fps,
+                )
+
+                if self._publish is not None:
+                    proto = frame.to_proto()
+                    topic = frame.mqtt_topic()
+                    await self._publish(topic, proto.SerializeToString())
+
+                # Throttle to configured FPS
+                if self._active_fps > 0:
+                    await asyncio.sleep(1.0 / self._active_fps)
+        finally:
+            self._running = False
+
+    async def stop(self) -> None:
+        """Stop the capture loop and disconnect the D-Bus session."""
+        self._running = False
+        if self._bus is not None:
+            self._bus.disconnect()
+            self._bus = None
+        self._session_handle = None
+
+    async def __aenter__(self) -> ScreenCastPortal:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.stop()

--- a/src/openbad/sensory/vision/config.py
+++ b/src/openbad/sensory/vision/config.py
@@ -1,0 +1,93 @@
+"""Vision configuration — FPS, resolution, format settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class VisionConfig:
+    """Configuration for the vision capture subsystem.
+
+    Attributes
+    ----------
+    fps_idle : float
+        Capture rate when the agent is passively monitoring (default 1.0).
+    fps_active : float
+        Capture rate during active GUI interaction (default 5.0).
+    output_format : str
+        Frame encoding — ``"raw_rgb"``, ``"jpeg"``, or ``"png"`` (default ``"jpeg"``).
+    jpeg_quality : int
+        JPEG compression quality 1-100 (default 85).
+    match_source_resolution : bool
+        When *True* (default) frames match the source window resolution.
+    max_width : int
+        Cap width if ``match_source_resolution`` is *False* (default 1920).
+    max_height : int
+        Cap height if ``match_source_resolution`` is *False* (default 1080).
+    portal_backend : str
+        xdg-desktop-portal backend hint (e.g. ``"wlr"``, ``"gnome"``).
+    """
+
+    fps_idle: float = 1.0
+    fps_active: float = 5.0
+    output_format: str = "jpeg"
+    jpeg_quality: int = 85
+    match_source_resolution: bool = True
+    max_width: int = 1920
+    max_height: int = 1080
+    portal_backend: str = ""
+
+    # Attention filter settings (co-located for convenience)
+    attention: AttentionConfig = field(default_factory=lambda: AttentionConfig())
+
+
+@dataclass
+class AttentionConfig:
+    """Attention filter thresholds.
+
+    Attributes
+    ----------
+    ssim_threshold : float
+        Minimum SSIM delta to forward a frame (default 0.05).
+    cooldown_ms : int
+        Minimum interval between attention triggers in milliseconds (default 500).
+    roi_enabled : bool
+        Enable region-of-interest change tracking (default *False*).
+    """
+
+    ssim_threshold: float = 0.05
+    cooldown_ms: int = 500
+    roi_enabled: bool = False
+
+
+def load_vision_config(path: Path | str | None = None) -> VisionConfig:
+    """Load :class:`VisionConfig` from a YAML file.
+
+    Falls back to defaults when *path* is ``None`` or the file does not exist.
+    """
+    if path is None:
+        return VisionConfig()
+
+    p = Path(path)
+    if not p.exists():
+        return VisionConfig()
+
+    raw: dict[str, Any] = yaml.safe_load(p.read_text()) or {}
+    vision_raw = raw.get("vision", raw)
+
+    attention_raw = vision_raw.pop("attention", {})
+    attention = AttentionConfig(**{
+        k: v for k, v in attention_raw.items() if k in AttentionConfig.__dataclass_fields__
+    })
+
+    fields = {
+        k: v
+        for k, v in vision_raw.items()
+        if k in VisionConfig.__dataclass_fields__ and k != "attention"
+    }
+    return VisionConfig(**fields, attention=attention)

--- a/tests/test_vision_capture.py
+++ b/tests/test_vision_capture.py
@@ -1,0 +1,268 @@
+"""Tests for PipeWire ScreenCast capture service — Issue #44."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from openbad.nervous_system.schemas import VisionFrame
+from openbad.nervous_system.schemas.sensory_pb2 import FrameFormat
+from openbad.sensory.vision.capture import (
+    _IS_LINUX,
+    CapturedFrame,
+    ScreenCastPortal,
+)
+from openbad.sensory.vision.config import VisionConfig
+
+# ---------------------------------------------------------------------------
+# CapturedFrame tests
+# ---------------------------------------------------------------------------
+
+
+class TestCapturedFrame:
+    def test_to_proto(self) -> None:
+        frame = CapturedFrame(
+            source_id="win-001",
+            window_title="Test Window",
+            width=800,
+            height=600,
+            data=b"\xff" * 100,
+            format=FrameFormat.JPEG,
+            fps=5.0,
+            timestamp=1234567890.0,
+        )
+        proto = frame.to_proto()
+        assert isinstance(proto, VisionFrame)
+        assert proto.source_id == "win-001"
+        assert proto.window_title == "Test Window"
+        assert proto.width == 800
+        assert proto.height == 600
+        assert proto.format == FrameFormat.JPEG
+        assert proto.frame_data == b"\xff" * 100
+        assert abs(proto.fps - 5.0) < 0.01
+        assert proto.header.source_module == "sensory.vision.capture"
+
+    def test_to_proto_serializes(self) -> None:
+        frame = CapturedFrame(
+            source_id="win-002",
+            window_title="Another Window",
+            width=1920,
+            height=1080,
+            data=b"\x00" * 50,
+            format=FrameFormat.RAW_RGB,
+            fps=1.0,
+        )
+        data = frame.to_proto().SerializeToString()
+        restored = VisionFrame()
+        restored.ParseFromString(data)
+        assert restored.source_id == "win-002"
+        assert restored.width == 1920
+
+    def test_mqtt_topic(self) -> None:
+        frame = CapturedFrame(
+            source_id="firefox-main",
+            window_title="Firefox",
+            width=800,
+            height=600,
+            data=b"",
+            format=FrameFormat.JPEG,
+            fps=1.0,
+        )
+        assert frame.mqtt_topic() == "agent/sensory/vision/firefox-main"
+
+    def test_timestamp_auto_set(self) -> None:
+        before = time.time()
+        frame = CapturedFrame(
+            source_id="test",
+            window_title="Test",
+            width=100,
+            height=100,
+            data=b"",
+            format=FrameFormat.JPEG,
+            fps=1.0,
+        )
+        after = time.time()
+        assert before <= frame.timestamp <= after
+
+
+# ---------------------------------------------------------------------------
+# ScreenCastPortal unit tests (with mocked D-Bus)
+# ---------------------------------------------------------------------------
+
+
+class TestScreenCastPortalConfig:
+    def test_default_config(self) -> None:
+        portal = ScreenCastPortal()
+        assert portal.current_fps == 1.0
+        assert portal.running is False
+
+    def test_custom_config(self) -> None:
+        cfg = VisionConfig(fps_idle=2.0, fps_active=10.0)
+        portal = ScreenCastPortal(config=cfg)
+        assert portal.current_fps == 2.0
+
+    def test_set_active_true(self) -> None:
+        cfg = VisionConfig(fps_idle=1.0, fps_active=10.0)
+        portal = ScreenCastPortal(config=cfg)
+        portal.set_active(True)
+        assert portal.current_fps == 10.0
+
+    def test_set_active_false(self) -> None:
+        cfg = VisionConfig(fps_idle=1.0, fps_active=10.0)
+        portal = ScreenCastPortal(config=cfg)
+        portal.set_active(True)
+        portal.set_active(False)
+        assert portal.current_fps == 1.0
+
+    def test_format_map_jpeg(self) -> None:
+        cfg = VisionConfig(output_format="jpeg")
+        portal = ScreenCastPortal(config=cfg)
+        assert portal._frame_format == FrameFormat.JPEG
+
+    def test_format_map_raw_rgb(self) -> None:
+        cfg = VisionConfig(output_format="raw_rgb")
+        portal = ScreenCastPortal(config=cfg)
+        assert portal._frame_format == FrameFormat.RAW_RGB
+
+    def test_format_map_png(self) -> None:
+        cfg = VisionConfig(output_format="png")
+        portal = ScreenCastPortal(config=cfg)
+        assert portal._frame_format == FrameFormat.PNG
+
+
+class TestScreenCastPortalPlatformGuard:
+    @pytest.mark.skipif(_IS_LINUX, reason="Test only on non-Linux")
+    async def test_connect_bus_fails_on_non_linux(self) -> None:
+        portal = ScreenCastPortal()
+        with pytest.raises(RuntimeError, match="Linux Wayland session"):
+            await portal._connect_bus()
+
+
+class TestScreenCastPortalFrameEncoding:
+    def _make_bgra_frame(self, width: int, height: int) -> bytes:
+        """Create a fake BGRA frame (blue channel = 0xFF, others = 0x00)."""
+        pixel = b"\xff\x00\x00\xff"  # BGRA: B=255, G=0, R=0, A=255
+        return pixel * (width * height)
+
+    def test_encode_raw_rgb(self) -> None:
+        cfg = VisionConfig(output_format="raw_rgb")
+        portal = ScreenCastPortal(config=cfg)
+        raw = self._make_bgra_frame(2, 2)
+        encoded, fmt = portal.encode_frame(raw, 2, 2)
+        assert fmt == FrameFormat.RAW_RGB
+        # BGRA (B=255,G=0,R=0,A=255) → RGB (R=0,G=0,B=255)
+        assert len(encoded) == 2 * 2 * 3  # RGB
+        # First pixel: R=0, G=0, B=255
+        assert encoded[0:3] == b"\x00\x00\xff"
+
+    def test_encode_jpeg_requires_pillow(self) -> None:
+        cfg = VisionConfig(output_format="jpeg")
+        portal = ScreenCastPortal(config=cfg)
+        raw = self._make_bgra_frame(2, 2)
+        # This will either succeed (Pillow installed) or raise RuntimeError
+        try:
+            encoded, fmt = portal.encode_frame(raw, 2, 2)
+            assert fmt == FrameFormat.JPEG
+            # JPEG magic bytes
+            assert encoded[:2] == b"\xff\xd8"
+        except RuntimeError:
+            pytest.skip("Pillow not installed")
+
+    def test_encode_png_requires_pillow(self) -> None:
+        cfg = VisionConfig(output_format="png")
+        portal = ScreenCastPortal(config=cfg)
+        raw = self._make_bgra_frame(2, 2)
+        try:
+            encoded, fmt = portal.encode_frame(raw, 2, 2)
+            assert fmt == FrameFormat.PNG
+            # PNG magic bytes
+            assert encoded[:4] == b"\x89PNG"
+        except RuntimeError:
+            pytest.skip("Pillow not installed")
+
+
+class TestScreenCastPortalCaptureLoop:
+    async def test_capture_publishes_frames(self) -> None:
+        """Mock frame provider delivers 3 frames; all are published."""
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        cfg = VisionConfig(output_format="raw_rgb", fps_idle=1000)  # fast for test
+        portal = ScreenCastPortal(config=cfg, publish_fn=mock_publish)
+
+        # Create a mock async iterable that yields 3 frames then stops
+        frames = [
+            (b"\xff\x00\x00\xff" * 4, 2, 2),
+            (b"\x00\xff\x00\xff" * 4, 2, 2),
+            (b"\x00\x00\xff\xff" * 4, 2, 2),
+        ]
+
+        async def frame_gen():
+            for f in frames:
+                yield f
+
+        await portal.capture_loop("test-win", "Test", frame_gen())
+
+        assert len(published) == 3
+        assert all(t == "agent/sensory/vision/test-win" for t, _ in published)
+        # Each payload should deserialize to VisionFrame
+        for _, payload in published:
+            vf = VisionFrame()
+            vf.ParseFromString(payload)
+            assert vf.source_id == "test-win"
+            assert vf.width == 2
+            assert vf.height == 2
+
+    async def test_capture_loop_sets_running_flag(self) -> None:
+        cfg = VisionConfig(output_format="raw_rgb", fps_idle=1000)
+        portal = ScreenCastPortal(config=cfg)
+
+        assert portal.running is False
+
+        async def empty_gen():
+            return
+            yield  # make it an async generator  # noqa: E501
+
+        await portal.capture_loop("x", "X", empty_gen())
+        assert portal.running is False  # cleaned up after completion
+
+    async def test_stop_terminates_loop(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        cfg = VisionConfig(output_format="raw_rgb", fps_idle=100)
+        portal = ScreenCastPortal(config=cfg, publish_fn=mock_publish)
+
+        async def infinite_gen():
+            while True:
+                yield (b"\xff\x00\x00\xff" * 4, 2, 2)
+
+        async def stop_soon():
+            await asyncio.sleep(0.05)
+            await portal.stop()
+
+        # Run capture loop and stop concurrently
+        await asyncio.gather(
+            portal.capture_loop("w", "W", infinite_gen()),
+            stop_soon(),
+        )
+        assert portal.running is False
+        assert len(published) >= 1  # At least one frame before stop
+
+
+class TestScreenCastPortalContextManager:
+    async def test_async_context_manager(self) -> None:
+        async with ScreenCastPortal() as portal:
+            assert isinstance(portal, ScreenCastPortal)
+        assert portal.running is False
+
+    async def test_stop_is_safe_to_call_multiple_times(self) -> None:
+        portal = ScreenCastPortal()
+        await portal.stop()
+        await portal.stop()  # Should not raise

--- a/tests/test_vision_config.py
+++ b/tests/test_vision_config.py
@@ -1,0 +1,144 @@
+"""Tests for vision configuration — Issue #44."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from openbad.sensory.vision.config import (
+    AttentionConfig,
+    VisionConfig,
+    load_vision_config,
+)
+
+
+class TestVisionConfigDefaults:
+    def test_default_fps_idle(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.fps_idle == 1.0
+
+    def test_default_fps_active(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.fps_active == 5.0
+
+    def test_default_output_format(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.output_format == "jpeg"
+
+    def test_default_jpeg_quality(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.jpeg_quality == 85
+
+    def test_default_match_source_resolution(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.match_source_resolution is True
+
+    def test_default_max_dimensions(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.max_width == 1920
+        assert cfg.max_height == 1080
+
+    def test_default_portal_backend_empty(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.portal_backend == ""
+
+    def test_default_attention_config(self) -> None:
+        cfg = VisionConfig()
+        assert isinstance(cfg.attention, AttentionConfig)
+        assert cfg.attention.ssim_threshold == 0.05
+        assert cfg.attention.cooldown_ms == 500
+        assert cfg.attention.roi_enabled is False
+
+
+class TestAttentionConfigDefaults:
+    def test_defaults(self) -> None:
+        cfg = AttentionConfig()
+        assert cfg.ssim_threshold == 0.05
+        assert cfg.cooldown_ms == 500
+        assert cfg.roi_enabled is False
+
+    def test_custom_threshold(self) -> None:
+        cfg = AttentionConfig(ssim_threshold=0.1, cooldown_ms=1000, roi_enabled=True)
+        assert cfg.ssim_threshold == 0.1
+        assert cfg.cooldown_ms == 1000
+        assert cfg.roi_enabled is True
+
+
+class TestLoadVisionConfig:
+    def test_none_path_returns_defaults(self) -> None:
+        cfg = load_vision_config(None)
+        assert cfg.fps_idle == 1.0
+        assert cfg.output_format == "jpeg"
+
+    def test_missing_file_returns_defaults(self) -> None:
+        cfg = load_vision_config("/nonexistent/path.yaml")
+        assert cfg.fps_idle == 1.0
+
+    def test_load_from_yaml(self, tmp_path: Path) -> None:
+        yaml_content = dedent("""\
+            vision:
+              fps_idle: 2.0
+              fps_active: 10.0
+              output_format: png
+              jpeg_quality: 90
+              match_source_resolution: false
+              max_width: 1280
+              max_height: 720
+              portal_backend: gnome
+              attention:
+                ssim_threshold: 0.1
+                cooldown_ms: 1000
+                roi_enabled: true
+        """)
+        cfg_file = tmp_path / "vision.yaml"
+        cfg_file.write_text(yaml_content)
+        cfg = load_vision_config(cfg_file)
+
+        assert cfg.fps_idle == 2.0
+        assert cfg.fps_active == 10.0
+        assert cfg.output_format == "png"
+        assert cfg.jpeg_quality == 90
+        assert cfg.match_source_resolution is False
+        assert cfg.max_width == 1280
+        assert cfg.max_height == 720
+        assert cfg.portal_backend == "gnome"
+        assert cfg.attention.ssim_threshold == 0.1
+        assert cfg.attention.cooldown_ms == 1000
+        assert cfg.attention.roi_enabled is True
+
+    def test_partial_yaml(self, tmp_path: Path) -> None:
+        yaml_content = dedent("""\
+            vision:
+              fps_idle: 3.0
+        """)
+        cfg_file = tmp_path / "partial.yaml"
+        cfg_file.write_text(yaml_content)
+        cfg = load_vision_config(cfg_file)
+        assert cfg.fps_idle == 3.0
+        assert cfg.fps_active == 5.0  # default
+        assert cfg.attention.ssim_threshold == 0.05  # default
+
+    def test_empty_yaml(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "empty.yaml"
+        cfg_file.write_text("")
+        cfg = load_vision_config(cfg_file)
+        assert cfg.fps_idle == 1.0
+
+    def test_ignores_unknown_keys(self, tmp_path: Path) -> None:
+        yaml_content = dedent("""\
+            vision:
+              fps_idle: 2.0
+              unknown_key: should_be_ignored
+        """)
+        cfg_file = tmp_path / "unknown.yaml"
+        cfg_file.write_text(yaml_content)
+        cfg = load_vision_config(cfg_file)
+        assert cfg.fps_idle == 2.0
+
+    def test_load_from_project_config(self) -> None:
+        """Load the actual config/sensory_vision.yaml from the repo."""
+        cfg_path = Path(__file__).resolve().parents[1] / "config" / "sensory_vision.yaml"
+        if cfg_path.exists():
+            cfg = load_vision_config(cfg_path)
+            assert cfg.fps_idle == 1.0
+            assert cfg.attention.ssim_threshold == 0.05


### PR DESCRIPTION
Closes #44

## Summary
- `ScreenCastPortal` class: async wrapper around xdg-desktop-portal ScreenCast D-Bus API
- `CapturedFrame` dataclass with proto serialisation and MQTT topic routing
- Frame encoding pipeline: raw BGRA → JPEG/PNG/RGB via Pillow
- `VisionConfig` / `AttentionConfig` dataclasses with YAML loader
- Platform guard: clear RuntimeError on non-Linux, graceful fallback
- Default config at `config/sensory_vision.yaml`

## How to test
```sh
python -m pytest tests/test_vision_config.py tests/test_vision_capture.py -v
```