### PR TITLE
#45: AT-SPI2 accessibility tree extractor

### DIFF
--- a/src/openbad/sensory/vision/accessibility.py
+++ b/src/openbad/sensory/vision/accessibility.py
@@ -1,0 +1,264 @@
+"""AT-SPI2 accessibility tree extractor.
+
+Connects to the Linux accessibility bus (AT-SPI2) via D-Bus to extract
+the widget tree of a target application.  The extracted tree is
+serialised as JSON and published as a ``ParsedScreen`` protobuf message
+on ``agent/sensory/vision/{source_id}/parsed``.
+
+Runtime requirements (Linux only):
+  - AT-SPI2 enabled in the desktop session
+  - ``dbus-next`` (MIT) Python package
+  - Target application exposing an AT-SPI2 accessible hierarchy
+
+On unsupported platforms the module exposes no-op helpers and raises a
+clear ``RuntimeError`` at connection time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import platform
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from openbad.nervous_system.schemas import Header, ParsedScreen
+from openbad.nervous_system.schemas.sensory_pb2 import ParseMethod
+from openbad.nervous_system.topics import SENSORY_VISION_PARSED, topic_for
+
+logger = logging.getLogger(__name__)
+
+_IS_LINUX = platform.system() == "Linux"
+
+# AT-SPI2 D-Bus constants
+ATSPI_BUS_NAME = "org.a11y.Bus"
+ATSPI_REGISTRY_PATH = "/org/a11y/atspi/accessible/root"
+ATSPI_ACCESSIBLE_IFACE = "org.a11y.atspi.Accessible"
+
+
+# ---------------------------------------------------------------------------
+# Extracted node model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AccessibleNode:
+    """One node in an AT-SPI2 accessibility tree."""
+
+    role: str
+    name: str
+    description: str = ""
+    states: list[str] = field(default_factory=list)
+    actions: list[str] = field(default_factory=list)
+    value: str = ""
+    bounds: tuple[int, int, int, int] | None = None  # x, y, w, h
+    children: list[AccessibleNode] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-friendly dict."""
+        d: dict[str, Any] = {"role": self.role, "name": self.name}
+        if self.description:
+            d["description"] = self.description
+        if self.states:
+            d["states"] = self.states
+        if self.actions:
+            d["actions"] = self.actions
+        if self.value:
+            d["value"] = self.value
+        if self.bounds is not None:
+            d["bounds"] = {"x": self.bounds[0], "y": self.bounds[1],
+                           "w": self.bounds[2], "h": self.bounds[3]}
+        if self.children:
+            d["children"] = [c.to_dict() for c in self.children]
+        return d
+
+    def node_count(self) -> int:
+        """Return total number of nodes in this subtree (including self)."""
+        return 1 + sum(c.node_count() for c in self.children)
+
+
+def tree_to_json(root: AccessibleNode) -> str:
+    """Serialise an accessibility tree to compact JSON."""
+    return json.dumps(root.to_dict(), separators=(",", ":"))
+
+
+# ---------------------------------------------------------------------------
+# AT-SPI2 D-Bus extractor
+# ---------------------------------------------------------------------------
+
+
+class ATSPIExtractor:
+    """Extract the accessibility tree from a running application via AT-SPI2.
+
+    Parameters
+    ----------
+    max_depth : int
+        Maximum depth to traverse in the accessibility tree. 0 means
+        unlimited.
+    publish_fn : callable | None
+        Optional async callback ``(topic, payload) -> None``.
+    """
+
+    def __init__(
+        self,
+        max_depth: int = 0,
+        publish_fn: Any | None = None,
+    ) -> None:
+        self._max_depth = max_depth
+        self._publish = publish_fn
+        self._bus: Any | None = None
+
+    # -- D-Bus connection ----------------------------------------------------
+
+    async def connect(self) -> None:
+        """Connect to the AT-SPI2 accessibility bus."""
+        if not _IS_LINUX:
+            msg = "AT-SPI2 requires a Linux desktop session"
+            raise RuntimeError(msg)
+
+        try:
+            from dbus_next.aio import MessageBus  # type: ignore[import-untyped]
+        except ImportError:
+            msg = (
+                "dbus-next is required for AT-SPI2 extraction. "
+                "Install with: pip install dbus-next"
+            )
+            raise RuntimeError(msg) from None
+
+        self._bus = await MessageBus().connect()
+        logger.info("Connected to AT-SPI2 bus")
+
+    async def disconnect(self) -> None:
+        """Disconnect from the D-Bus."""
+        if self._bus is not None:
+            self._bus.disconnect()
+            self._bus = None
+
+    # -- Tree extraction -----------------------------------------------------
+
+    async def _extract_node(
+        self,
+        bus: Any,
+        bus_name: str,
+        path: str,
+        depth: int,
+    ) -> AccessibleNode:
+        """Recursively extract one accessible node and its children."""
+        introspection = await bus.introspect(bus_name, path)
+        proxy = bus.get_proxy_object(bus_name, path, introspection)
+        accessible = proxy.get_interface(ATSPI_ACCESSIBLE_IFACE)
+
+        name = await accessible.get_name()
+        role = str(await accessible.get_role_name())
+        description = await accessible.get_description()
+
+        # Get child count and iterate
+        child_count = await accessible.get_child_count()
+        children: list[AccessibleNode] = []
+
+        if self._max_depth == 0 or depth < self._max_depth:
+            for i in range(child_count):
+                child_ref = await accessible.call_get_child_at_index(i)
+                # child_ref is (bus_name, path)
+                child_bus, child_path = child_ref
+                if child_path and child_path != "/":
+                    try:
+                        child = await self._extract_node(
+                            bus, child_bus, child_path, depth + 1
+                        )
+                        children.append(child)
+                    except Exception:
+                        logger.debug(
+                            "Skipping inaccessible child %s:%s", child_bus, child_path
+                        )
+
+        return AccessibleNode(
+            role=role,
+            name=name,
+            description=description,
+            children=children,
+        )
+
+    async def extract_tree(
+        self,
+        app_bus_name: str,
+        root_path: str = ATSPI_REGISTRY_PATH,
+    ) -> AccessibleNode:
+        """Extract the accessibility tree for an application.
+
+        Parameters
+        ----------
+        app_bus_name : str
+            The D-Bus bus name of the target application.
+        root_path : str
+            D-Bus object path to start extraction from.
+
+        Returns
+        -------
+        AccessibleNode
+            The root of the extracted accessibility tree.
+
+        Raises
+        ------
+        RuntimeError
+            If not connected.
+        """
+        if self._bus is None:
+            msg = "Not connected — call connect() first"
+            raise RuntimeError(msg)
+
+        start = time.perf_counter()
+        root = await self._extract_node(self._bus, app_bus_name, root_path, 0)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        logger.info(
+            "Extracted %d nodes from %s in %.1f ms",
+            root.node_count(),
+            app_bus_name,
+            elapsed_ms,
+        )
+        return root
+
+    async def extract_and_publish(
+        self,
+        source_id: str,
+        app_bus_name: str,
+        root_path: str = ATSPI_REGISTRY_PATH,
+    ) -> ParsedScreen:
+        """Extract the tree and optionally publish via the event bus.
+
+        Returns the ``ParsedScreen`` protobuf regardless of whether
+        a publisher is configured.
+        """
+        start = time.perf_counter()
+        root = await self.extract_tree(app_bus_name, root_path)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        tree_json = tree_to_json(root)
+        count = root.node_count()
+
+        proto = ParsedScreen(
+            header=Header(
+                timestamp_unix=time.time(),
+                source_module="sensory.vision.accessibility",
+                schema_version=1,
+            ),
+            source_id=source_id,
+            method=ParseMethod.AT_SPI2,
+            tree_json=tree_json,
+            node_count=count,
+            extraction_ms=elapsed_ms,
+        )
+
+        if self._publish is not None:
+            topic = topic_for(SENSORY_VISION_PARSED, source_id=source_id)
+            await self._publish(topic, proto.SerializeToString())
+
+        return proto
+
+    async def __aenter__(self) -> ATSPIExtractor:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.disconnect()

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,0 +1,267 @@
+"""Tests for AT-SPI2 accessibility tree extractor — Issue #45."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openbad.nervous_system.schemas import ParsedScreen
+from openbad.nervous_system.schemas.sensory_pb2 import ParseMethod
+from openbad.sensory.vision.accessibility import (
+    _IS_LINUX,
+    AccessibleNode,
+    ATSPIExtractor,
+    tree_to_json,
+)
+
+# ---------------------------------------------------------------------------
+# AccessibleNode tests
+# ---------------------------------------------------------------------------
+
+
+class TestAccessibleNode:
+    def test_simple_node(self) -> None:
+        node = AccessibleNode(role="push button", name="OK")
+        assert node.role == "push button"
+        assert node.name == "OK"
+        assert node.children == []
+        assert node.node_count() == 1
+
+    def test_node_with_children(self) -> None:
+        child1 = AccessibleNode(role="label", name="Hello")
+        child2 = AccessibleNode(role="text", name="World")
+        parent = AccessibleNode(role="panel", name="Container", children=[child1, child2])
+        assert parent.node_count() == 3
+
+    def test_deep_tree(self) -> None:
+        leaf = AccessibleNode(role="label", name="Leaf")
+        mid = AccessibleNode(role="panel", name="Mid", children=[leaf])
+        root = AccessibleNode(role="frame", name="Root", children=[mid])
+        assert root.node_count() == 3
+
+    def test_to_dict_minimal(self) -> None:
+        node = AccessibleNode(role="button", name="Click me")
+        d = node.to_dict()
+        assert d == {"role": "button", "name": "Click me"}
+
+    def test_to_dict_with_description(self) -> None:
+        node = AccessibleNode(role="button", name="OK", description="Confirm action")
+        d = node.to_dict()
+        assert d["description"] == "Confirm action"
+
+    def test_to_dict_with_states(self) -> None:
+        node = AccessibleNode(role="check box", name="Remember", states=["enabled", "checked"])
+        d = node.to_dict()
+        assert d["states"] == ["enabled", "checked"]
+
+    def test_to_dict_with_actions(self) -> None:
+        node = AccessibleNode(role="button", name="Act", actions=["click", "press"])
+        d = node.to_dict()
+        assert d["actions"] == ["click", "press"]
+
+    def test_to_dict_with_value(self) -> None:
+        node = AccessibleNode(role="slider", name="Volume", value="75")
+        d = node.to_dict()
+        assert d["value"] == "75"
+
+    def test_to_dict_with_bounds(self) -> None:
+        node = AccessibleNode(role="button", name="B", bounds=(10, 20, 100, 50))
+        d = node.to_dict()
+        assert d["bounds"] == {"x": 10, "y": 20, "w": 100, "h": 50}
+
+    def test_to_dict_with_children(self) -> None:
+        child = AccessibleNode(role="label", name="Text")
+        parent = AccessibleNode(role="panel", name="P", children=[child])
+        d = parent.to_dict()
+        assert len(d["children"]) == 1
+        assert d["children"][0]["role"] == "label"
+
+    def test_to_dict_omits_empty_optional_fields(self) -> None:
+        node = AccessibleNode(role="label", name="Plain")
+        d = node.to_dict()
+        assert "description" not in d
+        assert "states" not in d
+        assert "actions" not in d
+        assert "value" not in d
+        assert "bounds" not in d
+        assert "children" not in d
+
+
+class TestTreeToJson:
+    def test_single_node(self) -> None:
+        node = AccessibleNode(role="button", name="OK")
+        result = tree_to_json(node)
+        parsed = json.loads(result)
+        assert parsed == {"role": "button", "name": "OK"}
+
+    def test_nested_tree(self) -> None:
+        child = AccessibleNode(role="label", name="Hello")
+        root = AccessibleNode(role="frame", name="Window", children=[child])
+        result = tree_to_json(root)
+        parsed = json.loads(result)
+        assert parsed["children"][0]["name"] == "Hello"
+
+    def test_compact_json_no_spaces(self) -> None:
+        node = AccessibleNode(role="x", name="y")
+        result = tree_to_json(node)
+        assert " " not in result  # compact separators
+
+    def test_roundtrip_preserves_structure(self) -> None:
+        leaf1 = AccessibleNode(role="label", name="A", states=["enabled"])
+        leaf2 = AccessibleNode(role="button", name="B", bounds=(0, 0, 50, 30))
+        panel = AccessibleNode(role="panel", name="P", children=[leaf1, leaf2])
+        root = AccessibleNode(role="frame", name="App", children=[panel])
+
+        js = tree_to_json(root)
+        parsed = json.loads(js)
+        assert parsed["name"] == "App"
+        assert len(parsed["children"]) == 1
+        panel_d = parsed["children"][0]
+        assert len(panel_d["children"]) == 2
+        assert panel_d["children"][0]["states"] == ["enabled"]
+        assert panel_d["children"][1]["bounds"]["w"] == 50
+
+
+# ---------------------------------------------------------------------------
+# ATSPIExtractor unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestATSPIExtractorConfig:
+    def test_default_max_depth(self) -> None:
+        ext = ATSPIExtractor()
+        assert ext._max_depth == 0
+
+    def test_custom_max_depth(self) -> None:
+        ext = ATSPIExtractor(max_depth=5)
+        assert ext._max_depth == 5
+
+
+class TestATSPIExtractorPlatformGuard:
+    @pytest.mark.skipif(_IS_LINUX, reason="Test only on non-Linux")
+    async def test_connect_fails_on_non_linux(self) -> None:
+        ext = ATSPIExtractor()
+        with pytest.raises(RuntimeError, match="Linux desktop session"):
+            await ext.connect()
+
+
+class TestATSPIExtractorNotConnected:
+    async def test_extract_tree_requires_connection(self) -> None:
+        ext = ATSPIExtractor()
+        with pytest.raises(RuntimeError, match="Not connected"):
+            await ext.extract_tree("org.some.App")
+
+
+class TestATSPIExtractorPublish:
+    """Test extract_and_publish with a mocked tree extraction."""
+
+    async def test_publish_builds_proto(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        ext = ATSPIExtractor(publish_fn=mock_publish)
+        # Manually inject a connected bus (mocked)
+        ext._bus = object()  # truthy sentinel
+
+        # Monkey-patch extract_tree to return a known tree
+        tree = AccessibleNode(
+            role="frame",
+            name="TestApp",
+            children=[
+                AccessibleNode(role="button", name="OK"),
+                AccessibleNode(role="label", name="Status"),
+            ],
+        )
+
+        async def fake_extract(app_bus_name: str, root_path: str = "") -> AccessibleNode:
+            return tree
+
+        ext.extract_tree = fake_extract  # type: ignore[assignment]
+
+        result = await ext.extract_and_publish("firefox-1", "org.firefox")
+
+        assert isinstance(result, ParsedScreen)
+        assert result.source_id == "firefox-1"
+        assert result.method == ParseMethod.AT_SPI2
+        assert result.node_count == 3
+        assert result.extraction_ms >= 0
+
+        # Verify JSON tree
+        parsed_tree = json.loads(result.tree_json)
+        assert parsed_tree["name"] == "TestApp"
+        assert len(parsed_tree["children"]) == 2
+
+        # Verify publish was called
+        assert len(published) == 1
+        topic, payload = published[0]
+        assert topic == "agent/sensory/vision/firefox-1/parsed"
+
+        # Verify payload deserialises
+        restored = ParsedScreen()
+        restored.ParseFromString(payload)
+        assert restored.source_id == "firefox-1"
+        assert restored.node_count == 3
+
+    async def test_no_publish_fn_returns_proto_only(self) -> None:
+        ext = ATSPIExtractor()
+        ext._bus = object()
+
+        tree = AccessibleNode(role="frame", name="App")
+
+        async def fake_extract(app_bus_name: str, root_path: str = "") -> AccessibleNode:
+            return tree
+
+        ext.extract_tree = fake_extract  # type: ignore[assignment]
+
+        result = await ext.extract_and_publish("vim-1", "org.vim")
+        assert isinstance(result, ParsedScreen)
+        assert result.node_count == 1
+
+
+class TestATSPIExtractorContextManager:
+    @pytest.mark.skipif(_IS_LINUX, reason="Test only on non-Linux")
+    async def test_context_manager_connect_fails_gracefully(self) -> None:
+        with pytest.raises(RuntimeError):
+            async with ATSPIExtractor():
+                pass
+
+    async def test_disconnect_is_safe_when_not_connected(self) -> None:
+        ext = ATSPIExtractor()
+        await ext.disconnect()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Large tree performance test
+# ---------------------------------------------------------------------------
+
+
+class TestAccessibleNodeLargeTree:
+    def test_large_tree_node_count(self) -> None:
+        """Build a tree of ~1000 nodes and verify count."""
+
+        def build_tree(depth: int, breadth: int) -> AccessibleNode:
+            if depth == 0:
+                return AccessibleNode(role="label", name="leaf")
+            children = [build_tree(depth - 1, breadth) for _ in range(breadth)]
+            return AccessibleNode(role="panel", name=f"d{depth}", children=children)
+
+        # 4 levels, 5 children each = 5^0 + 5^1 + 5^2 + 5^3 + 5^4 = 781
+        root = build_tree(4, 5)
+        assert root.node_count() == 781
+
+    def test_large_tree_serialises(self) -> None:
+        """Ensure JSON serialisation handles moderate trees."""
+
+        def build_tree(depth: int, breadth: int) -> AccessibleNode:
+            if depth == 0:
+                return AccessibleNode(role="label", name="leaf")
+            children = [build_tree(depth - 1, breadth) for _ in range(breadth)]
+            return AccessibleNode(role="panel", name=f"d{depth}", children=children)
+
+        root = build_tree(3, 4)  # 85 nodes
+        js = tree_to_json(root)
+        parsed = json.loads(js)
+        assert parsed["name"] == "d3"


### PR DESCRIPTION
Closes #45

## Summary
- `AccessibleNode` dataclass: role, name, description, states, actions, value, bounds, children
- `tree_to_json()`: compact JSON serialisation of the widget tree
- `ATSPIExtractor`: async D-Bus client for AT-SPI2 bus, recursive tree extraction, platform guard
- `extract_and_publish()`: extract tree → build `ParsedScreen` proto → publish to event bus
- 25 unit tests covering tree model, serialisation, publishing, and platform guard

## How to test
```sh
python -m pytest tests/test_accessibility.py -v
```