### PR TITLE
#46: CDP DOM extractor for web browser content

### DIFF
--- a/src/openbad/sensory/vision/cdp_dom.py
+++ b/src/openbad/sensory/vision/cdp_dom.py
@@ -1,0 +1,250 @@
+"""Chrome DevTools Protocol (CDP) DOM extractor.
+
+Connects to a Chromium-based browser's remote debugging port to extract
+the live DOM tree, avoiding expensive pixel-level analysis for web
+content.
+
+Runtime requirements:
+  - A Chromium browser running with ``--remote-debugging-port=<port>``
+  - ``aiohttp`` (already a project dependency) for WebSocket transport
+
+The extracted DOM is serialised as a JSON widget tree and published as
+a ``ParsedScreen`` protobuf message on
+``agent/sensory/vision/{source_id}/parsed``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from openbad.nervous_system.schemas import Header, ParsedScreen
+from openbad.nervous_system.schemas.sensory_pb2 import ParseMethod
+from openbad.nervous_system.topics import SENSORY_VISION_PARSED, topic_for
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CDP_URL = "http://localhost:9222"
+
+
+# ---------------------------------------------------------------------------
+# DOM node model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DOMNode:
+    """A simplified DOM node extracted via CDP."""
+
+    tag: str
+    node_id: int = 0
+    attributes: dict[str, str] = field(default_factory=dict)
+    text: str = ""
+    children: list[DOMNode] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-friendly dict."""
+        d: dict[str, Any] = {"tag": self.tag}
+        if self.node_id:
+            d["nodeId"] = self.node_id
+        if self.attributes:
+            d["attributes"] = self.attributes
+        if self.text:
+            d["text"] = self.text
+        if self.children:
+            d["children"] = [c.to_dict() for c in self.children]
+        return d
+
+    def node_count(self) -> int:
+        """Total number of nodes in this subtree (including self)."""
+        return 1 + sum(c.node_count() for c in self.children)
+
+
+def dom_to_json(root: DOMNode) -> str:
+    """Serialise a DOM tree to compact JSON."""
+    return json.dumps(root.to_dict(), separators=(",", ":"))
+
+
+# ---------------------------------------------------------------------------
+# CDP node parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_cdp_node(node: dict[str, Any]) -> DOMNode:
+    """Parse a CDP ``DOM.Node`` dict into a ``DOMNode``.
+
+    CDP returns attributes as a flat list ``[key, value, key, value, ...]``.
+    """
+    tag = node.get("localName") or node.get("nodeName", "#unknown")
+    node_id = node.get("nodeId", 0)
+
+    # Parse flat attribute list
+    raw_attrs = node.get("attributes", [])
+    attrs: dict[str, str] = {}
+    for i in range(0, len(raw_attrs) - 1, 2):
+        attrs[raw_attrs[i]] = raw_attrs[i + 1]
+
+    # Text content for text nodes (#text)
+    text = node.get("nodeValue", "") or ""
+    if node.get("nodeType") == 3:  # TEXT_NODE
+        tag = "#text"
+
+    children: list[DOMNode] = []
+    for child in node.get("children", []):
+        children.append(_parse_cdp_node(child))
+
+    return DOMNode(
+        tag=tag,
+        node_id=node_id,
+        attributes=attrs,
+        text=text.strip(),
+        children=children,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CDP extractor
+# ---------------------------------------------------------------------------
+
+
+class CDPExtractor:
+    """Extract the DOM tree from a Chromium browser via CDP.
+
+    Parameters
+    ----------
+    cdp_url : str
+        Base URL for the CDP HTTP endpoint (e.g. ``http://localhost:9222``).
+    publish_fn : callable | None
+        Optional async callback ``(topic, payload) -> None``.
+    """
+
+    def __init__(
+        self,
+        cdp_url: str = DEFAULT_CDP_URL,
+        publish_fn: Any | None = None,
+    ) -> None:
+        self._cdp_url = cdp_url.rstrip("/")
+        self._publish = publish_fn
+        self._ws_url: str | None = None
+        self._msg_id = 0
+
+    def _next_id(self) -> int:
+        self._msg_id += 1
+        return self._msg_id
+
+    # -- Connection ----------------------------------------------------------
+
+    async def _get_ws_url(self) -> str:
+        """Discover the WebSocket debugger URL from the CDP HTTP endpoint."""
+        import aiohttp
+
+        url = f"{self._cdp_url}/json/version"
+        async with aiohttp.ClientSession() as session, session.get(url) as resp:
+            if resp.status != 200:
+                msg = f"CDP endpoint returned {resp.status}"
+                raise RuntimeError(msg)
+            data = await resp.json()
+            return data["webSocketDebuggerUrl"]
+
+    async def _get_page_ws_url(self, page_index: int = 0) -> str:
+        """Get the WebSocket URL of a specific page/tab."""
+        import aiohttp
+
+        url = f"{self._cdp_url}/json"
+        async with aiohttp.ClientSession() as session, session.get(url) as resp:
+            if resp.status != 200:
+                msg = f"CDP endpoint returned {resp.status}"
+                raise RuntimeError(msg)
+            pages = await resp.json()
+            pages = [p for p in pages if p.get("type") == "page"]
+            if page_index >= len(pages):
+                msg = f"Page index {page_index} out of range (have {len(pages)} pages)"
+                raise IndexError(msg)
+            return pages[page_index]["webSocketDebuggerUrl"]
+
+    async def _send_command(
+        self,
+        ws: Any,
+        method: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Send a CDP command and wait for the result."""
+        msg_id = self._next_id()
+        payload = {"id": msg_id, "method": method}
+        if params:
+            payload["params"] = params
+        await ws.send_json(payload)
+
+        async for msg in ws:
+            if msg.type == msg.type:  # always true — iterate over messages
+                data = json.loads(msg.data)
+                if data.get("id") == msg_id:
+                    if "error" in data:
+                        msg_text = data["error"].get("message", "Unknown CDP error")
+                        raise RuntimeError(msg_text)
+                    return data.get("result", {})
+        msg = "WebSocket closed before receiving response"
+        raise RuntimeError(msg)
+
+    # -- DOM extraction ------------------------------------------------------
+
+    async def extract_dom(self, page_index: int = 0) -> DOMNode:
+        """Extract the DOM tree from a browser tab.
+
+        Parameters
+        ----------
+        page_index : int
+            Zero-based index of the tab to extract from.
+
+        Returns
+        -------
+        DOMNode
+            The root of the parsed DOM tree.
+        """
+        import aiohttp
+
+        ws_url = await self._get_page_ws_url(page_index)
+
+        async with aiohttp.ClientSession() as session, session.ws_connect(ws_url) as ws:
+            result = await self._send_command(ws, "DOM.getDocument", {"depth": -1})
+            root_node = result.get("root", {})
+            return _parse_cdp_node(root_node)
+
+    async def extract_and_publish(
+        self,
+        source_id: str,
+        page_index: int = 0,
+    ) -> ParsedScreen:
+        """Extract the DOM and optionally publish via the event bus.
+
+        Returns the ``ParsedScreen`` protobuf regardless of whether
+        a publisher is configured.
+        """
+        start = time.perf_counter()
+        root = await self.extract_dom(page_index)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        tree_json = dom_to_json(root)
+        count = root.node_count()
+
+        proto = ParsedScreen(
+            header=Header(
+                timestamp_unix=time.time(),
+                source_module="sensory.vision.cdp_dom",
+                schema_version=1,
+            ),
+            source_id=source_id,
+            method=ParseMethod.CDP_DOM,
+            tree_json=tree_json,
+            node_count=count,
+            extraction_ms=elapsed_ms,
+        )
+
+        if self._publish is not None:
+            topic = topic_for(SENSORY_VISION_PARSED, source_id=source_id)
+            await self._publish(topic, proto.SerializeToString())
+
+        return proto

--- a/tests/test_cdp_dom.py
+++ b/tests/test_cdp_dom.py
@@ -1,0 +1,390 @@
+"""Tests for CDP DOM extractor — Issue #46."""
+
+from __future__ import annotations
+
+import json
+
+from openbad.nervous_system.schemas import ParsedScreen
+from openbad.nervous_system.schemas.sensory_pb2 import ParseMethod
+from openbad.sensory.vision.cdp_dom import (
+    CDPExtractor,
+    DOMNode,
+    _parse_cdp_node,
+    dom_to_json,
+)
+
+# ---------------------------------------------------------------------------
+# DOMNode tests
+# ---------------------------------------------------------------------------
+
+
+class TestDOMNode:
+    def test_simple_node(self) -> None:
+        node = DOMNode(tag="div")
+        assert node.tag == "div"
+        assert node.children == []
+        assert node.node_count() == 1
+
+    def test_node_with_children(self) -> None:
+        child1 = DOMNode(tag="span")
+        child2 = DOMNode(tag="p")
+        parent = DOMNode(tag="div", children=[child1, child2])
+        assert parent.node_count() == 3
+
+    def test_to_dict_minimal(self) -> None:
+        node = DOMNode(tag="br")
+        d = node.to_dict()
+        assert d == {"tag": "br"}
+
+    def test_to_dict_with_node_id(self) -> None:
+        node = DOMNode(tag="div", node_id=42)
+        d = node.to_dict()
+        assert d["nodeId"] == 42
+
+    def test_to_dict_with_attributes(self) -> None:
+        node = DOMNode(tag="a", attributes={"href": "/page", "class": "link"})
+        d = node.to_dict()
+        assert d["attributes"]["href"] == "/page"
+        assert d["attributes"]["class"] == "link"
+
+    def test_to_dict_with_text(self) -> None:
+        node = DOMNode(tag="#text", text="Hello World")
+        d = node.to_dict()
+        assert d["text"] == "Hello World"
+
+    def test_to_dict_with_children(self) -> None:
+        child = DOMNode(tag="li")
+        parent = DOMNode(tag="ul", children=[child])
+        d = parent.to_dict()
+        assert len(d["children"]) == 1
+        assert d["children"][0]["tag"] == "li"
+
+    def test_to_dict_omits_empty_fields(self) -> None:
+        node = DOMNode(tag="div")
+        d = node.to_dict()
+        assert "nodeId" not in d
+        assert "attributes" not in d
+        assert "text" not in d
+        assert "children" not in d
+
+    def test_deep_tree_count(self) -> None:
+        leaf = DOMNode(tag="span")
+        mid = DOMNode(tag="div", children=[leaf])
+        root = DOMNode(tag="body", children=[mid])
+        assert root.node_count() == 3
+
+
+class TestDomToJson:
+    def test_single_node(self) -> None:
+        node = DOMNode(tag="div")
+        result = dom_to_json(node)
+        parsed = json.loads(result)
+        assert parsed == {"tag": "div"}
+
+    def test_nested_tree(self) -> None:
+        child = DOMNode(tag="span", text="Hello")
+        root = DOMNode(tag="body", children=[child])
+        result = dom_to_json(root)
+        parsed = json.loads(result)
+        assert parsed["children"][0]["text"] == "Hello"
+
+    def test_compact_format(self) -> None:
+        node = DOMNode(tag="br")
+        result = dom_to_json(node)
+        assert " " not in result
+
+
+# ---------------------------------------------------------------------------
+# CDP node parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseCdpNode:
+    def test_simple_element(self) -> None:
+        cdp_node = {
+            "nodeId": 1,
+            "nodeType": 1,
+            "localName": "div",
+            "nodeName": "DIV",
+            "attributes": ["class", "container", "id", "main"],
+            "children": [],
+        }
+        result = _parse_cdp_node(cdp_node)
+        assert result.tag == "div"
+        assert result.node_id == 1
+        assert result.attributes == {"class": "container", "id": "main"}
+        assert result.children == []
+
+    def test_text_node(self) -> None:
+        cdp_node = {
+            "nodeId": 5,
+            "nodeType": 3,
+            "nodeName": "#text",
+            "nodeValue": " Hello World ",
+        }
+        result = _parse_cdp_node(cdp_node)
+        assert result.tag == "#text"
+        assert result.text == "Hello World"
+
+    def test_nested_children(self) -> None:
+        cdp_node = {
+            "nodeId": 1,
+            "nodeType": 1,
+            "localName": "ul",
+            "attributes": [],
+            "children": [
+                {
+                    "nodeId": 2,
+                    "nodeType": 1,
+                    "localName": "li",
+                    "attributes": [],
+                    "children": [],
+                },
+                {
+                    "nodeId": 3,
+                    "nodeType": 1,
+                    "localName": "li",
+                    "attributes": [],
+                    "children": [],
+                },
+            ],
+        }
+        result = _parse_cdp_node(cdp_node)
+        assert result.tag == "ul"
+        assert len(result.children) == 2
+        assert result.children[0].tag == "li"
+        assert result.children[1].tag == "li"
+
+    def test_empty_attributes(self) -> None:
+        cdp_node = {
+            "nodeId": 1,
+            "nodeType": 1,
+            "localName": "div",
+        }
+        result = _parse_cdp_node(cdp_node)
+        assert result.attributes == {}
+
+    def test_missing_children(self) -> None:
+        cdp_node = {
+            "nodeId": 1,
+            "nodeType": 1,
+            "localName": "img",
+            "attributes": ["src", "/logo.png"],
+        }
+        result = _parse_cdp_node(cdp_node)
+        assert result.children == []
+        assert result.attributes == {"src": "/logo.png"}
+
+    def test_odd_attribute_count_ignored(self) -> None:
+        """Odd-length attribute arrays: last key without value is skipped."""
+        cdp_node = {
+            "nodeId": 1,
+            "nodeType": 1,
+            "localName": "div",
+            "attributes": ["class", "x", "orphan"],
+        }
+        result = _parse_cdp_node(cdp_node)
+        assert result.attributes == {"class": "x"}
+
+    def test_document_node(self) -> None:
+        cdp_node = {
+            "nodeId": 1,
+            "nodeType": 9,
+            "nodeName": "#document",
+            "children": [
+                {
+                    "nodeId": 2,
+                    "nodeType": 1,
+                    "localName": "html",
+                    "attributes": [],
+                    "children": [],
+                }
+            ],
+        }
+        result = _parse_cdp_node(cdp_node)
+        assert result.tag == "#document"
+        assert len(result.children) == 1
+
+
+# ---------------------------------------------------------------------------
+# CDPExtractor unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCDPExtractorConfig:
+    def test_default_url(self) -> None:
+        ext = CDPExtractor()
+        assert ext._cdp_url == "http://localhost:9222"
+
+    def test_custom_url(self) -> None:
+        ext = CDPExtractor(cdp_url="http://127.0.0.1:9333/")
+        assert ext._cdp_url == "http://127.0.0.1:9333"
+
+    def test_message_id_increments(self) -> None:
+        ext = CDPExtractor()
+        assert ext._next_id() == 1
+        assert ext._next_id() == 2
+        assert ext._next_id() == 3
+
+
+class TestCDPExtractorPublish:
+    async def test_extract_and_publish_builds_proto(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        ext = CDPExtractor(publish_fn=mock_publish)
+
+        # Monkey-patch extract_dom to return a known tree
+        tree = DOMNode(
+            tag="html",
+            children=[
+                DOMNode(tag="head"),
+                DOMNode(tag="body", children=[
+                    DOMNode(tag="h1", text="Hello"),
+                    DOMNode(tag="p", text="World"),
+                ]),
+            ],
+        )
+
+        async def fake_extract(page_index: int = 0) -> DOMNode:
+            return tree
+
+        ext.extract_dom = fake_extract  # type: ignore[assignment]
+
+        result = await ext.extract_and_publish("chrome-1")
+
+        assert isinstance(result, ParsedScreen)
+        assert result.source_id == "chrome-1"
+        assert result.method == ParseMethod.CDP_DOM
+        assert result.node_count == 5
+        assert result.extraction_ms >= 0
+
+        # Verify tree in JSON
+        parsed = json.loads(result.tree_json)
+        assert parsed["tag"] == "html"
+        assert len(parsed["children"]) == 2
+
+        # Verify publish
+        assert len(published) == 1
+        topic, payload = published[0]
+        assert topic == "agent/sensory/vision/chrome-1/parsed"
+
+        restored = ParsedScreen()
+        restored.ParseFromString(payload)
+        assert restored.node_count == 5
+
+    async def test_no_publish_fn(self) -> None:
+        ext = CDPExtractor()
+
+        tree = DOMNode(tag="html")
+
+        async def fake_extract(page_index: int = 0) -> DOMNode:
+            return tree
+
+        ext.extract_dom = fake_extract  # type: ignore[assignment]
+
+        result = await ext.extract_and_publish("tab-1")
+        assert isinstance(result, ParsedScreen)
+        assert result.node_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Realistic CDP DOM tree test
+# ---------------------------------------------------------------------------
+
+
+class TestRealisticDOM:
+    def test_realistic_page_structure(self) -> None:
+        """Simulate a typical CDP response for a simple web page."""
+        cdp_response = {
+            "nodeId": 1,
+            "nodeType": 9,
+            "nodeName": "#document",
+            "children": [{
+                "nodeId": 2,
+                "nodeType": 1,
+                "localName": "html",
+                "attributes": ["lang", "en"],
+                "children": [
+                    {
+                        "nodeId": 3,
+                        "nodeType": 1,
+                        "localName": "head",
+                        "attributes": [],
+                        "children": [{
+                            "nodeId": 4,
+                            "nodeType": 1,
+                            "localName": "title",
+                            "attributes": [],
+                            "children": [{
+                                "nodeId": 5,
+                                "nodeType": 3,
+                                "nodeName": "#text",
+                                "nodeValue": "Test Page",
+                            }],
+                        }],
+                    },
+                    {
+                        "nodeId": 6,
+                        "nodeType": 1,
+                        "localName": "body",
+                        "attributes": ["class", "main"],
+                        "children": [
+                            {
+                                "nodeId": 7,
+                                "nodeType": 1,
+                                "localName": "h1",
+                                "attributes": ["id", "title"],
+                                "children": [{
+                                    "nodeId": 8,
+                                    "nodeType": 3,
+                                    "nodeName": "#text",
+                                    "nodeValue": "Welcome",
+                                }],
+                            },
+                            {
+                                "nodeId": 9,
+                                "nodeType": 1,
+                                "localName": "button",
+                                "attributes": ["type", "submit", "class", "btn"],
+                                "children": [{
+                                    "nodeId": 10,
+                                    "nodeType": 3,
+                                    "nodeName": "#text",
+                                    "nodeValue": "Click Me",
+                                }],
+                            },
+                        ],
+                    },
+                ],
+            }],
+        }
+
+        root = _parse_cdp_node(cdp_response)
+        assert root.tag == "#document"
+        assert root.node_count() == 10
+
+        # Navigate to body > h1 > #text
+        html = root.children[0]
+        assert html.tag == "html"
+        assert html.attributes["lang"] == "en"
+
+        body = html.children[1]
+        assert body.tag == "body"
+        assert body.attributes["class"] == "main"
+
+        h1 = body.children[0]
+        assert h1.tag == "h1"
+        assert h1.children[0].text == "Welcome"
+
+        button = body.children[1]
+        assert button.tag == "button"
+        assert button.attributes["type"] == "submit"
+        assert button.children[0].text == "Click Me"
+
+        # Full JSON roundtrip
+        js = dom_to_json(root)
+        parsed = json.loads(js)
+        assert parsed["children"][0]["tag"] == "html"


### PR DESCRIPTION
Closes #46

## Summary
- `DOMNode` dataclass with JSON serialisation and node counting
- `_parse_cdp_node()`: parses CDP `DOM.Node` dicts including flat attribute arrays
- `CDPExtractor`: connects to Chromium remote debugging port, extracts DOM via WebSocket
- `extract_and_publish()`: builds `ParsedScreen` proto with CDP_DOM method, publishes to event bus
- 25 tests covering node model, CDP parsing, realistic page structures, and publishing

## How to test
```sh
python -m pytest tests/test_cdp_dom.py -v
```