### PR TITLE
#47: OCR fallback pipeline

### DIFF
--- a/src/openbad/sensory/vision/ocr_fallback.py
+++ b/src/openbad/sensory/vision/ocr_fallback.py
@@ -1,0 +1,244 @@
+"""OCR fallback pipeline for applications without accessibility support.
+
+When AT-SPI2 and CDP are unavailable, this module applies Optical
+Character Recognition to captured screen frames to extract UI elements
+(text regions, buttons, labels) with bounding box coordinates.
+
+Supported backends:
+  - **Tesseract OCR** (Apache 2.0) — via ``pytesseract``
+  - **EasyOCR** (Apache 2.0) — deep-learning-based, higher accuracy on
+    complex layouts
+
+The extracted text regions are serialised as a JSON tree and published
+as a ``ParsedScreen`` protobuf message on
+``agent/sensory/vision/{source_id}/parsed``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from openbad.nervous_system.schemas import Header, ParsedScreen
+from openbad.nervous_system.schemas.sensory_pb2 import ParseMethod
+from openbad.nervous_system.topics import SENSORY_VISION_PARSED, topic_for
+
+logger = logging.getLogger(__name__)
+
+
+class OCRBackend(Enum):
+    """Available OCR engine backends."""
+
+    TESSERACT = "tesseract"
+    EASYOCR = "easyocr"
+
+
+@dataclass
+class TextRegion:
+    """A single text region detected by OCR."""
+
+    text: str
+    confidence: float  # 0.0–1.0
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"text": self.text, "confidence": round(self.confidence, 3)}
+        if self.width > 0 or self.height > 0:
+            d["bounds"] = {
+                "x": self.x, "y": self.y,
+                "w": self.width, "h": self.height,
+            }
+        return d
+
+
+@dataclass
+class OCRResult:
+    """Complete OCR result for a single frame."""
+
+    regions: list[TextRegion] = field(default_factory=list)
+    backend: OCRBackend = OCRBackend.TESSERACT
+    extraction_ms: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "backend": self.backend.value,
+            "extraction_ms": round(self.extraction_ms, 1),
+            "regions": [r.to_dict() for r in self.regions],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), separators=(",", ":"))
+
+    @property
+    def node_count(self) -> int:
+        return len(self.regions)
+
+
+# ---------------------------------------------------------------------------
+# Backend adapters
+# ---------------------------------------------------------------------------
+
+
+def _run_tesseract(image_bytes: bytes) -> list[TextRegion]:
+    """Run Tesseract OCR on raw image bytes. Requires pytesseract + Pillow."""
+    try:
+        import io
+
+        import pytesseract  # type: ignore[import-untyped]
+        from PIL import Image  # type: ignore[import-untyped]
+    except ImportError:
+        msg = (
+            "pytesseract and Pillow are required for Tesseract OCR. "
+            "Install with: pip install pytesseract Pillow"
+        )
+        raise RuntimeError(msg) from None
+
+    img = Image.open(io.BytesIO(image_bytes))
+    data = pytesseract.image_to_data(img, output_type=pytesseract.Output.DICT)
+
+    regions: list[TextRegion] = []
+    n = len(data["text"])
+    for i in range(n):
+        text = data["text"][i].strip()
+        if not text:
+            continue
+        conf = float(data["conf"][i])
+        if conf < 0:
+            continue
+        regions.append(TextRegion(
+            text=text,
+            confidence=conf / 100.0,
+            x=int(data["left"][i]),
+            y=int(data["top"][i]),
+            width=int(data["width"][i]),
+            height=int(data["height"][i]),
+        ))
+    return regions
+
+
+def _run_easyocr(image_bytes: bytes, languages: list[str] | None = None) -> list[TextRegion]:
+    """Run EasyOCR on raw image bytes."""
+    try:
+        import easyocr  # type: ignore[import-untyped]
+    except ImportError:
+        msg = (
+            "easyocr is required for EasyOCR backend. "
+            "Install with: pip install easyocr"
+        )
+        raise RuntimeError(msg) from None
+
+    langs = languages or ["en"]
+    reader = easyocr.Reader(langs, gpu=False)
+    results = reader.readtext(image_bytes)
+
+    regions: list[TextRegion] = []
+    for bbox, text, conf in results:
+        # bbox is [[x1,y1],[x2,y1],[x2,y2],[x1,y2]]
+        xs = [p[0] for p in bbox]
+        ys = [p[1] for p in bbox]
+        x = int(min(xs))
+        y = int(min(ys))
+        w = int(max(xs) - x)
+        h = int(max(ys) - y)
+        regions.append(TextRegion(
+            text=text, confidence=float(conf),
+            x=x, y=y, width=w, height=h,
+        ))
+    return regions
+
+
+# ---------------------------------------------------------------------------
+# OCR pipeline
+# ---------------------------------------------------------------------------
+
+
+class OCRPipeline:
+    """OCR fallback pipeline for screen frame text extraction.
+
+    Parameters
+    ----------
+    backend : OCRBackend
+        Which OCR engine to use.
+    min_confidence : float
+        Discard regions below this confidence threshold (0.0–1.0).
+    languages : list[str] | None
+        Language codes for EasyOCR (default: ``["en"]``).
+    publish_fn : callable | None
+        Optional async callback ``(topic, payload) -> None``.
+    """
+
+    def __init__(
+        self,
+        backend: OCRBackend = OCRBackend.TESSERACT,
+        min_confidence: float = 0.3,
+        languages: list[str] | None = None,
+        publish_fn: Any | None = None,
+    ) -> None:
+        self._backend = backend
+        self._min_confidence = min_confidence
+        self._languages = languages
+        self._publish = publish_fn
+
+    @property
+    def backend(self) -> OCRBackend:
+        return self._backend
+
+    def process_image(self, image_bytes: bytes) -> OCRResult:
+        """Run OCR on raw image bytes (JPEG/PNG).
+
+        Returns an ``OCRResult`` with detected text regions.
+        """
+        start = time.perf_counter()
+
+        if self._backend == OCRBackend.TESSERACT:
+            raw_regions = _run_tesseract(image_bytes)
+        elif self._backend == OCRBackend.EASYOCR:
+            raw_regions = _run_easyocr(image_bytes, self._languages)
+        else:
+            msg = f"Unknown OCR backend: {self._backend}"
+            raise ValueError(msg)
+
+        # Filter by confidence
+        regions = [r for r in raw_regions if r.confidence >= self._min_confidence]
+
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        return OCRResult(
+            regions=regions,
+            backend=self._backend,
+            extraction_ms=elapsed_ms,
+        )
+
+    async def process_and_publish(
+        self,
+        source_id: str,
+        image_bytes: bytes,
+    ) -> ParsedScreen:
+        """Process an image and optionally publish via the event bus."""
+        result = self.process_image(image_bytes)
+
+        proto = ParsedScreen(
+            header=Header(
+                timestamp_unix=time.time(),
+                source_module="sensory.vision.ocr_fallback",
+                schema_version=1,
+            ),
+            source_id=source_id,
+            method=ParseMethod.OCR,
+            tree_json=result.to_json(),
+            node_count=result.node_count,
+            extraction_ms=result.extraction_ms,
+        )
+
+        if self._publish is not None:
+            topic = topic_for(SENSORY_VISION_PARSED, source_id=source_id)
+            await self._publish(topic, proto.SerializeToString())
+
+        return proto

--- a/tests/test_ocr_fallback.py
+++ b/tests/test_ocr_fallback.py
@@ -1,0 +1,253 @@
+"""Tests for OCR fallback pipeline — Issue #47."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from openbad.nervous_system.schemas import ParsedScreen
+from openbad.nervous_system.schemas.sensory_pb2 import ParseMethod
+from openbad.sensory.vision.ocr_fallback import (
+    OCRBackend,
+    OCRPipeline,
+    OCRResult,
+    TextRegion,
+)
+
+# ---------------------------------------------------------------------------
+# TextRegion tests
+# ---------------------------------------------------------------------------
+
+
+class TestTextRegion:
+    def test_basic(self) -> None:
+        r = TextRegion(text="Hello", confidence=0.95)
+        assert r.text == "Hello"
+        assert r.confidence == 0.95
+
+    def test_to_dict_without_bounds(self) -> None:
+        r = TextRegion(text="OK", confidence=0.8)
+        d = r.to_dict()
+        assert d == {"text": "OK", "confidence": 0.8}
+        assert "bounds" not in d
+
+    def test_to_dict_with_bounds(self) -> None:
+        r = TextRegion(text="Button", confidence=0.9, x=10, y=20, width=100, height=30)
+        d = r.to_dict()
+        assert d["bounds"] == {"x": 10, "y": 20, "w": 100, "h": 30}
+
+    def test_confidence_rounding(self) -> None:
+        r = TextRegion(text="X", confidence=0.12345)
+        d = r.to_dict()
+        assert d["confidence"] == 0.123
+
+
+# ---------------------------------------------------------------------------
+# OCRResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestOCRResult:
+    def test_empty_result(self) -> None:
+        result = OCRResult()
+        assert result.regions == []
+        assert result.node_count == 0
+
+    def test_to_dict(self) -> None:
+        result = OCRResult(
+            regions=[TextRegion(text="Hello", confidence=0.9)],
+            backend=OCRBackend.TESSERACT,
+            extraction_ms=42.5,
+        )
+        d = result.to_dict()
+        assert d["backend"] == "tesseract"
+        assert d["extraction_ms"] == 42.5
+        assert len(d["regions"]) == 1
+
+    def test_to_json(self) -> None:
+        result = OCRResult(
+            regions=[TextRegion(text="A", confidence=1.0)],
+            backend=OCRBackend.EASYOCR,
+        )
+        js = result.to_json()
+        parsed = json.loads(js)
+        assert parsed["backend"] == "easyocr"
+        assert len(parsed["regions"]) == 1
+
+    def test_node_count(self) -> None:
+        regions = [
+            TextRegion(text="A", confidence=0.9),
+            TextRegion(text="B", confidence=0.8),
+            TextRegion(text="C", confidence=0.7),
+        ]
+        result = OCRResult(regions=regions)
+        assert result.node_count == 3
+
+
+# ---------------------------------------------------------------------------
+# OCRBackend enum tests
+# ---------------------------------------------------------------------------
+
+
+class TestOCRBackend:
+    def test_values(self) -> None:
+        assert OCRBackend.TESSERACT.value == "tesseract"
+        assert OCRBackend.EASYOCR.value == "easyocr"
+
+
+# ---------------------------------------------------------------------------
+# OCRPipeline tests (with mocked backends)
+# ---------------------------------------------------------------------------
+
+
+class TestOCRPipelineConfig:
+    def test_default_backend(self) -> None:
+        pipeline = OCRPipeline()
+        assert pipeline.backend == OCRBackend.TESSERACT
+
+    def test_custom_backend(self) -> None:
+        pipeline = OCRPipeline(backend=OCRBackend.EASYOCR)
+        assert pipeline.backend == OCRBackend.EASYOCR
+
+
+class TestOCRPipelineProcess:
+    def test_process_with_mocked_tesseract(self) -> None:
+        mock_regions = [
+            TextRegion(text="Hello", confidence=0.95, x=10, y=20, width=80, height=20),
+            TextRegion(text="World", confidence=0.88, x=10, y=50, width=80, height=20),
+            TextRegion(text="noise", confidence=0.1, x=0, y=0, width=5, height=5),
+        ]
+
+        with patch(
+            "openbad.sensory.vision.ocr_fallback._run_tesseract",
+            return_value=mock_regions,
+        ):
+            pipeline = OCRPipeline(backend=OCRBackend.TESSERACT, min_confidence=0.3)
+            result = pipeline.process_image(b"fake-jpeg-data")
+
+        # Low-confidence region filtered out
+        assert len(result.regions) == 2
+        assert result.regions[0].text == "Hello"
+        assert result.regions[1].text == "World"
+        assert result.backend == OCRBackend.TESSERACT
+        assert result.extraction_ms >= 0
+
+    def test_process_with_mocked_easyocr(self) -> None:
+        mock_regions = [
+            TextRegion(text="Click", confidence=0.92, x=100, y=200, width=60, height=25),
+        ]
+
+        with patch(
+            "openbad.sensory.vision.ocr_fallback._run_easyocr",
+            return_value=mock_regions,
+        ):
+            pipeline = OCRPipeline(backend=OCRBackend.EASYOCR)
+            result = pipeline.process_image(b"fake-png-data")
+
+        assert len(result.regions) == 1
+        assert result.regions[0].text == "Click"
+
+    def test_confidence_filtering(self) -> None:
+        mock_regions = [
+            TextRegion(text="High", confidence=0.9),
+            TextRegion(text="Med", confidence=0.5),
+            TextRegion(text="Low", confidence=0.2),
+        ]
+
+        with patch(
+            "openbad.sensory.vision.ocr_fallback._run_tesseract",
+            return_value=mock_regions,
+        ):
+            pipeline = OCRPipeline(min_confidence=0.6)
+            result = pipeline.process_image(b"data")
+
+        assert len(result.regions) == 1
+        assert result.regions[0].text == "High"
+
+    def test_all_filtered_out(self) -> None:
+        mock_regions = [
+            TextRegion(text="Junk", confidence=0.1),
+        ]
+
+        with patch(
+            "openbad.sensory.vision.ocr_fallback._run_tesseract",
+            return_value=mock_regions,
+        ):
+            pipeline = OCRPipeline(min_confidence=0.5)
+            result = pipeline.process_image(b"data")
+
+        assert len(result.regions) == 0
+        assert result.node_count == 0
+
+
+class TestOCRPipelinePublish:
+    async def test_process_and_publish(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        mock_regions = [
+            TextRegion(text="Submit", confidence=0.97, x=200, y=300, width=80, height=30),
+            TextRegion(text="Cancel", confidence=0.91, x=300, y=300, width=80, height=30),
+        ]
+
+        with patch(
+            "openbad.sensory.vision.ocr_fallback._run_tesseract",
+            return_value=mock_regions,
+        ):
+            pipeline = OCRPipeline(publish_fn=mock_publish)
+            result = await pipeline.process_and_publish("app-1", b"image-data")
+
+        assert isinstance(result, ParsedScreen)
+        assert result.source_id == "app-1"
+        assert result.method == ParseMethod.OCR
+        assert result.node_count == 2
+
+        # Verify JSON
+        parsed = json.loads(result.tree_json)
+        assert parsed["backend"] == "tesseract"
+        assert len(parsed["regions"]) == 2
+
+        # Verify published
+        assert len(published) == 1
+        topic, payload = published[0]
+        assert topic == "agent/sensory/vision/app-1/parsed"
+
+        restored = ParsedScreen()
+        restored.ParseFromString(payload)
+        assert restored.node_count == 2
+
+    async def test_no_publish_fn(self) -> None:
+        mock_regions = [TextRegion(text="X", confidence=0.9)]
+
+        with patch(
+            "openbad.sensory.vision.ocr_fallback._run_tesseract",
+            return_value=mock_regions,
+        ):
+            pipeline = OCRPipeline()
+            result = await pipeline.process_and_publish("test", b"data")
+
+        assert isinstance(result, ParsedScreen)
+        assert result.node_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tesseract backend import error
+# ---------------------------------------------------------------------------
+
+
+class TestBackendImportError:
+    def test_tesseract_import_error(self) -> None:
+        with patch.dict("sys.modules", {"pytesseract": None, "PIL": None}):
+            pipeline = OCRPipeline(backend=OCRBackend.TESSERACT)
+            with pytest.raises(RuntimeError, match="pytesseract"):
+                pipeline.process_image(b"data")
+
+    def test_easyocr_import_error(self) -> None:
+        with patch.dict("sys.modules", {"easyocr": None}):
+            pipeline = OCRPipeline(backend=OCRBackend.EASYOCR)
+            with pytest.raises(RuntimeError, match="easyocr"):
+                pipeline.process_image(b"data")


### PR DESCRIPTION
Closes #47

## Summary
- `TextRegion` dataclass with bounding box coords and confidence
- `OCRResult` container with JSON serialisation and confidence filtering
- `OCRPipeline`: pluggable Tesseract/EasyOCR backends, publishes `ParsedScreen` proto with OCR method
- Backend adapters: `_run_tesseract()` (pytesseract), `_run_easyocr()` (easyocr)
- 19 unit tests with mocked backends covering filtering, publishing, and import error handling

## How to test
```sh
python -m pytest tests/test_ocr_fallback.py -v
```