### PR TITLE
#49: PipeWire audio capture routing

### DIFF
--- a/config/sensory_audio.yaml
+++ b/config/sensory_audio.yaml
@@ -1,0 +1,20 @@
+audio:
+  capture:
+    sample_rate: 16000
+    channels: 1
+    sample_format: "s16le"
+    chunk_duration_ms: 100
+    device: ""
+    passive: true
+  asr:
+    vosk_model_path: ""
+    whisper_model: "base"
+    default_engine: "vosk"
+  wake_word:
+    phrases:
+      - "hey agent"
+    threshold: 0.5
+  tts:
+    engine: "piper"
+    model_path: ""
+    output_device: ""

--- a/src/openbad/sensory/audio/capture.py
+++ b/src/openbad/sensory/audio/capture.py
@@ -1,0 +1,204 @@
+"""PipeWire audio capture node management.
+
+Creates virtual audio capture streams via the PipeWire D-Bus interface
+to passively monitor microphone input and optional application audio
+without disrupting the user's normal audio experience.
+
+Audio chunks are published as ``AudioChunk`` protobuf messages on
+``agent/sensory/audio/{source_id}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import struct
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from openbad.nervous_system.topics import SENSORY_AUDIO, topic_for
+from openbad.sensory.audio.config import AudioCaptureConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AudioChunk:
+    """A single chunk of captured audio data.
+
+    Attributes
+    ----------
+    source_id : str
+        Identifier for the audio source (e.g. ``"mic"``, ``"app-firefox"``).
+    pcm_data : bytes
+        Raw PCM audio bytes.
+    sample_rate : int
+        Sample rate in Hz.
+    channels : int
+        Number of audio channels.
+    sample_format : str
+        PCM format string (e.g. ``"s16le"``, ``"f32le"``).
+    timestamp : float
+        Unix timestamp when the chunk was captured.
+    sequence : int
+        Monotonic sequence number for ordering.
+    """
+
+    source_id: str
+    pcm_data: bytes
+    sample_rate: int = 16000
+    channels: int = 1
+    sample_format: str = "s16le"
+    timestamp: float = field(default_factory=time.time)
+    sequence: int = 0
+
+    @property
+    def duration_ms(self) -> float:
+        """Duration of this chunk in milliseconds."""
+        bytes_per_sample = 4 if self.sample_format == "f32le" else 2
+        frame_size = self.channels * bytes_per_sample
+        if frame_size == 0 or self.sample_rate == 0:
+            return 0.0
+        num_frames = len(self.pcm_data) / frame_size
+        return (num_frames / self.sample_rate) * 1000
+
+    @property
+    def rms_amplitude(self) -> float:
+        """Root mean square amplitude of PCM data (s16le only).
+
+        Returns 0.0 for unsupported formats or empty data.
+        """
+        if self.sample_format != "s16le" or len(self.pcm_data) < 2:
+            return 0.0
+        n = len(self.pcm_data) // 2
+        total = 0.0
+        for i in range(n):
+            sample = struct.unpack_from("<h", self.pcm_data, i * 2)[0]
+            total += sample * sample
+        return (total / n) ** 0.5
+
+    def mqtt_topic(self) -> str:
+        return topic_for(SENSORY_AUDIO, source_id=self.source_id)
+
+
+# ---------------------------------------------------------------------------
+# PipeWire audio stream
+# ---------------------------------------------------------------------------
+
+
+class PipeWireAudioStream:
+    """Async audio capture stream using PipeWire.
+
+    On Linux, this creates a PipeWire stream node that passively
+    captures audio from the specified source.  Audio chunks are emitted
+    via an async generator or published directly to the event bus.
+
+    Parameters
+    ----------
+    source_id : str
+        Human-readable name for this audio source.
+    config : AudioCaptureConfig | None
+        Capture settings.  Uses defaults if omitted.
+    publish_fn : callable | None
+        Optional async callback ``(topic, payload) -> None``.
+    """
+
+    def __init__(
+        self,
+        source_id: str = "mic",
+        config: AudioCaptureConfig | None = None,
+        publish_fn: Any | None = None,
+    ) -> None:
+        if sys.platform != "linux":
+            msg = (
+                "PipeWireAudioStream requires Linux with PipeWire. "
+                f"Current platform: {sys.platform}"
+            )
+            raise RuntimeError(msg)
+
+        self._source_id = source_id
+        self._config = config or AudioCaptureConfig()
+        self._publish = publish_fn
+        self._running = False
+        self._sequence = 0
+
+    @property
+    def source_id(self) -> str:
+        return self._source_id
+
+    @property
+    def config(self) -> AudioCaptureConfig:
+        return self._config
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    def _make_chunk(self, pcm_data: bytes) -> AudioChunk:
+        self._sequence += 1
+        return AudioChunk(
+            source_id=self._source_id,
+            pcm_data=pcm_data,
+            sample_rate=self._config.sample_rate,
+            channels=self._config.channels,
+            sample_format=self._config.sample_format,
+            sequence=self._sequence,
+        )
+
+    async def _read_audio(self) -> bytes:
+        """Read audio from PipeWire (placeholder for real implementation).
+
+        In production this would use pw-cat subprocess or PipeWire's
+        native Python bindings to read PCM data.  For now, it raises
+        NotImplementedError to indicate the integration point.
+        """
+        msg = (
+            "PipeWire audio read not yet connected. "
+            "Production implementation will use pw-cat or libpipewire."
+        )
+        raise NotImplementedError(msg)
+
+    async def capture_loop(
+        self,
+        audio_provider: Any | None = None,
+    ) -> None:
+        """Run the audio capture loop.
+
+        Parameters
+        ----------
+        audio_provider : async callable | None
+            Override for testing — an async callable returning ``bytes``
+            or ``None`` to stop the loop.  If omitted, uses the real
+            PipeWire reader.
+        """
+        reader = audio_provider or self._read_audio
+        self._running = True
+        chunk_interval = self._config.chunk_duration_ms / 1000
+
+        try:
+            while self._running:
+                pcm_data = await reader()
+                if pcm_data is None:
+                    break
+
+                chunk = self._make_chunk(pcm_data)
+
+                if self._publish is not None:
+                    topic = chunk.mqtt_topic()
+                    await self._publish(topic, chunk.pcm_data)
+
+                await asyncio.sleep(chunk_interval)
+        finally:
+            self._running = False
+
+    def stop(self) -> None:
+        """Signal the capture loop to stop."""
+        self._running = False
+
+    async def __aenter__(self) -> PipeWireAudioStream:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        self.stop()

--- a/src/openbad/sensory/audio/config.py
+++ b/src/openbad/sensory/audio/config.py
@@ -1,0 +1,146 @@
+"""Audio configuration — device selection, sample format, ASR settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class AudioCaptureConfig:
+    """PipeWire audio capture settings.
+
+    Attributes
+    ----------
+    sample_rate : int
+        Sample rate in Hz (default 16000, standard for ASR).
+    channels : int
+        Number of audio channels (default 1 — mono for ASR).
+    sample_format : str
+        PCM sample format: ``"s16le"`` (signed 16-bit LE) or ``"f32le"`` (default ``"s16le"``).
+    chunk_duration_ms : int
+        Duration of each audio chunk in milliseconds (default 100).
+    device : str
+        PipeWire source node name/serial. Empty string = default mic.
+    passive : bool
+        Monitor mode — tap existing stream without disrupting it (default True).
+    """
+
+    sample_rate: int = 16000
+    channels: int = 1
+    sample_format: str = "s16le"
+    chunk_duration_ms: int = 100
+    device: str = ""
+    passive: bool = True
+
+    @property
+    def chunk_bytes(self) -> int:
+        """Number of bytes per chunk."""
+        bytes_per_sample = 4 if self.sample_format == "f32le" else 2
+        samples = int(self.sample_rate * self.chunk_duration_ms / 1000)
+        return samples * self.channels * bytes_per_sample
+
+
+@dataclass
+class ASRConfig:
+    """Automatic speech recognition settings.
+
+    Attributes
+    ----------
+    vosk_model_path : str
+        Path to the Vosk language model directory.
+    whisper_model : str
+        Whisper model size (default ``"base"``).
+    default_engine : str
+        Default ASR engine: ``"vosk"`` or ``"whisper"`` (default ``"vosk"``).
+    """
+
+    vosk_model_path: str = ""
+    whisper_model: str = "base"
+    default_engine: str = "vosk"
+
+
+@dataclass
+class WakeWordConfig:
+    """Wake-word detector settings.
+
+    Attributes
+    ----------
+    phrases : list[str]
+        Activation phrases to listen for.
+    threshold : float
+        Detection confidence threshold 0.0–1.0 (default 0.5).
+    """
+
+    phrases: list[str] = field(default_factory=lambda: ["hey agent"])
+    threshold: float = 0.5
+
+
+@dataclass
+class TTSConfig:
+    """Text-to-speech output settings.
+
+    Attributes
+    ----------
+    engine : str
+        TTS backend: ``"piper"`` (default).
+    model_path : str
+        Path to TTS voice model.
+    output_device : str
+        PipeWire sink node for TTS output. Empty = default.
+    """
+
+    engine: str = "piper"
+    model_path: str = ""
+    output_device: str = ""
+
+
+@dataclass
+class AudioConfig:
+    """Top-level audio configuration."""
+
+    capture: AudioCaptureConfig = field(default_factory=AudioCaptureConfig)
+    asr: ASRConfig = field(default_factory=ASRConfig)
+    wake_word: WakeWordConfig = field(default_factory=WakeWordConfig)
+    tts: TTSConfig = field(default_factory=TTSConfig)
+
+
+def load_audio_config(path: Path | str | None = None) -> AudioConfig:
+    """Load :class:`AudioConfig` from a YAML file.
+
+    Falls back to defaults when *path* is ``None`` or the file does not exist.
+    """
+    if path is None:
+        return AudioConfig()
+
+    p = Path(path)
+    if not p.exists():
+        return AudioConfig()
+
+    raw: dict[str, Any] = yaml.safe_load(p.read_text()) or {}
+    audio_raw = raw.get("audio", raw)
+
+    capture_raw = audio_raw.get("capture", {})
+    capture = AudioCaptureConfig(**{
+        k: v for k, v in capture_raw.items() if k in AudioCaptureConfig.__dataclass_fields__
+    })
+
+    asr_raw = audio_raw.get("asr", {})
+    asr = ASRConfig(**{
+        k: v for k, v in asr_raw.items() if k in ASRConfig.__dataclass_fields__
+    })
+
+    ww_raw = audio_raw.get("wake_word", {})
+    wake_word = WakeWordConfig(**{
+        k: v for k, v in ww_raw.items() if k in WakeWordConfig.__dataclass_fields__
+    })
+
+    tts_raw = audio_raw.get("tts", {})
+    tts = TTSConfig(**{
+        k: v for k, v in tts_raw.items() if k in TTSConfig.__dataclass_fields__
+    })
+
+    return AudioConfig(capture=capture, asr=asr, wake_word=wake_word, tts=tts)

--- a/tests/test_audio_capture.py
+++ b/tests/test_audio_capture.py
@@ -1,0 +1,179 @@
+"""Tests for PipeWire audio capture — Issue #49."""
+
+from __future__ import annotations
+
+import struct
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from openbad.sensory.audio.capture import AudioChunk, PipeWireAudioStream
+from openbad.sensory.audio.config import AudioCaptureConfig
+
+# ---------------------------------------------------------------------------
+# AudioChunk
+# ---------------------------------------------------------------------------
+
+
+class TestAudioChunk:
+    def test_basic_creation(self) -> None:
+        chunk = AudioChunk(source_id="mic", pcm_data=b"\x00" * 3200)
+        assert chunk.source_id == "mic"
+        assert len(chunk.pcm_data) == 3200
+
+    def test_duration_ms_s16le(self) -> None:
+        # 1600 samples * 2 bytes = 3200 bytes at 16kHz = 100ms
+        chunk = AudioChunk(
+            source_id="mic", pcm_data=b"\x00" * 3200,
+            sample_rate=16000, channels=1, sample_format="s16le",
+        )
+        assert abs(chunk.duration_ms - 100.0) < 0.01
+
+    def test_duration_ms_f32le(self) -> None:
+        # 1600 samples * 4 bytes = 6400 bytes at 16kHz = 100ms
+        chunk = AudioChunk(
+            source_id="mic", pcm_data=b"\x00" * 6400,
+            sample_rate=16000, channels=1, sample_format="f32le",
+        )
+        assert abs(chunk.duration_ms - 100.0) < 0.01
+
+    def test_duration_ms_empty(self) -> None:
+        chunk = AudioChunk(source_id="mic", pcm_data=b"")
+        assert chunk.duration_ms == 0.0
+
+    def test_mqtt_topic(self) -> None:
+        chunk = AudioChunk(source_id="mic", pcm_data=b"")
+        assert chunk.mqtt_topic() == "agent/sensory/audio/mic"
+
+    def test_mqtt_topic_app(self) -> None:
+        chunk = AudioChunk(source_id="app-firefox", pcm_data=b"")
+        assert chunk.mqtt_topic() == "agent/sensory/audio/app-firefox"
+
+    def test_rms_amplitude_silence(self) -> None:
+        chunk = AudioChunk(source_id="mic", pcm_data=b"\x00" * 200)
+        assert chunk.rms_amplitude == 0.0
+
+    def test_rms_amplitude_signal(self) -> None:
+        # Create 4 samples of value 1000 (s16le)
+        samples = [1000, -1000, 1000, -1000]
+        pcm = b"".join(struct.pack("<h", s) for s in samples)
+        chunk = AudioChunk(source_id="mic", pcm_data=pcm)
+        assert abs(chunk.rms_amplitude - 1000.0) < 0.1
+
+    def test_rms_unsupported_format(self) -> None:
+        chunk = AudioChunk(
+            source_id="mic", pcm_data=b"\x00" * 100,
+            sample_format="f32le",
+        )
+        assert chunk.rms_amplitude == 0.0
+
+    def test_sequence_numbering(self) -> None:
+        chunk = AudioChunk(source_id="mic", pcm_data=b"", sequence=42)
+        assert chunk.sequence == 42
+
+
+# ---------------------------------------------------------------------------
+# PipeWireAudioStream — platform guard
+# ---------------------------------------------------------------------------
+
+
+class TestPipeWireAudioStreamPlatform:
+    def test_linux_only(self) -> None:
+        if sys.platform == "linux":
+            stream = PipeWireAudioStream(source_id="mic")
+            assert stream.source_id == "mic"
+        else:
+            with pytest.raises(RuntimeError, match="requires Linux"):
+                PipeWireAudioStream(source_id="mic")
+
+
+# ---------------------------------------------------------------------------
+# PipeWireAudioStream — with mocked platform
+# ---------------------------------------------------------------------------
+
+
+class TestPipeWireAudioStreamMocked:
+    @pytest.fixture(autouse=True)
+    def _patch_linux(self) -> None:
+        """Pretend we are on Linux for stream tests."""
+        with patch.object(sys, "platform", "linux"):
+            yield
+
+    def test_default_config(self) -> None:
+        stream = PipeWireAudioStream(source_id="mic")
+        assert stream.config.sample_rate == 16000
+        assert stream.is_running is False
+
+    def test_custom_config(self) -> None:
+        cfg = AudioCaptureConfig(sample_rate=44100, channels=2)
+        stream = PipeWireAudioStream(source_id="app", config=cfg)
+        assert stream.config.sample_rate == 44100
+        assert stream.config.channels == 2
+
+    def test_make_chunk(self) -> None:
+        stream = PipeWireAudioStream(source_id="mic")
+        chunk = stream._make_chunk(b"\x00" * 3200)
+        assert chunk.source_id == "mic"
+        assert chunk.sequence == 1
+        chunk2 = stream._make_chunk(b"\x00" * 3200)
+        assert chunk2.sequence == 2
+
+    async def test_capture_loop_with_provider(self) -> None:
+        chunks_received: list[bytes] = []
+        call_count = 0
+
+        async def provider() -> bytes | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count > 3:
+                return None
+            return b"\x00" * 3200
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            chunks_received.append(payload)
+
+        stream = PipeWireAudioStream(source_id="mic", publish_fn=mock_publish)
+        await stream.capture_loop(audio_provider=provider)
+
+        assert len(chunks_received) == 3
+        assert stream.is_running is False
+
+    async def test_capture_loop_stop(self) -> None:
+        call_count = 0
+
+        async def provider() -> bytes | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                # Simulate stop from outside
+                stream.stop()
+            return b"\x00" * 100
+
+        stream = PipeWireAudioStream(source_id="mic")
+        await stream.capture_loop(audio_provider=provider)
+        assert stream.is_running is False
+
+    async def test_context_manager(self) -> None:
+        async with PipeWireAudioStream(source_id="mic") as stream:
+            assert isinstance(stream, PipeWireAudioStream)
+        assert stream.is_running is False
+
+    async def test_capture_topics(self) -> None:
+        topics: list[str] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            topics.append(topic)
+
+        call_count = 0
+
+        async def provider() -> bytes | None:
+            nonlocal call_count
+            call_count += 1
+            return b"\x00" * 100 if call_count <= 2 else None
+
+        stream = PipeWireAudioStream(source_id="meeting", publish_fn=mock_publish)
+        await stream.capture_loop(audio_provider=provider)
+
+        assert all(t == "agent/sensory/audio/meeting" for t in topics)
+        assert len(topics) == 2

--- a/tests/test_audio_config.py
+++ b/tests/test_audio_config.py
@@ -1,0 +1,134 @@
+"""Tests for audio configuration — Issue #49."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openbad.sensory.audio.config import (
+    ASRConfig,
+    AudioCaptureConfig,
+    AudioConfig,
+    TTSConfig,
+    WakeWordConfig,
+    load_audio_config,
+)
+
+# ---------------------------------------------------------------------------
+# AudioCaptureConfig
+# ---------------------------------------------------------------------------
+
+
+class TestAudioCaptureConfig:
+    def test_defaults(self) -> None:
+        c = AudioCaptureConfig()
+        assert c.sample_rate == 16000
+        assert c.channels == 1
+        assert c.sample_format == "s16le"
+        assert c.chunk_duration_ms == 100
+        assert c.device == ""
+        assert c.passive is True
+
+    def test_chunk_bytes_s16le(self) -> None:
+        c = AudioCaptureConfig(sample_rate=16000, channels=1, sample_format="s16le",
+                               chunk_duration_ms=100)
+        # 16000 * 0.1 = 1600 samples * 1 ch * 2 bytes = 3200
+        assert c.chunk_bytes == 3200
+
+    def test_chunk_bytes_f32le(self) -> None:
+        c = AudioCaptureConfig(sample_rate=16000, channels=1, sample_format="f32le",
+                               chunk_duration_ms=100)
+        # 1600 samples * 1 ch * 4 bytes = 6400
+        assert c.chunk_bytes == 6400
+
+    def test_chunk_bytes_stereo(self) -> None:
+        c = AudioCaptureConfig(sample_rate=48000, channels=2, sample_format="s16le",
+                               chunk_duration_ms=50)
+        # 48000 * 0.05 = 2400 samples * 2 ch * 2 bytes = 9600
+        assert c.chunk_bytes == 9600
+
+
+# ---------------------------------------------------------------------------
+# ASRConfig
+# ---------------------------------------------------------------------------
+
+
+class TestASRConfig:
+    def test_defaults(self) -> None:
+        c = ASRConfig()
+        assert c.vosk_model_path == ""
+        assert c.whisper_model == "base"
+        assert c.default_engine == "vosk"
+
+
+# ---------------------------------------------------------------------------
+# WakeWordConfig & TTSConfig
+# ---------------------------------------------------------------------------
+
+
+class TestWakeWordConfig:
+    def test_defaults(self) -> None:
+        c = WakeWordConfig()
+        assert c.phrases == ["hey agent"]
+        assert c.threshold == 0.5
+
+
+class TestTTSConfig:
+    def test_defaults(self) -> None:
+        c = TTSConfig()
+        assert c.engine == "piper"
+        assert c.model_path == ""
+        assert c.output_device == ""
+
+
+# ---------------------------------------------------------------------------
+# AudioConfig
+# ---------------------------------------------------------------------------
+
+
+class TestAudioConfig:
+    def test_top_level_defaults(self) -> None:
+        config = AudioConfig()
+        assert isinstance(config.capture, AudioCaptureConfig)
+        assert isinstance(config.asr, ASRConfig)
+        assert isinstance(config.wake_word, WakeWordConfig)
+        assert isinstance(config.tts, TTSConfig)
+
+
+# ---------------------------------------------------------------------------
+# load_audio_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAudioConfig:
+    def test_none_returns_defaults(self) -> None:
+        config = load_audio_config(None)
+        assert config.capture.sample_rate == 16000
+
+    def test_missing_file_returns_defaults(self) -> None:
+        config = load_audio_config("/nonexistent/audio.yaml")
+        assert config.capture.sample_rate == 16000
+
+    def test_loads_project_config(self) -> None:
+        cfg_path = Path(__file__).resolve().parents[1] / "config" / "sensory_audio.yaml"
+        if not cfg_path.exists():
+            return
+        config = load_audio_config(cfg_path)
+        assert config.capture.sample_rate == 16000
+        assert config.asr.default_engine == "vosk"
+        assert config.wake_word.phrases == ["hey agent"]
+        assert config.tts.engine == "piper"
+
+    def test_partial_config(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "partial.yaml"
+        cfg.write_text("audio:\n  capture:\n    sample_rate: 44100\n")
+        config = load_audio_config(cfg)
+        assert config.capture.sample_rate == 44100
+        # Other defaults preserved
+        assert config.capture.channels == 1
+        assert config.asr.default_engine == "vosk"
+
+    def test_unknown_keys_ignored(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "extra.yaml"
+        cfg.write_text("audio:\n  capture:\n    sample_rate: 8000\n    unknown_field: 42\n")
+        config = load_audio_config(cfg)
+        assert config.capture.sample_rate == 8000


### PR DESCRIPTION
Closes #49

## Summary
- `AudioCaptureConfig`, `ASRConfig`, `WakeWordConfig`, `TTSConfig`, `AudioConfig` dataclasses
- `load_audio_config()` YAML loader with section-level defaults
- `AudioChunk` dataclass with duration, RMS amplitude, MQTT topic helpers
- `PipeWireAudioStream` async capture loop with pluggable audio provider, platform guard, publish support
- `config/sensory_audio.yaml` default config
- 31 unit tests covering config, chunk properties, capture loop, platform guard

## How to test
```sh
python -m pytest tests/test_audio_config.py tests/test_audio_capture.py -v
```