### PR TITLE
#50: Vosk streaming ASR

### DIFF
--- a/src/openbad/sensory/audio/asr_vosk.py
+++ b/src/openbad/sensory/audio/asr_vosk.py
@@ -1,0 +1,189 @@
+"""Vosk streaming automatic speech recognition.
+
+Provides always-on ambient speech recognition using the Vosk library.
+Audio chunks from PipeWire are fed into the recogniser, producing partial
+and final transcription results with confidence scores.
+
+Transcription events are published as protobuf messages on
+``agent/sensory/audio/{source_id}``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from openbad.nervous_system.schemas import Header, TranscriptionEvent
+from openbad.nervous_system.topics import SENSORY_AUDIO, topic_for
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TranscriptionResult:
+    """A single transcription result from the Vosk recogniser.
+
+    Attributes
+    ----------
+    text : str
+        Recognised text.
+    confidence : float
+        Average confidence score 0.0–1.0.
+    is_final : bool
+        True for final results, False for partial/interim results.
+    source_id : str
+        Audio source identifier.
+    timestamp : float
+        Unix timestamp of the result.
+    """
+
+    text: str
+    confidence: float
+    is_final: bool = True
+    source_id: str = ""
+    timestamp: float = field(default_factory=time.time)
+
+    def to_proto(self) -> TranscriptionEvent:
+        return TranscriptionEvent(
+            header=Header(
+                timestamp_unix=self.timestamp,
+                source_module="sensory.audio.asr_vosk",
+                schema_version=1,
+            ),
+            source_id=self.source_id,
+            text=self.text,
+            confidence=self.confidence,
+            is_final=self.is_final,
+        )
+
+
+class VoskRecogniser:
+    """Streaming speech recogniser backed by Vosk.
+
+    Parameters
+    ----------
+    model_path : str
+        Path to the Vosk language model directory.
+    sample_rate : int
+        Audio sample rate in Hz (must match the model, typically 16000).
+    publish_fn : callable | None
+        Optional async callback ``(topic, payload) -> None``.
+    """
+
+    def __init__(
+        self,
+        model_path: str = "",
+        sample_rate: int = 16000,
+        publish_fn: Any | None = None,
+    ) -> None:
+        self._model_path = model_path
+        self._sample_rate = sample_rate
+        self._publish = publish_fn
+        self._model: Any | None = None
+        self._recogniser: Any | None = None
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._recogniser is not None
+
+    def load_model(self) -> None:
+        """Load the Vosk model and create a recogniser.
+
+        Raises RuntimeError if vosk is not installed.
+        """
+        try:
+            import vosk  # type: ignore[import-untyped]
+        except ImportError:
+            msg = (
+                "vosk is required for Vosk ASR. "
+                "Install with: pip install vosk"
+            )
+            raise RuntimeError(msg) from None
+
+        if not self._model_path:
+            msg = "Vosk model path must be specified"
+            raise ValueError(msg)
+
+        vosk.SetLogLevel(-1)
+        self._model = vosk.Model(self._model_path)
+        self._recogniser = vosk.KaldiRecognizer(self._model, self._sample_rate)
+
+    def accept_waveform(self, pcm_data: bytes) -> TranscriptionResult | None:
+        """Feed PCM audio data and return a result if speech is detected.
+
+        Returns a ``TranscriptionResult`` when Vosk produces a final or
+        partial result with non-empty text.  Returns ``None`` if no
+        speech is detected in this chunk.
+        """
+        if self._recogniser is None:
+            msg = "Model not loaded — call load_model() first"
+            raise RuntimeError(msg)
+
+        if self._recogniser.AcceptWaveform(pcm_data):
+            raw = json.loads(self._recogniser.Result())
+            text = raw.get("text", "").strip()
+            if text:
+                return TranscriptionResult(
+                    text=text,
+                    confidence=self._extract_confidence(raw),
+                    is_final=True,
+                )
+        else:
+            raw = json.loads(self._recogniser.PartialResult())
+            text = raw.get("partial", "").strip()
+            if text:
+                return TranscriptionResult(
+                    text=text,
+                    confidence=0.0,
+                    is_final=False,
+                )
+
+        return None
+
+    def final_result(self) -> TranscriptionResult | None:
+        """Flush the recogniser and return any remaining text."""
+        if self._recogniser is None:
+            return None
+
+        raw = json.loads(self._recogniser.FinalResult())
+        text = raw.get("text", "").strip()
+        if text:
+            return TranscriptionResult(
+                text=text,
+                confidence=self._extract_confidence(raw),
+                is_final=True,
+            )
+        return None
+
+    async def process_and_publish(
+        self,
+        source_id: str,
+        pcm_data: bytes,
+    ) -> TranscriptionResult | None:
+        """Process audio and optionally publish the result."""
+        result = self.accept_waveform(pcm_data)
+
+        if result is not None:
+            result.source_id = source_id
+            if self._publish is not None:
+                proto = result.to_proto()
+                topic = topic_for(SENSORY_AUDIO, source_id=source_id)
+                await self._publish(topic, proto.SerializeToString())
+
+        return result
+
+    @staticmethod
+    def _extract_confidence(raw: dict[str, Any]) -> float:
+        """Extract average confidence from Vosk result dict.
+
+        Vosk includes per-word confidence in the ``result`` array when
+        the model supports it.  Falls back to 0.0 if unavailable.
+        """
+        words = raw.get("result", [])
+        if not words:
+            return 0.0
+        total = sum(w.get("conf", 0.0) for w in words)
+        return total / len(words)

--- a/tests/test_asr_vosk.py
+++ b/tests/test_asr_vosk.py
@@ -1,0 +1,236 @@
+"""Tests for Vosk streaming ASR — Issue #50."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openbad.nervous_system.schemas import TranscriptionEvent
+from openbad.sensory.audio.asr_vosk import TranscriptionResult, VoskRecogniser
+
+# ---------------------------------------------------------------------------
+# TranscriptionResult
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptionResult:
+    def test_basic(self) -> None:
+        r = TranscriptionResult(text="hello world", confidence=0.95)
+        assert r.text == "hello world"
+        assert r.confidence == 0.95
+        assert r.is_final is True
+
+    def test_partial(self) -> None:
+        r = TranscriptionResult(text="hello", confidence=0.0, is_final=False)
+        assert r.is_final is False
+
+    def test_to_proto(self) -> None:
+        r = TranscriptionResult(
+            text="test transcription",
+            confidence=0.88,
+            is_final=True,
+            source_id="mic",
+        )
+        proto = r.to_proto()
+        assert isinstance(proto, TranscriptionEvent)
+        assert proto.text == "test transcription"
+        assert abs(proto.confidence - 0.88) < 0.001
+        assert proto.is_final is True
+        assert proto.source_id == "mic"
+        assert proto.header.source_module == "sensory.audio.asr_vosk"
+
+    def test_proto_roundtrip(self) -> None:
+        r = TranscriptionResult(text="hello", confidence=0.9, source_id="app")
+        proto = r.to_proto()
+        data = proto.SerializeToString()
+        restored = TranscriptionEvent()
+        restored.ParseFromString(data)
+        assert restored.text == "hello"
+
+
+# ---------------------------------------------------------------------------
+# VoskRecogniser — config
+# ---------------------------------------------------------------------------
+
+
+class TestVoskRecogniserConfig:
+    def test_defaults(self) -> None:
+        rec = VoskRecogniser()
+        assert rec.is_loaded is False
+
+    def test_not_loaded_raises(self) -> None:
+        rec = VoskRecogniser()
+        with pytest.raises(RuntimeError, match="Model not loaded"):
+            rec.accept_waveform(b"\x00" * 100)
+
+
+class TestVoskRecogniserImportError:
+    def test_import_error(self) -> None:
+        with patch.dict("sys.modules", {"vosk": None}):
+            rec = VoskRecogniser(model_path="/some/model")
+            with pytest.raises(RuntimeError, match="vosk is required"):
+                rec.load_model()
+
+    def test_empty_model_path(self) -> None:
+        mock_vosk = MagicMock()
+        with patch.dict("sys.modules", {"vosk": mock_vosk}):
+            rec = VoskRecogniser(model_path="")
+            with pytest.raises(ValueError, match="model path must be specified"):
+                rec.load_model()
+
+
+# ---------------------------------------------------------------------------
+# VoskRecogniser — with mocked vosk
+# ---------------------------------------------------------------------------
+
+
+class TestVoskRecogniserMocked:
+    @pytest.fixture()
+    def recogniser(self) -> VoskRecogniser:
+        """Create a VoskRecogniser with mocked internals."""
+        rec = VoskRecogniser(model_path="/test/model", sample_rate=16000)
+        mock_rec = MagicMock()
+        rec._model = MagicMock()
+        rec._recogniser = mock_rec
+        return rec
+
+    def test_final_result_from_accept(self, recogniser: VoskRecogniser) -> None:
+        mock_rec = recogniser._recogniser
+        mock_rec.AcceptWaveform.return_value = True
+        mock_rec.Result.return_value = json.dumps({
+            "text": "hello world",
+            "result": [
+                {"conf": 0.98, "word": "hello"},
+                {"conf": 0.95, "word": "world"},
+            ],
+        })
+
+        result = recogniser.accept_waveform(b"\x00" * 3200)
+        assert result is not None
+        assert result.text == "hello world"
+        assert result.is_final is True
+        assert abs(result.confidence - 0.965) < 0.01
+
+    def test_partial_result(self, recogniser: VoskRecogniser) -> None:
+        mock_rec = recogniser._recogniser
+        mock_rec.AcceptWaveform.return_value = False
+        mock_rec.PartialResult.return_value = json.dumps({"partial": "hello"})
+
+        result = recogniser.accept_waveform(b"\x00" * 1600)
+        assert result is not None
+        assert result.text == "hello"
+        assert result.is_final is False
+        assert result.confidence == 0.0
+
+    def test_silence_returns_none(self, recogniser: VoskRecogniser) -> None:
+        mock_rec = recogniser._recogniser
+        mock_rec.AcceptWaveform.return_value = False
+        mock_rec.PartialResult.return_value = json.dumps({"partial": ""})
+
+        result = recogniser.accept_waveform(b"\x00" * 1600)
+        assert result is None
+
+    def test_final_empty_text(self, recogniser: VoskRecogniser) -> None:
+        mock_rec = recogniser._recogniser
+        mock_rec.AcceptWaveform.return_value = True
+        mock_rec.Result.return_value = json.dumps({"text": ""})
+
+        result = recogniser.accept_waveform(b"\x00" * 3200)
+        assert result is None
+
+    def test_flush_final_result(self, recogniser: VoskRecogniser) -> None:
+        mock_rec = recogniser._recogniser
+        mock_rec.FinalResult.return_value = json.dumps({
+            "text": "goodbye",
+            "result": [{"conf": 0.9, "word": "goodbye"}],
+        })
+
+        result = recogniser.final_result()
+        assert result is not None
+        assert result.text == "goodbye"
+        assert result.is_final is True
+
+    def test_flush_empty(self, recogniser: VoskRecogniser) -> None:
+        mock_rec = recogniser._recogniser
+        mock_rec.FinalResult.return_value = json.dumps({"text": ""})
+        assert recogniser.final_result() is None
+
+    def test_final_result_no_model(self) -> None:
+        rec = VoskRecogniser()
+        assert rec.final_result() is None
+
+    def test_confidence_no_words(self) -> None:
+        assert VoskRecogniser._extract_confidence({"text": "hi"}) == 0.0
+
+    def test_confidence_with_words(self) -> None:
+        raw = {"result": [{"conf": 0.8}, {"conf": 0.9}, {"conf": 1.0}]}
+        assert abs(VoskRecogniser._extract_confidence(raw) - 0.9) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# VoskRecogniser — async publish
+# ---------------------------------------------------------------------------
+
+
+class TestVoskRecogniserPublish:
+    async def test_publish_on_result(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        rec = VoskRecogniser(
+            model_path="/test/model",
+            publish_fn=mock_publish,
+        )
+        mock_rec = MagicMock()
+        rec._model = MagicMock()
+        rec._recogniser = mock_rec
+
+        mock_rec.AcceptWaveform.return_value = True
+        mock_rec.Result.return_value = json.dumps({"text": "check calendar"})
+
+        result = await rec.process_and_publish("mic", b"\x00" * 3200)
+        assert result is not None
+        assert result.source_id == "mic"
+
+        assert len(published) == 1
+        topic, payload = published[0]
+        assert topic == "agent/sensory/audio/mic"
+
+        restored = TranscriptionEvent()
+        restored.ParseFromString(payload)
+        assert restored.text == "check calendar"
+
+    async def test_no_publish_on_silence(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        rec = VoskRecogniser(publish_fn=mock_publish)
+        mock_rec = MagicMock()
+        rec._model = MagicMock()
+        rec._recogniser = mock_rec
+
+        mock_rec.AcceptWaveform.return_value = False
+        mock_rec.PartialResult.return_value = json.dumps({"partial": ""})
+
+        result = await rec.process_and_publish("mic", b"\x00" * 1600)
+        assert result is None
+        assert len(published) == 0
+
+    async def test_no_publish_fn(self) -> None:
+        rec = VoskRecogniser()
+        mock_rec = MagicMock()
+        rec._model = MagicMock()
+        rec._recogniser = mock_rec
+
+        mock_rec.AcceptWaveform.return_value = True
+        mock_rec.Result.return_value = json.dumps({"text": "test"})
+
+        result = await rec.process_and_publish("mic", b"\x00" * 3200)
+        assert result is not None
+        assert result.text == "test"


### PR DESCRIPTION
Closes #50

## Summary
- `TranscriptionResult` dataclass with proto serialisation
- `VoskRecogniser`: streaming speech recognition with partial/final results, confidence extraction, model lifecycle
- Publishes `TranscriptionEvent` protobuf on `agent/sensory/audio/{source_id}`
- Import error handling for optional vosk dependency
- 20 unit tests with mocked Vosk internals covering config, recognition, publish

## How to test
```sh
python -m pytest tests/test_asr_vosk.py -v
```