### PR TITLE
#51: Whisper high-accuracy transcription

### DIFF
--- a/src/openbad/sensory/audio/asr_whisper.py
+++ b/src/openbad/sensory/audio/asr_whisper.py
@@ -1,0 +1,238 @@
+"""Whisper high-accuracy automatic speech recognition.
+
+Provides on-demand, high-fidelity transcription using OpenAI Whisper
+via the ``faster-whisper`` CTranslate2 backend.  Triggered by the reflex
+arc when the wake-word detector or attention filter escalates from Vosk
+ambient mode.
+
+Transcription events are published as ``TranscriptionEvent`` protobuf
+messages on ``agent/sensory/audio/{source_id}``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from openbad.nervous_system.schemas import Header, TranscriptionEvent
+from openbad.nervous_system.topics import SENSORY_AUDIO, topic_for
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WhisperSegment:
+    """A single transcribed segment from Whisper.
+
+    Attributes
+    ----------
+    text : str
+        Transcribed text.
+    start : float
+        Start time in seconds within the audio.
+    end : float
+        End time in seconds within the audio.
+    avg_logprob : float
+        Average log-probability (lower = less confident).
+    no_speech_prob : float
+        Probability that this segment is silence/noise.
+    """
+
+    text: str
+    start: float = 0.0
+    end: float = 0.0
+    avg_logprob: float = 0.0
+    no_speech_prob: float = 0.0
+
+    @property
+    def confidence(self) -> float:
+        """Rough confidence estimate derived from avg_logprob.
+
+        Maps log-probabilities to 0.0–1.0 range.  Values below -1.0
+        are treated as very low confidence.
+        """
+        import math
+
+        return max(0.0, min(1.0, math.exp(self.avg_logprob)))
+
+
+@dataclass
+class WhisperResult:
+    """Complete Whisper transcription result for an audio buffer.
+
+    Attributes
+    ----------
+    segments : list[WhisperSegment]
+        Ordered list of transcribed segments.
+    language : str
+        Detected or specified language code.
+    language_probability : float
+        Confidence of the language detection.
+    duration_s : float
+        Total audio duration in seconds.
+    processing_ms : float
+        Wall-clock processing time in milliseconds.
+    """
+
+    segments: list[WhisperSegment] = field(default_factory=list)
+    language: str = "en"
+    language_probability: float = 0.0
+    duration_s: float = 0.0
+    processing_ms: float = 0.0
+
+    @property
+    def full_text(self) -> str:
+        return " ".join(s.text.strip() for s in self.segments if s.text.strip())
+
+    @property
+    def avg_confidence(self) -> float:
+        if not self.segments:
+            return 0.0
+        return sum(s.confidence for s in self.segments) / len(self.segments)
+
+    def to_proto(self, source_id: str = "") -> TranscriptionEvent:
+        return TranscriptionEvent(
+            header=Header(
+                timestamp_unix=time.time(),
+                source_module="sensory.audio.asr_whisper",
+                schema_version=1,
+            ),
+            source_id=source_id,
+            text=self.full_text,
+            confidence=self.avg_confidence,
+            is_final=True,
+        )
+
+
+class WhisperTranscriber:
+    """On-demand high-accuracy transcription using faster-whisper.
+
+    Parameters
+    ----------
+    model_size : str
+        Whisper model: ``"tiny"``, ``"base"``, ``"small"``, ``"medium"``,
+        ``"large-v3"`` (default ``"base"``).
+    device : str
+        Compute device: ``"cpu"`` or ``"cuda"`` (default ``"cpu"``).
+    compute_type : str
+        CTranslate2 compute type (default ``"int8"``).
+    publish_fn : callable | None
+        Optional async callback ``(topic, payload) -> None``.
+    """
+
+    VALID_MODELS = ("tiny", "base", "small", "medium", "large-v3")
+
+    def __init__(
+        self,
+        model_size: str = "base",
+        device: str = "cpu",
+        compute_type: str = "int8",
+        publish_fn: Any | None = None,
+    ) -> None:
+        self._model_size = model_size
+        self._device = device
+        self._compute_type = compute_type
+        self._publish = publish_fn
+        self._model: Any | None = None
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+    @property
+    def model_size(self) -> str:
+        return self._model_size
+
+    def load_model(self) -> None:
+        """Load the faster-whisper model.
+
+        Raises RuntimeError if faster-whisper is not installed.
+        """
+        try:
+            from faster_whisper import WhisperModel  # type: ignore[import-untyped]
+        except ImportError:
+            msg = (
+                "faster-whisper is required for Whisper transcription. "
+                "Install with: pip install faster-whisper"
+            )
+            raise RuntimeError(msg) from None
+
+        if self._model_size not in self.VALID_MODELS:
+            msg = (
+                f"Invalid model size '{self._model_size}'. "
+                f"Valid options: {self.VALID_MODELS}"
+            )
+            raise ValueError(msg)
+
+        self._model = WhisperModel(
+            self._model_size,
+            device=self._device,
+            compute_type=self._compute_type,
+        )
+
+    def transcribe(
+        self,
+        audio: Any,
+        language: str | None = None,
+    ) -> WhisperResult:
+        """Transcribe audio data.
+
+        Parameters
+        ----------
+        audio : str | numpy.ndarray | bytes
+            Audio input — a file path, numpy array (float32, mono, 16kHz),
+            or raw bytes.
+        language : str | None
+            Force language code (e.g. ``"en"``).  ``None`` for auto-detect.
+
+        Returns :class:`WhisperResult` with all segments.
+        """
+        if self._model is None:
+            msg = "Model not loaded — call load_model() first"
+            raise RuntimeError(msg)
+
+        start = time.perf_counter()
+
+        kwargs: dict[str, Any] = {}
+        if language is not None:
+            kwargs["language"] = language
+
+        segments_gen, info = self._model.transcribe(audio, **kwargs)
+
+        segments: list[WhisperSegment] = []
+        for seg in segments_gen:
+            segments.append(WhisperSegment(
+                text=seg.text,
+                start=seg.start,
+                end=seg.end,
+                avg_logprob=seg.avg_logprob,
+                no_speech_prob=seg.no_speech_prob,
+            ))
+
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        return WhisperResult(
+            segments=segments,
+            language=info.language,
+            language_probability=info.language_probability,
+            duration_s=info.duration,
+            processing_ms=elapsed_ms,
+        )
+
+    async def transcribe_and_publish(
+        self,
+        source_id: str,
+        audio: Any,
+        language: str | None = None,
+    ) -> WhisperResult:
+        """Transcribe audio and optionally publish the result."""
+        result = self.transcribe(audio, language=language)
+
+        if self._publish is not None and result.full_text:
+            proto = result.to_proto(source_id=source_id)
+            topic = topic_for(SENSORY_AUDIO, source_id=source_id)
+            await self._publish(topic, proto.SerializeToString())
+
+        return result

--- a/tests/test_asr_whisper.py
+++ b/tests/test_asr_whisper.py
@@ -1,0 +1,226 @@
+"""Tests for Whisper high-accuracy transcription — Issue #51."""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openbad.nervous_system.schemas import TranscriptionEvent
+from openbad.sensory.audio.asr_whisper import (
+    WhisperResult,
+    WhisperSegment,
+    WhisperTranscriber,
+)
+
+# ---------------------------------------------------------------------------
+# WhisperSegment
+# ---------------------------------------------------------------------------
+
+
+class TestWhisperSegment:
+    def test_basic(self) -> None:
+        s = WhisperSegment(text="hello", start=0.0, end=1.5)
+        assert s.text == "hello"
+        assert s.start == 0.0
+        assert s.end == 1.5
+
+    def test_confidence_from_logprob(self) -> None:
+        # avg_logprob=0 → confidence=1.0 (exp(0)=1)
+        s = WhisperSegment(text="x", avg_logprob=0.0)
+        assert abs(s.confidence - 1.0) < 0.001
+
+    def test_confidence_low(self) -> None:
+        # avg_logprob=-2.0 → exp(-2)≈0.135
+        s = WhisperSegment(text="x", avg_logprob=-2.0)
+        assert abs(s.confidence - math.exp(-2.0)) < 0.001
+
+    def test_confidence_clamped(self) -> None:
+        # Very negative → effectively zero
+        s = WhisperSegment(text="x", avg_logprob=-100.0)
+        assert s.confidence < 0.001
+
+
+# ---------------------------------------------------------------------------
+# WhisperResult
+# ---------------------------------------------------------------------------
+
+
+class TestWhisperResult:
+    def test_empty(self) -> None:
+        r = WhisperResult()
+        assert r.full_text == ""
+        assert r.avg_confidence == 0.0
+
+    def test_full_text(self) -> None:
+        r = WhisperResult(segments=[
+            WhisperSegment(text=" Hello "),
+            WhisperSegment(text=" world "),
+        ])
+        assert r.full_text == "Hello world"
+
+    def test_avg_confidence(self) -> None:
+        r = WhisperResult(segments=[
+            WhisperSegment(text="a", avg_logprob=0.0),  # conf=1.0
+            WhisperSegment(text="b", avg_logprob=-0.693),  # conf≈0.5
+        ])
+        assert 0.7 < r.avg_confidence < 0.8
+
+    def test_to_proto(self) -> None:
+        r = WhisperResult(segments=[
+            WhisperSegment(text="test", avg_logprob=-0.1),
+        ])
+        proto = r.to_proto(source_id="mic")
+        assert isinstance(proto, TranscriptionEvent)
+        assert proto.text == "test"
+        assert proto.source_id == "mic"
+        assert proto.is_final is True
+        assert proto.header.source_module == "sensory.audio.asr_whisper"
+
+    def test_proto_roundtrip(self) -> None:
+        r = WhisperResult(segments=[WhisperSegment(text="hello")])
+        data = r.to_proto("app").SerializeToString()
+        restored = TranscriptionEvent()
+        restored.ParseFromString(data)
+        assert restored.text == "hello"
+
+
+# ---------------------------------------------------------------------------
+# WhisperTranscriber — config
+# ---------------------------------------------------------------------------
+
+
+class TestWhisperTranscriberConfig:
+    def test_defaults(self) -> None:
+        t = WhisperTranscriber()
+        assert t.model_size == "base"
+        assert t.is_loaded is False
+
+    def test_not_loaded_raises(self) -> None:
+        t = WhisperTranscriber()
+        with pytest.raises(RuntimeError, match="Model not loaded"):
+            t.transcribe("audio.wav")
+
+
+class TestWhisperTranscriberImportError:
+    def test_import_error(self) -> None:
+        with patch.dict("sys.modules", {"faster_whisper": None}):
+            t = WhisperTranscriber(model_size="base")
+            with pytest.raises(RuntimeError, match="faster-whisper is required"):
+                t.load_model()
+
+    def test_invalid_model_size(self) -> None:
+        mock_fw = MagicMock()
+        with patch.dict("sys.modules", {"faster_whisper": mock_fw}):
+            t = WhisperTranscriber(model_size="invalid")
+            with pytest.raises(ValueError, match="Invalid model size"):
+                t.load_model()
+
+
+# ---------------------------------------------------------------------------
+# WhisperTranscriber — with mocked model
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_segment(text: str, start: float = 0.0, end: float = 1.0) -> SimpleNamespace:
+    return SimpleNamespace(
+        text=text, start=start, end=end,
+        avg_logprob=-0.2, no_speech_prob=0.05,
+    )
+
+
+def _make_mock_info(lang: str = "en") -> SimpleNamespace:
+    return SimpleNamespace(
+        language=lang,
+        language_probability=0.98,
+        duration=5.0,
+    )
+
+
+class TestWhisperTranscriberMocked:
+    @pytest.fixture()
+    def transcriber(self) -> WhisperTranscriber:
+        t = WhisperTranscriber(model_size="base")
+        mock_model = MagicMock()
+        t._model = mock_model
+        return t
+
+    def test_transcribe_segments(self, transcriber: WhisperTranscriber) -> None:
+        segs = [
+            _make_mock_segment("Hello world", 0.0, 2.0),
+            _make_mock_segment("testing now", 2.0, 4.0),
+        ]
+        transcriber._model.transcribe.return_value = (segs, _make_mock_info())
+
+        result = transcriber.transcribe("audio.wav")
+        assert len(result.segments) == 2
+        assert result.full_text == "Hello world testing now"
+        assert result.language == "en"
+        assert result.processing_ms >= 0
+
+    def test_transcribe_empty(self, transcriber: WhisperTranscriber) -> None:
+        transcriber._model.transcribe.return_value = ([], _make_mock_info())
+        result = transcriber.transcribe("silence.wav")
+        assert result.full_text == ""
+        assert result.avg_confidence == 0.0
+
+    def test_transcribe_with_language(self, transcriber: WhisperTranscriber) -> None:
+        segs = [_make_mock_segment("Bonjour")]
+        transcriber._model.transcribe.return_value = (segs, _make_mock_info("fr"))
+        result = transcriber.transcribe("audio.wav", language="fr")
+        transcriber._model.transcribe.assert_called_once_with("audio.wav", language="fr")
+        assert result.language == "fr"
+
+
+# ---------------------------------------------------------------------------
+# WhisperTranscriber — async publish
+# ---------------------------------------------------------------------------
+
+
+class TestWhisperTranscriberPublish:
+    async def test_publish_on_result(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        t = WhisperTranscriber(publish_fn=mock_publish)
+        t._model = MagicMock()
+
+        segs = [_make_mock_segment("check calendar")]
+        t._model.transcribe.return_value = (segs, _make_mock_info())
+
+        result = await t.transcribe_and_publish("mic", "audio.wav")
+        assert result.full_text == "check calendar"
+
+        assert len(published) == 1
+        topic, payload = published[0]
+        assert topic == "agent/sensory/audio/mic"
+
+        restored = TranscriptionEvent()
+        restored.ParseFromString(payload)
+        assert restored.text == "check calendar"
+
+    async def test_no_publish_on_empty(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_publish(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        t = WhisperTranscriber(publish_fn=mock_publish)
+        t._model = MagicMock()
+        t._model.transcribe.return_value = ([], _make_mock_info())
+
+        await t.transcribe_and_publish("mic", "silence.wav")
+        assert len(published) == 0
+
+    async def test_no_publish_fn(self) -> None:
+        t = WhisperTranscriber()
+        t._model = MagicMock()
+        segs = [_make_mock_segment("hello")]
+        t._model.transcribe.return_value = (segs, _make_mock_info())
+
+        result = await t.transcribe_and_publish("mic", "audio.wav")
+        assert result.full_text == "hello"


### PR DESCRIPTION
Closes #51

## Summary
- `WhisperSegment` dataclass with log-probability confidence mapping
- `WhisperResult` container with full_text aggregation, proto serialisation
- `WhisperTranscriber`: on-demand transcription via faster-whisper with model validation
- Publishes `TranscriptionEvent` protobuf on `agent/sensory/audio/{source_id}`
- Import error handling for optional faster-whisper dependency
- 19 unit tests covering segments, results, model lifecycle, publish

## How to test
```sh
python -m pytest tests/test_asr_whisper.py -v
```