### PR TITLE
#52: Wake-word detector

### DIFF
--- a/src/openbad/sensory/audio/wake_word.py
+++ b/src/openbad/sensory/audio/wake_word.py
@@ -1,0 +1,171 @@
+"""Wake-word / activation phrase detector.
+
+Runs a lightweight keyword-spotting model (openWakeWord) ahead of full
+ASR to detect configurable activation phrases.  When a wake word is
+detected the module:
+
+1. Publishes a ``WakeWordEvent`` protobuf on ``agent/sensory/audio/{source_id}``.
+2. Publishes an ``AttentionTrigger`` on ``agent/reflex/attention/trigger``
+   so the reflex arc can switch from Vosk ambient mode to Whisper high-
+   accuracy mode.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from openbad.nervous_system.schemas import AttentionTrigger, Header, WakeWordEvent
+from openbad.nervous_system.topics import (
+    SENSORY_ATTENTION_TRIGGER,
+    SENSORY_AUDIO,
+    topic_for,
+)
+from openbad.sensory.audio.config import WakeWordConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Detection:
+    """A single wake-word detection event.
+
+    Attributes
+    ----------
+    phrase : str
+        The detected activation phrase.
+    confidence : float
+        Detection confidence 0.0–1.0.
+    timestamp : float
+        Unix timestamp of the detection.
+    """
+
+    phrase: str
+    confidence: float
+    timestamp: float = field(default_factory=time.time)
+
+
+class WakeWordDetector:
+    """Lightweight keyword-spotting detector using openWakeWord.
+
+    Parameters
+    ----------
+    config : WakeWordConfig | None
+        Phrases and threshold.  Uses defaults if omitted.
+    publish_fn : callable | None
+        Optional async callback ``(topic, payload) -> None``.
+    """
+
+    def __init__(
+        self,
+        config: WakeWordConfig | None = None,
+        publish_fn: Any | None = None,
+    ) -> None:
+        self._config = config or WakeWordConfig()
+        self._publish = publish_fn
+        self._model: Any | None = None
+        self._detection_count: int = 0
+
+    @property
+    def config(self) -> WakeWordConfig:
+        return self._config
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+    @property
+    def detection_count(self) -> int:
+        return self._detection_count
+
+    def load_model(self) -> None:
+        """Load the openWakeWord model.
+
+        Raises RuntimeError if openwakeword is not installed.
+        """
+        try:
+            import openwakeword  # type: ignore[import-untyped]
+        except ImportError:
+            msg = (
+                "openwakeword is required for wake-word detection. "
+                "Install with: pip install openwakeword"
+            )
+            raise RuntimeError(msg) from None
+
+        self._model = openwakeword.Model()
+
+    def process_audio(self, pcm_data: bytes) -> list[Detection]:
+        """Feed PCM audio and return any detected wake words.
+
+        Parameters
+        ----------
+        pcm_data : bytes
+            Raw 16-bit signed LE mono PCM audio at 16kHz.
+
+        Returns a list of :class:`Detection` objects for phrases that
+        exceeded the confidence threshold.
+        """
+        if self._model is None:
+            msg = "Model not loaded — call load_model() first"
+            raise RuntimeError(msg)
+
+        prediction = self._model.predict(pcm_data)
+
+        detections: list[Detection] = []
+        for phrase in self._config.phrases:
+            # openWakeWord returns a dict keyed by model name
+            score = prediction.get(phrase, 0.0)
+            if score >= self._config.threshold:
+                detections.append(Detection(
+                    phrase=phrase,
+                    confidence=float(score),
+                ))
+                self._detection_count += 1
+
+        return detections
+
+    async def process_and_publish(
+        self,
+        source_id: str,
+        pcm_data: bytes,
+    ) -> list[Detection]:
+        """Process audio, publish events for any detections.
+
+        Publishes both a ``WakeWordEvent`` on the audio channel and an
+        ``AttentionTrigger`` on the reflex channel for each detection.
+        """
+        detections = self.process_audio(pcm_data)
+
+        for det in detections:
+            ww_proto = WakeWordEvent(
+                header=Header(
+                    timestamp_unix=det.timestamp,
+                    source_module="sensory.audio.wake_word",
+                    schema_version=1,
+                ),
+                keyword=det.phrase,
+                score=det.confidence,
+            )
+
+            attn_proto = AttentionTrigger(
+                header=Header(
+                    timestamp_unix=det.timestamp,
+                    source_module="sensory.audio.wake_word",
+                    schema_version=1,
+                ),
+                source_id=source_id,
+                ssim_delta=0.0,
+                region_description=f"Wake word detected: {det.phrase}",
+            )
+
+            if self._publish is not None:
+                audio_topic = topic_for(SENSORY_AUDIO, source_id=source_id)
+                await self._publish(audio_topic, ww_proto.SerializeToString())
+                await self._publish(
+                    SENSORY_ATTENTION_TRIGGER,
+                    attn_proto.SerializeToString(),
+                )
+
+        return detections

--- a/tests/test_wake_word.py
+++ b/tests/test_wake_word.py
@@ -1,0 +1,187 @@
+"""Tests for wake-word detector — Issue #52."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openbad.nervous_system.schemas import AttentionTrigger, WakeWordEvent
+from openbad.sensory.audio.config import WakeWordConfig
+from openbad.sensory.audio.wake_word import Detection, WakeWordDetector
+
+# ---------------------------------------------------------------------------
+# Detection dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestDetection:
+    def test_basic(self) -> None:
+        d = Detection(phrase="hey agent", confidence=0.95, timestamp=1000.0)
+        assert d.phrase == "hey agent"
+        assert d.confidence == 0.95
+        assert d.timestamp == 1000.0
+
+    def test_auto_timestamp(self) -> None:
+        d = Detection(phrase="test", confidence=0.8)
+        assert d.timestamp > 0
+
+
+# ---------------------------------------------------------------------------
+# WakeWordDetector — config
+# ---------------------------------------------------------------------------
+
+
+class TestWakeWordDetectorConfig:
+    def test_defaults(self) -> None:
+        det = WakeWordDetector()
+        assert det.is_loaded is False
+        assert det.detection_count == 0
+        assert "hey agent" in det.config.phrases
+
+    def test_custom_config(self) -> None:
+        cfg = WakeWordConfig(phrases=["ok computer"], threshold=0.8)
+        det = WakeWordDetector(config=cfg)
+        assert det.config.threshold == 0.8
+        assert det.config.phrases == ["ok computer"]
+
+
+class TestWakeWordDetectorNotLoaded:
+    def test_raises_not_loaded(self) -> None:
+        det = WakeWordDetector()
+        with pytest.raises(RuntimeError, match="Model not loaded"):
+            det.process_audio(b"\x00" * 3200)
+
+
+# ---------------------------------------------------------------------------
+# WakeWordDetector — import error handling
+# ---------------------------------------------------------------------------
+
+
+class TestWakeWordDetectorImportError:
+    def test_import_error(self) -> None:
+        with patch.dict("sys.modules", {"openwakeword": None}):
+            det = WakeWordDetector()
+            with pytest.raises(RuntimeError, match="openwakeword is required"):
+                det.load_model()
+
+
+# ---------------------------------------------------------------------------
+# WakeWordDetector — mocked model
+# ---------------------------------------------------------------------------
+
+
+class TestWakeWordDetectorMocked:
+    @pytest.fixture()
+    def detector(self) -> WakeWordDetector:
+        cfg = WakeWordConfig(phrases=["hey agent", "ok computer"], threshold=0.5)
+        det = WakeWordDetector(config=cfg)
+        det._model = MagicMock()
+        return det
+
+    def test_single_detection(self, detector: WakeWordDetector) -> None:
+        detector._model.predict.return_value = {
+            "hey agent": 0.9,
+            "ok computer": 0.2,
+        }
+        results = detector.process_audio(b"\x00" * 3200)
+        assert len(results) == 1
+        assert results[0].phrase == "hey agent"
+        assert results[0].confidence == 0.9
+        assert detector.detection_count == 1
+
+    def test_multi_detection(self, detector: WakeWordDetector) -> None:
+        detector._model.predict.return_value = {
+            "hey agent": 0.8,
+            "ok computer": 0.7,
+        }
+        results = detector.process_audio(b"\x00" * 3200)
+        assert len(results) == 2
+        assert detector.detection_count == 2
+
+    def test_no_detection(self, detector: WakeWordDetector) -> None:
+        detector._model.predict.return_value = {
+            "hey agent": 0.1,
+            "ok computer": 0.05,
+        }
+        results = detector.process_audio(b"\x00" * 3200)
+        assert len(results) == 0
+        assert detector.detection_count == 0
+
+    def test_missing_phrase_in_prediction(self, detector: WakeWordDetector) -> None:
+        # Model may not return all configured phrases
+        detector._model.predict.return_value = {"hey agent": 0.8}
+        results = detector.process_audio(b"\x00" * 3200)
+        assert len(results) == 1
+
+    def test_detection_count_accumulates(self, detector: WakeWordDetector) -> None:
+        detector._model.predict.return_value = {"hey agent": 0.9, "ok computer": 0.1}
+        detector.process_audio(b"\x00" * 3200)
+        detector.process_audio(b"\x00" * 3200)
+        assert detector.detection_count == 2
+
+    def test_threshold_boundary(self, detector: WakeWordDetector) -> None:
+        # Exactly at threshold → should detect
+        detector._model.predict.return_value = {"hey agent": 0.5}
+        results = detector.process_audio(b"\x00" * 3200)
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# WakeWordDetector — async publish
+# ---------------------------------------------------------------------------
+
+
+class TestWakeWordDetectorPublish:
+    async def test_publishes_both_events(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_pub(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        cfg = WakeWordConfig(phrases=["hey agent"], threshold=0.5)
+        det = WakeWordDetector(config=cfg, publish_fn=mock_pub)
+        det._model = MagicMock()
+        det._model.predict.return_value = {"hey agent": 0.95}
+
+        results = await det.process_and_publish("mic", b"\x00" * 3200)
+        assert len(results) == 1
+
+        # Two messages published: WakeWordEvent + AttentionTrigger
+        assert len(published) == 2
+
+        ww_topic, ww_data = published[0]
+        assert ww_topic == "agent/sensory/audio/mic"
+        ww = WakeWordEvent()
+        ww.ParseFromString(ww_data)
+        assert ww.keyword == "hey agent"
+        assert ww.score == pytest.approx(0.95)
+
+        attn_topic, attn_data = published[1]
+        assert attn_topic == "agent/reflex/attention/trigger"
+        attn = AttentionTrigger()
+        attn.ParseFromString(attn_data)
+        assert "hey agent" in attn.region_description
+
+    async def test_no_publish_without_detection(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        async def mock_pub(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        cfg = WakeWordConfig(phrases=["hey agent"], threshold=0.9)
+        det = WakeWordDetector(config=cfg, publish_fn=mock_pub)
+        det._model = MagicMock()
+        det._model.predict.return_value = {"hey agent": 0.1}
+
+        await det.process_and_publish("mic", b"\x00" * 3200)
+        assert len(published) == 0
+
+    async def test_no_publish_fn(self) -> None:
+        det = WakeWordDetector()
+        det._model = MagicMock()
+        det._model.predict.return_value = {"hey agent": 0.9}
+
+        # Should not raise
+        results = await det.process_and_publish("mic", b"\x00" * 3200)
+        assert len(results) == 1


### PR DESCRIPTION
Closes #52

## Summary
- `Detection` dataclass for wake-word events
- `WakeWordDetector`: openWakeWord integration with configurable phrases and threshold
- Publishes both `WakeWordEvent` proto and `AttentionTrigger` on detection
- Import error handling for optional openwakeword dependency
- 15 unit tests

## How to test
```sh
python -m pytest tests/test_wake_word.py -v
```