### PR TITLE
#54: Add sensory-to-reflex dispatcher with visual/audio handlers

### DIFF
--- a/config/threshold_policies.yaml
+++ b/config/threshold_policies.yaml
@@ -20,3 +20,8 @@ thresholds:
   thermal_celsius:
     warning: 80
     critical: 95
+
+# Sensory dispatcher settings (not metric thresholds)
+sensory:
+  vision_change_rate_max: 30       # Max visual attention events per minute
+  audio_noise_floor: 0.3           # Min transcription confidence to route

--- a/src/openbad/reflex_arc/handlers/sensory_audio.py
+++ b/src/openbad/reflex_arc/handlers/sensory_audio.py
@@ -1,0 +1,106 @@
+"""Audio sensory reflex handler.
+
+Processes :class:`TranscriptionEvent` and :class:`WakeWordEvent` from
+the sensory dispatcher and decides on reflex actions:
+
+- **Wake word**: activates the FSM (IDLE → ACTIVE) and optionally
+  escalates to System 2 for command processing.
+- **High-confidence transcription**: routes to System 2 for NLU.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from openbad.nervous_system.schemas import TranscriptionEvent, WakeWordEvent
+
+logger = logging.getLogger(__name__)
+
+# Minimum confidence to escalate a transcription
+DEFAULT_ESCALATION_CONFIDENCE = 0.7
+
+
+class AudioReflexHandler:
+    """Handle audio events from the sensory dispatcher.
+
+    Parameters
+    ----------
+    fsm : object | None
+        Optional :class:`AgentFSM` — fires ``activate`` on wake word.
+    escalation_gw : object | None
+        Optional :class:`EscalationGateway` for System 1→2 escalation.
+    escalation_confidence : float
+        Minimum confidence to escalate transcription events.
+    """
+
+    def __init__(
+        self,
+        fsm: Any | None = None,
+        escalation_gw: Any | None = None,
+        escalation_confidence: float = DEFAULT_ESCALATION_CONFIDENCE,
+    ) -> None:
+        self._fsm = fsm
+        self._escalation = escalation_gw
+        self._escalation_confidence = escalation_confidence
+        self._wake_count: int = 0
+        self._transcription_count: int = 0
+        self._escalation_count: int = 0
+
+    @property
+    def wake_count(self) -> int:
+        return self._wake_count
+
+    @property
+    def transcription_count(self) -> int:
+        return self._transcription_count
+
+    @property
+    def escalation_count(self) -> int:
+        return self._escalation_count
+
+    def handle_wake_word(self, event: WakeWordEvent) -> bool:
+        """Process a wake-word detection.
+
+        Activates the FSM and escalates to System 2.
+        """
+        self._wake_count += 1
+
+        # Activate the FSM
+        if self._fsm is not None:
+            try:
+                self._fsm.fire("activate")
+            except Exception:
+                logger.debug("FSM activate failed (may already be ACTIVE)")
+
+        # Escalate for command processing
+        if self._escalation is not None:
+            self._escalation_count += 1
+            self._escalation.escalate(
+                event_topic="agent/sensory/audio/wake_word",
+                event_payload=event.SerializeToString(),
+                reason=f"Wake word detected: {event.keyword}",
+                reflex_id="sensory/audio",
+            )
+
+        return True
+
+    def handle_transcription(self, event: TranscriptionEvent) -> bool:
+        """Process a transcription event.
+
+        High-confidence transcriptions are escalated to System 2 for
+        natural language understanding.
+        """
+        self._transcription_count += 1
+
+        if event.confidence >= self._escalation_confidence:
+            self._escalation_count += 1
+            if self._escalation is not None:
+                self._escalation.escalate(
+                    event_topic="agent/sensory/audio/transcription",
+                    event_payload=event.SerializeToString(),
+                    reason=f"Transcription: '{event.text[:50]}'",
+                    reflex_id="sensory/audio",
+                )
+
+        return True

--- a/src/openbad/reflex_arc/handlers/sensory_visual.py
+++ b/src/openbad/reflex_arc/handlers/sensory_visual.py
@@ -1,0 +1,72 @@
+"""Visual attention reflex handler.
+
+Processes :class:`AttentionTrigger` events from the sensory dispatcher
+and decides whether to escalate to the cognitive engine (System 2).
+
+Examples of escalation-worthy visual triggers:
+- Error dialog detected on screen
+- Critical UI element changed
+- Rapid successive attention spikes
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from openbad.nervous_system.schemas import AttentionTrigger
+
+logger = logging.getLogger(__name__)
+
+# SSIM delta above which an event is considered critical
+DEFAULT_CRITICAL_DELTA = 0.5
+
+
+class VisualReflexHandler:
+    """Handle visual attention triggers from the sensory dispatcher.
+
+    Parameters
+    ----------
+    escalation_gw : object | None
+        Optional :class:`EscalationGateway` for System 1→2 escalation.
+    critical_delta : float
+        SSIM delta above which the event triggers escalation.
+    """
+
+    def __init__(
+        self,
+        escalation_gw: Any | None = None,
+        critical_delta: float = DEFAULT_CRITICAL_DELTA,
+    ) -> None:
+        self._escalation = escalation_gw
+        self._critical_delta = critical_delta
+        self._trigger_count: int = 0
+        self._escalation_count: int = 0
+
+    @property
+    def trigger_count(self) -> int:
+        return self._trigger_count
+
+    @property
+    def escalation_count(self) -> int:
+        return self._escalation_count
+
+    def handle(self, trigger: AttentionTrigger) -> bool:
+        """Evaluate an attention trigger and optionally escalate.
+
+        Returns True if the event was handled (always True for valid
+        triggers — escalation is an additional action).
+        """
+        self._trigger_count += 1
+
+        if trigger.ssim_delta >= self._critical_delta:
+            self._escalation_count += 1
+            if self._escalation is not None:
+                self._escalation.escalate(
+                    event_topic="agent/reflex/attention/trigger",
+                    event_payload=trigger.SerializeToString(),
+                    reason=f"High visual change: ssim_delta={trigger.ssim_delta:.3f}",
+                    reflex_id="sensory/visual",
+                )
+
+        return True

--- a/src/openbad/sensory/dispatcher.py
+++ b/src/openbad/sensory/dispatcher.py
@@ -1,0 +1,268 @@
+"""Sensory → reflex arc dispatcher.
+
+Subscribes to **all** sensory events (``agent/sensory/#``) and routes
+them to the appropriate reflex handlers.  The dispatcher respects the
+FSM state — during THROTTLED or EMERGENCY, non-critical sensory events
+are suppressed.
+
+The dispatcher sits between the sensory layer and the reflex arc,
+acting as a bridge that transforms raw perception events into reflex
+triggers.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from openbad.nervous_system.schemas import (
+    AttentionTrigger,
+    Header,
+    TranscriptionEvent,
+    WakeWordEvent,
+)
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult
+from openbad.nervous_system.topics import (
+    SENSORY_ATTENTION_TRIGGER,
+)
+
+logger = logging.getLogger(__name__)
+
+# Topics this dispatcher subscribes to
+SENSORY_WILDCARD = "agent/sensory/#"
+
+# FSM states where sensory events are suppressed
+_SUPPRESSED_STATES = frozenset({"THROTTLED", "EMERGENCY"})
+
+# Minimum confidence for transcription events to be routed
+DEFAULT_AUDIO_NOISE_FLOOR = 0.3
+
+# Maximum visual change events per minute before throttling
+DEFAULT_VISION_CHANGE_RATE_MAX = 30
+
+
+@dataclass
+class DispatcherConfig:
+    """Configuration for the sensory dispatcher.
+
+    Attributes
+    ----------
+    audio_noise_floor : float
+        Minimum transcription confidence to route.
+    vision_change_rate_max : int
+        Max visual attention events per minute.
+    """
+
+    audio_noise_floor: float = DEFAULT_AUDIO_NOISE_FLOOR
+    vision_change_rate_max: int = DEFAULT_VISION_CHANGE_RATE_MAX
+
+
+@dataclass
+class DispatchStats:
+    """Tracked statistics for the dispatcher."""
+
+    total_received: int = 0
+    total_dispatched: int = 0
+    total_suppressed: int = 0
+    vision_events: int = 0
+    audio_events: int = 0
+    wake_word_events: int = 0
+    below_threshold: int = 0
+    rate_limited: int = 0
+
+
+class SensoryDispatcher:
+    """Routes sensory events to reflex arc handlers.
+
+    Parameters
+    ----------
+    fsm : object | None
+        Optional :class:`AgentFSM` — checked for suppression state.
+    publish_fn : callable | None
+        Optional ``(topic, data) -> None``.
+    config : DispatcherConfig | None
+        Thresholds.  Defaults used if omitted.
+    visual_handler : callable | None
+        ``(AttentionTrigger) -> bool`` handler for vision events.
+    audio_handler : callable | None
+        ``(TranscriptionEvent) -> bool`` handler for audio events.
+    wake_word_handler : callable | None
+        ``(WakeWordEvent) -> bool`` handler for wake-word events.
+    """
+
+    def __init__(
+        self,
+        fsm: Any | None = None,
+        publish_fn: Any | None = None,
+        config: DispatcherConfig | None = None,
+        visual_handler: Any | None = None,
+        audio_handler: Any | None = None,
+        wake_word_handler: Any | None = None,
+    ) -> None:
+        self._fsm = fsm
+        self._publish = publish_fn
+        self._config = config or DispatcherConfig()
+        self._visual_handler = visual_handler
+        self._audio_handler = audio_handler
+        self._wake_word_handler = wake_word_handler
+        self._stats = DispatchStats()
+        self._vision_timestamps: list[float] = []
+
+    @property
+    def stats(self) -> DispatchStats:
+        return self._stats
+
+    def _is_suppressed(self) -> bool:
+        """Check if the FSM is in a state that suppresses sensory events."""
+        if self._fsm is None:
+            return False
+        state = getattr(self._fsm, "state", "IDLE")
+        return str(state).upper() in _SUPPRESSED_STATES
+
+    def _is_vision_rate_limited(self) -> bool:
+        """Check if visual events exceed the per-minute rate limit."""
+        now = time.monotonic()
+        # Prune timestamps older than 60s
+        self._vision_timestamps = [
+            t for t in self._vision_timestamps if now - t < 60
+        ]
+        return len(self._vision_timestamps) >= self._config.vision_change_rate_max
+
+    def dispatch(self, topic: str, payload: bytes) -> bool:
+        """Route a sensory event to the appropriate handler.
+
+        Returns True if the event was dispatched, False if suppressed
+        or filtered.
+        """
+        self._stats.total_received += 1
+
+        # Suppress in restricted FSM states
+        if self._is_suppressed():
+            self._stats.total_suppressed += 1
+            return False
+
+        # Route by topic
+        if topic == SENSORY_ATTENTION_TRIGGER:
+            return self._dispatch_visual(payload)
+
+        if topic.startswith("agent/sensory/audio/") and "tts" not in topic:
+            return self._dispatch_audio(payload)
+
+        # TTS complete and other topics — no routing needed
+        return False
+
+    def _dispatch_visual(self, payload: bytes) -> bool:
+        """Route a visual attention trigger."""
+        # Rate limit check
+        if self._is_vision_rate_limited():
+            self._stats.rate_limited += 1
+            return False
+
+        try:
+            trigger = AttentionTrigger()
+            trigger.ParseFromString(payload)
+        except Exception:
+            logger.warning("Failed to parse AttentionTrigger")
+            return False
+
+        self._vision_timestamps.append(time.monotonic())
+        self._stats.vision_events += 1
+
+        if self._visual_handler is not None:
+            handled = self._visual_handler(trigger)
+            if handled:
+                self._stats.total_dispatched += 1
+                self._publish_result(
+                    "sensory/visual",
+                    handled=True,
+                    action="visual_attention_routed",
+                )
+            return handled
+
+        self._stats.total_dispatched += 1
+        return True
+
+    def _dispatch_audio(self, payload: bytes) -> bool:
+        """Route an audio event (transcription or wake-word)."""
+        # Try wake word first — discriminate by score > 0
+        try:
+            ww = WakeWordEvent()
+            ww.ParseFromString(payload)
+            if ww.keyword and ww.score > 0:
+                self._stats.wake_word_events += 1
+                if self._wake_word_handler is not None:
+                    handled = self._wake_word_handler(ww)
+                    if handled:
+                        self._stats.total_dispatched += 1
+                        self._publish_result(
+                            "sensory/audio",
+                            handled=True,
+                            action=f"wake_word_detected: {ww.keyword}",
+                        )
+                    return handled
+                self._stats.total_dispatched += 1
+                return True
+        except Exception:
+            logger.debug("Payload is not a WakeWordEvent, trying TranscriptionEvent")
+
+        # Try transcription event
+        try:
+            te = TranscriptionEvent()
+            te.ParseFromString(payload)
+            if te.text:
+                self._stats.audio_events += 1
+
+                # Confidence gate
+                if te.confidence < self._config.audio_noise_floor:
+                    self._stats.below_threshold += 1
+                    return False
+
+                if self._audio_handler is not None:
+                    handled = self._audio_handler(te)
+                    if handled:
+                        self._stats.total_dispatched += 1
+                        self._publish_result(
+                            "sensory/audio",
+                            handled=True,
+                            action="transcription_routed",
+                        )
+                    return handled
+                self._stats.total_dispatched += 1
+                return True
+        except Exception:
+            logger.debug("Failed to parse audio payload as TranscriptionEvent")
+
+        return False
+
+    def _publish_result(
+        self,
+        reflex_id: str,
+        *,
+        handled: bool,
+        action: str,
+    ) -> None:
+        if self._publish is None:
+            return
+
+        result = ReflexResult(
+            header=Header(
+                timestamp_unix=time.time(),
+                source_module="sensory.dispatcher",
+                schema_version=1,
+            ),
+            reflex_id=reflex_id,
+            handled=handled,
+            action_taken=action,
+        )
+        topic = f"agent/reflex/{reflex_id}/result"
+        self._publish(topic, result.SerializeToString())
+
+    def subscribe(self, client: Any) -> None:
+        """Subscribe to all sensory topics on the given MQTT client."""
+
+        def _on_message(topic: str, payload: bytes) -> None:
+            self.dispatch(topic, payload)
+
+        client.subscribe(SENSORY_WILDCARD, _on_message)

--- a/tests/test_sensory_dispatcher.py
+++ b/tests/test_sensory_dispatcher.py
@@ -1,0 +1,248 @@
+"""Tests for sensory → reflex arc dispatcher — Issue #54."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from openbad.nervous_system.schemas import (
+    AttentionTrigger,
+    Header,
+    TranscriptionEvent,
+    WakeWordEvent,
+)
+from openbad.sensory.dispatcher import (
+    DispatcherConfig,
+    SensoryDispatcher,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_attention_payload(ssim_delta: float = 0.6) -> bytes:
+    return AttentionTrigger(
+        header=Header(timestamp_unix=time.time(), source_module="test"),
+        source_id="screen0",
+        ssim_delta=ssim_delta,
+        region_description="test region",
+    ).SerializeToString()
+
+
+def _make_transcription_payload(
+    text: str = "hello world", confidence: float = 0.9,
+) -> bytes:
+    return TranscriptionEvent(
+        header=Header(timestamp_unix=time.time(), source_module="test"),
+        source_id="mic",
+        text=text,
+        confidence=confidence,
+        is_final=True,
+    ).SerializeToString()
+
+
+def _make_wake_word_payload(keyword: str = "hey agent") -> bytes:
+    return WakeWordEvent(
+        header=Header(timestamp_unix=time.time(), source_module="test"),
+        keyword=keyword,
+        score=0.95,
+    ).SerializeToString()
+
+
+def _mock_fsm(state: str = "ACTIVE") -> SimpleNamespace:
+    return SimpleNamespace(state=state)
+
+
+# ---------------------------------------------------------------------------
+# DispatcherConfig
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherConfig:
+    def test_defaults(self) -> None:
+        cfg = DispatcherConfig()
+        assert cfg.audio_noise_floor == 0.3
+        assert cfg.vision_change_rate_max == 30
+
+    def test_custom(self) -> None:
+        cfg = DispatcherConfig(audio_noise_floor=0.5, vision_change_rate_max=10)
+        assert cfg.audio_noise_floor == 0.5
+
+
+# ---------------------------------------------------------------------------
+# SensoryDispatcher — basic routing
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherRouting:
+    def test_visual_trigger(self) -> None:
+        d = SensoryDispatcher()
+        result = d.dispatch("agent/reflex/attention/trigger", _make_attention_payload())
+        assert result is True
+        assert d.stats.vision_events == 1
+        assert d.stats.total_dispatched == 1
+
+    def test_audio_transcription(self) -> None:
+        d = SensoryDispatcher()
+        result = d.dispatch("agent/sensory/audio/mic", _make_transcription_payload())
+        assert result is True
+        assert d.stats.audio_events == 1
+
+    def test_tts_ignored(self) -> None:
+        d = SensoryDispatcher()
+        result = d.dispatch("agent/sensory/audio/tts/complete", b"\x00")
+        assert result is False
+
+    def test_unknown_topic(self) -> None:
+        d = SensoryDispatcher()
+        result = d.dispatch("agent/sensory/video/unknown", b"\x00")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# FSM suppression
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherSuppression:
+    def test_throttled_suppresses(self) -> None:
+        fsm = _mock_fsm("THROTTLED")
+        d = SensoryDispatcher(fsm=fsm)
+        result = d.dispatch("agent/reflex/attention/trigger", _make_attention_payload())
+        assert result is False
+        assert d.stats.total_suppressed == 1
+
+    def test_emergency_suppresses(self) -> None:
+        fsm = _mock_fsm("EMERGENCY")
+        d = SensoryDispatcher(fsm=fsm)
+        result = d.dispatch("agent/sensory/audio/mic", _make_transcription_payload())
+        assert result is False
+
+    def test_active_allows(self) -> None:
+        fsm = _mock_fsm("ACTIVE")
+        d = SensoryDispatcher(fsm=fsm)
+        result = d.dispatch("agent/reflex/attention/trigger", _make_attention_payload())
+        assert result is True
+
+    def test_idle_allows(self) -> None:
+        fsm = _mock_fsm("IDLE")
+        d = SensoryDispatcher(fsm=fsm)
+        result = d.dispatch("agent/reflex/attention/trigger", _make_attention_payload())
+        assert result is True
+
+    def test_no_fsm_allows(self) -> None:
+        d = SensoryDispatcher(fsm=None)
+        result = d.dispatch("agent/reflex/attention/trigger", _make_attention_payload())
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Confidence gating
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherConfidenceGating:
+    def test_low_confidence_filtered(self) -> None:
+        d = SensoryDispatcher(config=DispatcherConfig(audio_noise_floor=0.5))
+        payload = _make_transcription_payload(confidence=0.2)
+        result = d.dispatch("agent/sensory/audio/mic", payload)
+        assert result is False
+        assert d.stats.below_threshold == 1
+
+    def test_at_threshold_passes(self) -> None:
+        d = SensoryDispatcher(config=DispatcherConfig(audio_noise_floor=0.5))
+        payload = _make_transcription_payload(confidence=0.5)
+        result = d.dispatch("agent/sensory/audio/mic", payload)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Vision rate limiting
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherVisionRateLimit:
+    def test_rate_limited(self) -> None:
+        cfg = DispatcherConfig(vision_change_rate_max=3)
+        d = SensoryDispatcher(config=cfg)
+        payload = _make_attention_payload()
+
+        # First 3 should pass
+        for _ in range(3):
+            assert d.dispatch("agent/reflex/attention/trigger", payload) is True
+
+        # 4th should be rate limited
+        assert d.dispatch("agent/reflex/attention/trigger", payload) is False
+        assert d.stats.rate_limited == 1
+
+
+# ---------------------------------------------------------------------------
+# Custom handlers
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherHandlers:
+    def test_visual_handler_called(self) -> None:
+        handler = MagicMock(return_value=True)
+        d = SensoryDispatcher(visual_handler=handler)
+        d.dispatch("agent/reflex/attention/trigger", _make_attention_payload())
+        handler.assert_called_once()
+        assert d.stats.total_dispatched == 1
+
+    def test_audio_handler_called(self) -> None:
+        handler = MagicMock(return_value=True)
+        d = SensoryDispatcher(audio_handler=handler)
+        d.dispatch("agent/sensory/audio/mic", _make_transcription_payload())
+        handler.assert_called_once()
+
+    def test_wake_word_handler_called(self) -> None:
+        handler = MagicMock(return_value=True)
+        d = SensoryDispatcher(wake_word_handler=handler)
+        d.dispatch("agent/sensory/audio/mic", _make_wake_word_payload())
+        handler.assert_called_once()
+        assert d.stats.wake_word_events == 1
+
+    def test_handler_returning_false(self) -> None:
+        handler = MagicMock(return_value=False)
+        d = SensoryDispatcher(visual_handler=handler)
+        result = d.dispatch("agent/reflex/attention/trigger", _make_attention_payload())
+        assert result is False
+        assert d.stats.total_dispatched == 0
+
+
+# ---------------------------------------------------------------------------
+# Publish result
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherPublish:
+    def test_publishes_result_on_visual(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        def pub(topic: str, data: bytes) -> None:
+            published.append((topic, data))
+
+        handler = MagicMock(return_value=True)
+        d = SensoryDispatcher(publish_fn=pub, visual_handler=handler)
+        d.dispatch("agent/reflex/attention/trigger", _make_attention_payload())
+
+        assert len(published) == 1
+        assert published[0][0] == "agent/reflex/sensory/visual/result"
+
+
+# ---------------------------------------------------------------------------
+# Subscribe
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherSubscribe:
+    def test_subscribe(self) -> None:
+        client = MagicMock()
+        d = SensoryDispatcher()
+        d.subscribe(client)
+        client.subscribe.assert_called_once()
+        args = client.subscribe.call_args[0]
+        assert args[0] == "agent/sensory/#"
+        assert callable(args[1])

--- a/tests/test_sensory_handlers.py
+++ b/tests/test_sensory_handlers.py
@@ -1,0 +1,138 @@
+"""Tests for visual and audio sensory reflex handlers — Issue #54."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from openbad.nervous_system.schemas import (
+    AttentionTrigger,
+    Header,
+    TranscriptionEvent,
+    WakeWordEvent,
+)
+from openbad.reflex_arc.handlers.sensory_audio import AudioReflexHandler
+from openbad.reflex_arc.handlers.sensory_visual import VisualReflexHandler
+
+# ---------------------------------------------------------------------------
+# VisualReflexHandler
+# ---------------------------------------------------------------------------
+
+
+class TestVisualReflexHandler:
+    def _trigger(self, ssim_delta: float = 0.6) -> AttentionTrigger:
+        return AttentionTrigger(
+            header=Header(timestamp_unix=time.time(), source_module="test"),
+            source_id="screen0",
+            ssim_delta=ssim_delta,
+        )
+
+    def test_handle_always_returns_true(self) -> None:
+        h = VisualReflexHandler()
+        assert h.handle(self._trigger(0.1)) is True
+        assert h.trigger_count == 1
+
+    def test_no_escalation_below_threshold(self) -> None:
+        esc = MagicMock()
+        h = VisualReflexHandler(escalation_gw=esc, critical_delta=0.5)
+        h.handle(self._trigger(0.3))
+        esc.escalate.assert_not_called()
+        assert h.escalation_count == 0
+
+    def test_escalation_above_threshold(self) -> None:
+        esc = MagicMock()
+        h = VisualReflexHandler(escalation_gw=esc, critical_delta=0.5)
+        h.handle(self._trigger(0.7))
+        esc.escalate.assert_called_once()
+        assert h.escalation_count == 1
+
+    def test_escalation_at_threshold(self) -> None:
+        esc = MagicMock()
+        h = VisualReflexHandler(escalation_gw=esc, critical_delta=0.5)
+        h.handle(self._trigger(0.5))
+        esc.escalate.assert_called_once()
+
+    def test_no_escalation_gw(self) -> None:
+        h = VisualReflexHandler(escalation_gw=None, critical_delta=0.5)
+        # Should not raise even with high delta
+        assert h.handle(self._trigger(0.9)) is True
+        assert h.escalation_count == 1
+
+    def test_count_accumulates(self) -> None:
+        h = VisualReflexHandler()
+        h.handle(self._trigger(0.1))
+        h.handle(self._trigger(0.2))
+        assert h.trigger_count == 2
+
+
+# ---------------------------------------------------------------------------
+# AudioReflexHandler
+# ---------------------------------------------------------------------------
+
+
+class TestAudioReflexHandler:
+    def _wake_word(self, keyword: str = "hey agent") -> WakeWordEvent:
+        return WakeWordEvent(
+            header=Header(timestamp_unix=time.time(), source_module="test"),
+            keyword=keyword,
+            score=0.95,
+        )
+
+    def _transcription(
+        self, text: str = "open the file", confidence: float = 0.9,
+    ) -> TranscriptionEvent:
+        return TranscriptionEvent(
+            header=Header(timestamp_unix=time.time(), source_module="test"),
+            source_id="mic",
+            text=text,
+            confidence=confidence,
+            is_final=True,
+        )
+
+    def test_wake_word_activates_fsm(self) -> None:
+        fsm = MagicMock()
+        h = AudioReflexHandler(fsm=fsm)
+        assert h.handle_wake_word(self._wake_word()) is True
+        fsm.fire.assert_called_once_with("activate")
+        assert h.wake_count == 1
+
+    def test_wake_word_escalates(self) -> None:
+        esc = MagicMock()
+        h = AudioReflexHandler(escalation_gw=esc)
+        h.handle_wake_word(self._wake_word())
+        esc.escalate.assert_called_once()
+        assert h.escalation_count == 1
+
+    def test_wake_word_fsm_error_tolerated(self) -> None:
+        fsm = MagicMock()
+        fsm.fire.side_effect = RuntimeError("already active")
+        h = AudioReflexHandler(fsm=fsm)
+        assert h.handle_wake_word(self._wake_word()) is True
+
+    def test_transcription_high_conf_escalates(self) -> None:
+        esc = MagicMock()
+        h = AudioReflexHandler(escalation_gw=esc, escalation_confidence=0.7)
+        h.handle_transcription(self._transcription(confidence=0.9))
+        esc.escalate.assert_called_once()
+        assert h.escalation_count == 1
+        assert h.transcription_count == 1
+
+    def test_transcription_low_conf_no_escalation(self) -> None:
+        esc = MagicMock()
+        h = AudioReflexHandler(escalation_gw=esc, escalation_confidence=0.7)
+        h.handle_transcription(self._transcription(confidence=0.5))
+        esc.escalate.assert_not_called()
+        assert h.transcription_count == 1
+        assert h.escalation_count == 0
+
+    def test_no_esc_gw(self) -> None:
+        h = AudioReflexHandler(escalation_gw=None)
+        assert h.handle_transcription(self._transcription(confidence=0.9)) is True
+
+    def test_counts_accumulate(self) -> None:
+        h = AudioReflexHandler()
+        h.handle_wake_word(self._wake_word())
+        h.handle_wake_word(self._wake_word())
+        h.handle_transcription(self._transcription())
+        assert h.wake_count == 2
+        assert h.transcription_count == 1


### PR DESCRIPTION
Closes #54

Adds SensoryDispatcher that routes vision/audio events from the sensory wildcard topic to reflex arc handlers. Includes:
- DispatcherConfig with audio noise floor and vision rate limit
- FSM state suppression (THROTTLED/EMERGENCY)
- VisualReflexHandler with escalation on high ssim_delta
- AudioReflexHandler with FSM activation on wake word and escalation on high-confidence transcription
- Sensory thresholds in threshold_policies.yaml

## How to test
```n.venv/Scripts/python.exe -m pytest tests/test_sensory_dispatcher.py tests/test_sensory_handlers.py -v
```