### PR TITLE
#69: Add immune system scaffold, protos, topics, and config

### DIFF
--- a/config/immune.yaml
+++ b/config/immune.yaml
@@ -1,0 +1,21 @@
+# Immune system configuration — Phase 3
+# See src/openbad/immune_system/config.py for field descriptions.
+
+immune:
+  enabled: true
+  scan_timeout_ms: 100
+
+  rules:
+    rules_path: "config/immune_rules.yaml"
+    max_scan_ms: 50
+
+  classifier:
+    base_url: "http://localhost:11434"
+    model: "llama3.2"
+    timeout_ms: 500
+    confidence_threshold: 0.7
+
+  quarantine:
+    quarantine_dir: "quarantine"
+    encryption_key_env: "OPENBAD_QUARANTINE_KEY"
+    max_payload_bytes: 10485760   # 10 MB

--- a/src/openbad/immune_system/__init__.py
+++ b/src/openbad/immune_system/__init__.py
@@ -1,0 +1,1 @@
+"""Digital immune system (amygdala) — threat detection, quarantine, and adaptive memory."""

--- a/src/openbad/immune_system/config.py
+++ b/src/openbad/immune_system/config.py
@@ -1,0 +1,69 @@
+"""Immune system configuration — detection thresholds, model paths, quarantine settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass(frozen=True)
+class RulesConfig:
+    """Configuration for the regex rules engine."""
+
+    rules_path: str = "config/immune_rules.yaml"
+    max_scan_ms: int = 50
+
+
+@dataclass(frozen=True)
+class ClassifierConfig:
+    """Configuration for the Ollama-based prompt injection classifier."""
+
+    base_url: str = "http://localhost:11434"
+    model: str = "llama3.2"
+    timeout_ms: int = 500
+    confidence_threshold: float = 0.7
+
+
+@dataclass(frozen=True)
+class QuarantineConfig:
+    """Configuration for the quarantine subsystem."""
+
+    quarantine_dir: str = "quarantine"
+    encryption_key_env: str = "OPENBAD_QUARANTINE_KEY"
+    max_payload_bytes: int = 10 * 1024 * 1024  # 10 MB
+
+
+@dataclass(frozen=True)
+class ImmuneConfig:
+    """Top-level immune system configuration."""
+
+    rules: RulesConfig = field(default_factory=RulesConfig)
+    classifier: ClassifierConfig = field(default_factory=ClassifierConfig)
+    quarantine: QuarantineConfig = field(default_factory=QuarantineConfig)
+    scan_timeout_ms: int = 100
+    enabled: bool = True
+
+
+def load_immune_config(yaml_path: str | Path = "config/immune.yaml") -> ImmuneConfig:
+    """Load immune system config from a YAML file, falling back to defaults."""
+    path = Path(yaml_path)
+    if not path.exists():
+        return ImmuneConfig()
+
+    with open(path) as f:  # noqa: S108
+        data = yaml.safe_load(f) or {}
+
+    immune = data.get("immune", {})
+    rules_data = immune.get("rules", {})
+    classifier_data = immune.get("classifier", {})
+    quarantine_data = immune.get("quarantine", {})
+
+    return ImmuneConfig(
+        rules=RulesConfig(**rules_data),
+        classifier=ClassifierConfig(**classifier_data),
+        quarantine=QuarantineConfig(**quarantine_data),
+        scan_timeout_ms=immune.get("scan_timeout_ms", 100),
+        enabled=immune.get("enabled", True),
+    )

--- a/src/openbad/nervous_system/schemas/__init__.py
+++ b/src/openbad/nervous_system/schemas/__init__.py
@@ -3,7 +3,13 @@
 from openbad.nervous_system.schemas.cognitive_pb2 import CognitiveResult, EscalationRequest
 from openbad.nervous_system.schemas.common_pb2 import Header, Priority, Severity
 from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
-from openbad.nervous_system.schemas.immune_pb2 import ImmuneAlert, QuarantineEvent
+from openbad.nervous_system.schemas.immune_pb2 import (
+    ImmuneAlert,
+    QuarantineEvent,
+    ScanResult,
+    ThreatDetection,
+    ThreatType,
+)
 from openbad.nervous_system.schemas.memory_pb2 import LtmConsolidate, StmWrite
 from openbad.nervous_system.schemas.reflex_pb2 import ReflexResult, ReflexState, ReflexTrigger
 from openbad.nervous_system.schemas.sensory_pb2 import (
@@ -46,8 +52,11 @@ __all__ = [
     "ReflexResult",
     "ReflexState",
     "ReflexTrigger",
+    "ScanResult",
     "Severity",
     "StmWrite",
+    "ThreatDetection",
+    "ThreatType",
     "TokenTelemetry",
     "TranscriptionEvent",
     "TTSComplete",

--- a/src/openbad/nervous_system/schemas/immune.proto
+++ b/src/openbad/nervous_system/schemas/immune.proto
@@ -3,6 +3,39 @@ package openbad;
 
 import "common.proto";
 
+// Threat type classification for immune detections.
+enum ThreatType {
+  THREAT_TYPE_UNSPECIFIED = 0;
+  PROMPT_INJECTION = 1;
+  INSTRUCTION_OVERRIDE = 2;
+  DATA_EXFILTRATION = 3;
+  SSRF_ATTEMPT = 4;
+  SCHEMA_VIOLATION = 5;
+  PRIVILEGE_ESCALATION = 6;
+  ENCODED_PAYLOAD = 7;
+  DELIMITER_ESCAPE = 8;
+}
+
+// Result of scanning a single payload through the immune pipeline.
+// Published on: agent/immune/scan
+message ScanResult {
+  Header header = 1;
+  string payload_hash = 2;          // SHA-256 hash of the scanned payload.
+  bool   is_threat = 3;             // True if any detector flagged the payload.
+  repeated ThreatDetection detections = 4;  // Individual threat detections.
+  double scan_latency_ms = 5;       // Total scan time in milliseconds.
+  string source_topic = 6;          // MQTT topic the payload arrived on.
+}
+
+// Individual threat detection from a specific detector.
+message ThreatDetection {
+  string detector = 1;              // e.g. "rules_engine", "anomaly_detector", "model_classifier".
+  ThreatType threat_type = 2;
+  double confidence = 3;            // 0.0–1.0 confidence score.
+  string rule_name = 4;             // Name of the matched rule (if rules engine).
+  string detail = 5;                // Human-readable description.
+}
+
 // Published on: agent/immune/alert
 message ImmuneAlert {
   Header header = 1;

--- a/src/openbad/nervous_system/schemas/immune_pb2.py
+++ b/src/openbad/nervous_system/schemas/immune_pb2.py
@@ -25,15 +25,21 @@ _sym_db = _symbol_database.Default()
 from . import common_pb2 as common__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cimmune.proto\x12\x07openbad\x1a\x0c\x63ommon.proto\"\x9d\x01\n\x0bImmuneAlert\x12\x1f\n\x06header\x18\x01 \x01(\x0b\x32\x0f.openbad.Header\x12#\n\x08severity\x18\x02 \x01(\x0e\x32\x11.openbad.Severity\x12\x13\n\x0bthreat_type\x18\x03 \x01(\t\x12\x11\n\tsource_id\x18\x04 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x05 \x01(\t\x12\x10\n\x08\x65vidence\x18\x06 \x01(\x0c\"\x8a\x01\n\x0fQuarantineEvent\x12\x1f\n\x06header\x18\x01 \x01(\x0b\x32\x0f.openbad.Header\x12\x11\n\tsource_id\x18\x02 \x01(\t\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x14\n\x0c\x61\x63tion_taken\x18\x04 \x01(\t\x12\x1d\n\x15quarantine_until_unix\x18\x05 \x01(\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cimmune.proto\x12\x07openbad\x1a\x0c\x63ommon.proto\"\xb3\x01\n\nScanResult\x12\x1f\n\x06header\x18\x01 \x01(\x0b\x32\x0f.openbad.Header\x12\x14\n\x0cpayload_hash\x18\x02 \x01(\t\x12\x11\n\tis_threat\x18\x03 \x01(\x08\x12,\n\ndetections\x18\x04 \x03(\x0b\x32\x18.openbad.ThreatDetection\x12\x17\n\x0fscan_latency_ms\x18\x05 \x01(\x01\x12\x14\n\x0csource_topic\x18\x06 \x01(\t\"\x84\x01\n\x0fThreatDetection\x12\x10\n\x08\x64\x65tector\x18\x01 \x01(\t\x12(\n\x0bthreat_type\x18\x02 \x01(\x0e\x32\x13.openbad.ThreatType\x12\x12\n\nconfidence\x18\x03 \x01(\x01\x12\x11\n\trule_name\x18\x04 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x05 \x01(\t\"\x9d\x01\n\x0bImmuneAlert\x12\x1f\n\x06header\x18\x01 \x01(\x0b\x32\x0f.openbad.Header\x12#\n\x08severity\x18\x02 \x01(\x0e\x32\x11.openbad.Severity\x12\x13\n\x0bthreat_type\x18\x03 \x01(\t\x12\x11\n\tsource_id\x18\x04 \x01(\t\x12\x0e\n\x06\x64\x65tail\x18\x05 \x01(\t\x12\x10\n\x08\x65vidence\x18\x06 \x01(\x0c\"\x8a\x01\n\x0fQuarantineEvent\x12\x1f\n\x06header\x18\x01 \x01(\x0b\x32\x0f.openbad.Header\x12\x11\n\tsource_id\x18\x02 \x01(\t\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x14\n\x0c\x61\x63tion_taken\x18\x04 \x01(\t\x12\x1d\n\x15quarantine_until_unix\x18\x05 \x01(\x01*\xdd\x01\n\nThreatType\x12\x1b\n\x17THREAT_TYPE_UNSPECIFIED\x10\x00\x12\x14\n\x10PROMPT_INJECTION\x10\x01\x12\x18\n\x14INSTRUCTION_OVERRIDE\x10\x02\x12\x15\n\x11\x44\x41TA_EXFILTRATION\x10\x03\x12\x10\n\x0cSSRF_ATTEMPT\x10\x04\x12\x14\n\x10SCHEMA_VIOLATION\x10\x05\x12\x18\n\x14PRIVILEGE_ESCALATION\x10\x06\x12\x13\n\x0f\x45NCODED_PAYLOAD\x10\x07\x12\x14\n\x10\x44\x45LIMITER_ESCAPE\x10\x08\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'immune_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_IMMUNEALERT']._serialized_start=40
-  _globals['_IMMUNEALERT']._serialized_end=197
-  _globals['_QUARANTINEEVENT']._serialized_start=200
-  _globals['_QUARANTINEEVENT']._serialized_end=338
+  _globals['_THREATTYPE']._serialized_start=658
+  _globals['_THREATTYPE']._serialized_end=879
+  _globals['_SCANRESULT']._serialized_start=40
+  _globals['_SCANRESULT']._serialized_end=219
+  _globals['_THREATDETECTION']._serialized_start=222
+  _globals['_THREATDETECTION']._serialized_end=354
+  _globals['_IMMUNEALERT']._serialized_start=357
+  _globals['_IMMUNEALERT']._serialized_end=514
+  _globals['_QUARANTINEEVENT']._serialized_start=517
+  _globals['_QUARANTINEEVENT']._serialized_end=655
 # @@protoc_insertion_point(module_scope)

--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -63,8 +63,14 @@ COGNITIVE_RESULT = "agent/cognitive/result"
 # ---------------------------------------------------------------------------
 # Immune system
 # ---------------------------------------------------------------------------
+IMMUNE_SCAN = "agent/immune/scan"
+IMMUNE_THREAT = "agent/immune/threat"
 IMMUNE_ALERT = "agent/immune/alert"
 IMMUNE_QUARANTINE = "agent/immune/quarantine"
+IMMUNE_CLEARED = "agent/immune/cleared"
+
+# Wildcard: all immune events
+IMMUNE_ALL = "agent/immune/+"
 
 # ---------------------------------------------------------------------------
 # Endocrine (hormone channels)
@@ -123,8 +129,11 @@ STATIC_TOPICS: tuple[str, ...] = (
     REFLEX_STATE,
     COGNITIVE_ESCALATION,
     COGNITIVE_RESULT,
+    IMMUNE_SCAN,
+    IMMUNE_THREAT,
     IMMUNE_ALERT,
     IMMUNE_QUARANTINE,
+    IMMUNE_CLEARED,
     ENDOCRINE_CORTISOL,
     ENDOCRINE_ADRENALINE,
     ENDOCRINE_ENDORPHIN,
@@ -151,6 +160,7 @@ WILDCARD_TOPICS: tuple[str, ...] = (
     SENSORY_ALL,
     SENSORY_VISION_ALL,
     SENSORY_AUDIO_ALL,
+    IMMUNE_ALL,
     ENDOCRINE_ALL,
     MEMORY_ALL,
     SLEEP_ALL,

--- a/tests/test_immune_config.py
+++ b/tests/test_immune_config.py
@@ -1,0 +1,121 @@
+"""Tests for openbad.immune_system.config — immune system configuration."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from openbad.immune_system.config import (
+    ClassifierConfig,
+    ImmuneConfig,
+    QuarantineConfig,
+    RulesConfig,
+    load_immune_config,
+)
+
+# ---------------------------------------------------------------------------
+# Default config
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultConfig:
+    def test_immune_config_defaults(self) -> None:
+        cfg = ImmuneConfig()
+        assert cfg.enabled is True
+        assert cfg.scan_timeout_ms == 100
+
+    def test_rules_defaults(self) -> None:
+        cfg = RulesConfig()
+        assert cfg.rules_path == "config/immune_rules.yaml"
+        assert cfg.max_scan_ms == 50
+
+    def test_classifier_defaults(self) -> None:
+        cfg = ClassifierConfig()
+        assert cfg.base_url == "http://localhost:11434"
+        assert cfg.model == "llama3.2"
+        assert cfg.timeout_ms == 500
+        assert cfg.confidence_threshold == 0.7
+
+    def test_quarantine_defaults(self) -> None:
+        cfg = QuarantineConfig()
+        assert cfg.quarantine_dir == "quarantine"
+        assert cfg.encryption_key_env == "OPENBAD_QUARANTINE_KEY"
+        assert cfg.max_payload_bytes == 10 * 1024 * 1024
+
+    def test_nested_defaults(self) -> None:
+        cfg = ImmuneConfig()
+        assert isinstance(cfg.rules, RulesConfig)
+        assert isinstance(cfg.classifier, ClassifierConfig)
+        assert isinstance(cfg.quarantine, QuarantineConfig)
+
+    def test_frozen(self) -> None:
+        cfg = ImmuneConfig()
+        try:
+            cfg.enabled = False  # type: ignore[misc]
+            raised = False
+        except AttributeError:
+            raised = True
+        assert raised
+
+
+# ---------------------------------------------------------------------------
+# Load from YAML
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_load_missing_file_returns_defaults(self, tmp_path: Path) -> None:
+        cfg = load_immune_config(tmp_path / "nonexistent.yaml")
+        assert cfg == ImmuneConfig()
+
+    def test_load_empty_file_returns_defaults(self, tmp_path: Path) -> None:
+        yaml_path = tmp_path / "empty.yaml"
+        yaml_path.write_text("")
+        cfg = load_immune_config(yaml_path)
+        assert cfg == ImmuneConfig()
+
+    def test_load_partial_config(self, tmp_path: Path) -> None:
+        yaml_path = tmp_path / "partial.yaml"
+        yaml_path.write_text(
+            textwrap.dedent("""\
+            immune:
+              enabled: false
+              scan_timeout_ms: 200
+        """)
+        )
+        cfg = load_immune_config(yaml_path)
+        assert cfg.enabled is False
+        assert cfg.scan_timeout_ms == 200
+        # Nested should still be defaults
+        assert cfg.rules == RulesConfig()
+        assert cfg.classifier == ClassifierConfig()
+
+    def test_load_full_config(self, tmp_path: Path) -> None:
+        yaml_path = tmp_path / "full.yaml"
+        yaml_path.write_text(
+            textwrap.dedent("""\
+            immune:
+              enabled: true
+              scan_timeout_ms: 75
+              rules:
+                rules_path: "custom/rules.yaml"
+                max_scan_ms: 25
+              classifier:
+                base_url: "http://remote:11434"
+                model: "phi3"
+                timeout_ms: 300
+                confidence_threshold: 0.9
+              quarantine:
+                quarantine_dir: "/var/quarantine"
+                encryption_key_env: "CUSTOM_KEY"
+                max_payload_bytes: 5242880
+        """)
+        )
+        cfg = load_immune_config(yaml_path)
+        assert cfg.scan_timeout_ms == 75
+        assert cfg.rules.rules_path == "custom/rules.yaml"
+        assert cfg.rules.max_scan_ms == 25
+        assert cfg.classifier.base_url == "http://remote:11434"
+        assert cfg.classifier.model == "phi3"
+        assert cfg.quarantine.quarantine_dir == "/var/quarantine"
+        assert cfg.quarantine.max_payload_bytes == 5242880

--- a/tests/test_immune_protos.py
+++ b/tests/test_immune_protos.py
@@ -1,0 +1,173 @@
+"""Tests for immune system proto messages and topic definitions."""
+
+from __future__ import annotations
+
+import time
+
+from openbad.nervous_system.schemas import (
+    Header,
+    ImmuneAlert,
+    QuarantineEvent,
+    ScanResult,
+    Severity,
+    ThreatDetection,
+    ThreatType,
+)
+from openbad.nervous_system.topics import (
+    IMMUNE_ALERT,
+    IMMUNE_ALL,
+    IMMUNE_CLEARED,
+    IMMUNE_QUARANTINE,
+    IMMUNE_SCAN,
+    IMMUNE_THREAT,
+    STATIC_TOPICS,
+    WILDCARD_TOPICS,
+)
+
+# ---------------------------------------------------------------------------
+# Proto round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def _header() -> Header:
+    return Header(
+        timestamp_unix=time.time(),
+        source_module="immune_system",
+        correlation_id="test-001",
+        schema_version=1,
+    )
+
+
+class TestScanResultProto:
+    def test_serialize_deserialize(self) -> None:
+        msg = ScanResult(
+            header=_header(),
+            payload_hash="abc123",
+            is_threat=True,
+            detections=[
+                ThreatDetection(
+                    detector="rules_engine",
+                    threat_type=ThreatType.PROMPT_INJECTION,
+                    confidence=0.95,
+                    rule_name="instruction_override",
+                    detail="Detected 'ignore previous instructions'",
+                ),
+            ],
+            scan_latency_ms=12.5,
+            source_topic="agent/sensory/vision/screen0/parsed",
+        )
+        data = msg.SerializeToString()
+        restored = ScanResult()
+        restored.ParseFromString(data)
+        assert restored.payload_hash == "abc123"
+        assert restored.is_threat is True
+        assert len(restored.detections) == 1
+        assert restored.detections[0].threat_type == ThreatType.PROMPT_INJECTION
+        assert restored.detections[0].confidence == 0.95
+        assert restored.scan_latency_ms == 12.5
+
+    def test_empty_detections(self) -> None:
+        msg = ScanResult(
+            header=_header(),
+            payload_hash="def456",
+            is_threat=False,
+        )
+        data = msg.SerializeToString()
+        restored = ScanResult()
+        restored.ParseFromString(data)
+        assert restored.is_threat is False
+        assert len(restored.detections) == 0
+
+
+class TestThreatDetectionProto:
+    def test_all_threat_types(self) -> None:
+        for tt in [
+            ThreatType.PROMPT_INJECTION,
+            ThreatType.INSTRUCTION_OVERRIDE,
+            ThreatType.DATA_EXFILTRATION,
+            ThreatType.SSRF_ATTEMPT,
+            ThreatType.SCHEMA_VIOLATION,
+            ThreatType.PRIVILEGE_ESCALATION,
+            ThreatType.ENCODED_PAYLOAD,
+            ThreatType.DELIMITER_ESCAPE,
+        ]:
+            det = ThreatDetection(
+                detector="test",
+                threat_type=tt,
+                confidence=0.9,
+            )
+            data = det.SerializeToString()
+            restored = ThreatDetection()
+            restored.ParseFromString(data)
+            assert restored.threat_type == tt
+
+
+class TestImmuneAlertProto:
+    def test_serialize_deserialize(self) -> None:
+        msg = ImmuneAlert(
+            header=_header(),
+            severity=Severity.CRITICAL,
+            threat_type="prompt-injection",
+            source_id="vision-parser",
+            detail="Blocked injection attempt",
+            evidence=b"raw evidence data",
+        )
+        data = msg.SerializeToString()
+        restored = ImmuneAlert()
+        restored.ParseFromString(data)
+        assert restored.severity == Severity.CRITICAL
+        assert restored.threat_type == "prompt-injection"
+        assert restored.evidence == b"raw evidence data"
+
+
+class TestQuarantineEventProto:
+    def test_serialize_deserialize(self) -> None:
+        now = time.time()
+        msg = QuarantineEvent(
+            header=_header(),
+            source_id="tool-xyz",
+            reason="Prompt injection detected",
+            action_taken="payload-quarantined",
+            quarantine_until_unix=now + 3600,
+        )
+        data = msg.SerializeToString()
+        restored = QuarantineEvent()
+        restored.ParseFromString(data)
+        assert restored.source_id == "tool-xyz"
+        assert restored.reason == "Prompt injection detected"
+        assert restored.quarantine_until_unix > now
+
+
+# ---------------------------------------------------------------------------
+# Topic tests
+# ---------------------------------------------------------------------------
+
+
+class TestImmuneTopics:
+    def test_topic_values(self) -> None:
+        assert IMMUNE_SCAN == "agent/immune/scan"
+        assert IMMUNE_THREAT == "agent/immune/threat"
+        assert IMMUNE_ALERT == "agent/immune/alert"
+        assert IMMUNE_QUARANTINE == "agent/immune/quarantine"
+        assert IMMUNE_CLEARED == "agent/immune/cleared"
+
+    def test_wildcard(self) -> None:
+        assert IMMUNE_ALL == "agent/immune/+"
+
+    def test_scan_in_static_topics(self) -> None:
+        assert IMMUNE_SCAN in STATIC_TOPICS
+
+    def test_threat_in_static_topics(self) -> None:
+        assert IMMUNE_THREAT in STATIC_TOPICS
+
+    def test_alert_in_static_topics(self) -> None:
+        assert IMMUNE_ALERT in STATIC_TOPICS
+
+    def test_quarantine_in_static_topics(self) -> None:
+        assert IMMUNE_QUARANTINE in STATIC_TOPICS
+
+    def test_cleared_in_static_topics(self) -> None:
+        assert IMMUNE_CLEARED in STATIC_TOPICS
+
+    def test_wildcard_in_wildcard_topics(self) -> None:
+        assert IMMUNE_ALL in WILDCARD_TOPICS


### PR DESCRIPTION
Closes #69

## Summary
- Created `src/openbad/immune_system/` package with `__init__.py` and `config.py`
- Extended `immune.proto` with `ThreatType` enum, `ScanResult`, and `ThreatDetection` messages
- Added new topics: `IMMUNE_SCAN`, `IMMUNE_THREAT`, `IMMUNE_CLEARED`, `IMMUNE_ALL`
- Created `config/immune.yaml` with defaults
- Created `quarantine/.gitkeep` directory
- Updated schemas `__init__.py` to export new proto types
- 23 new tests (config loading + proto round-trip + topic validation)

## How to Test
```bash
pytest tests/test_immune_config.py tests/test_immune_protos.py -v
```