### PR TITLE
#71: Add structural anomaly detector

### DIFF
--- a/src/openbad/immune_system/anomaly_detector.py
+++ b/src/openbad/immune_system/anomaly_detector.py
@@ -1,0 +1,246 @@
+"""Structural anomaly detector — SSRF, exfiltration, schema, and privilege checks."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+from google.protobuf.message import DecodeError, Message
+
+
+@dataclass(frozen=True)
+class AnomalyResult:
+    """A single anomaly finding."""
+
+    anomaly_type: str
+    severity: str
+    detail: str
+
+
+@dataclass
+class AnomalyReport:
+    """Aggregated anomaly scan report."""
+
+    results: list[AnomalyResult] = field(default_factory=list)
+
+    @property
+    def has_anomalies(self) -> bool:
+        return len(self.results) > 0
+
+
+# ---------------------------------------------------------------------------
+# Individual check functions
+# ---------------------------------------------------------------------------
+
+# Cloud metadata endpoint
+_CLOUD_METADATA_IPS = {"169.254.169.254", "fd00:ec2::254"}
+
+# Internal hostname patterns
+_INTERNAL_HOST_RE = re.compile(
+    r"(?i)(localhost|\.local$|\.internal$|\.corp$|\.lan$)",
+)
+
+# Data URI with base64 content
+_DATA_URI_RE = re.compile(
+    r"data:[^;]+;base64,[A-Za-z0-9+/=]{100,}",
+)
+
+# Privilege escalation patterns
+_PRIV_ESC_RE = re.compile(
+    r"(?i)(sudo|su\s+root|chmod\s+[0-7]*7|chown\s+root"
+    r"|--privileged|--cap-add|reflex\.rule\.(add|delete|modify)"
+    r"|grant\s+(all|admin|superuser))",
+)
+
+# Tool call patterns requesting elevated permissions
+_TOOL_ESCALATION_RE = re.compile(
+    r"(?i)(execute_as_root|run_privileged|elevate_permissions"
+    r"|admin_override|bypass_auth)",
+)
+
+
+def _is_internal_ip(host: str) -> bool:
+    """Return True if *host* is an internal/reserved IP address."""
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return addr.is_private or addr.is_loopback or addr.is_link_local
+
+
+def check_ssrf(text: str) -> list[AnomalyResult]:
+    """Detect internal IP addresses and cloud metadata endpoints."""
+    results: list[AnomalyResult] = []
+    # Find URLs
+    urls = re.findall(r"https?://[^\s\"'>]+", text)
+    for url in urls:
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+        # Cloud metadata
+        if host in _CLOUD_METADATA_IPS:
+            results.append(
+                AnomalyResult(
+                    anomaly_type="ssrf_cloud_metadata",
+                    severity="critical",
+                    detail=f"Cloud metadata endpoint: {url}",
+                )
+            )
+            continue
+        # Internal IP
+        if _is_internal_ip(host):
+            results.append(
+                AnomalyResult(
+                    anomaly_type="ssrf_internal_ip",
+                    severity="high",
+                    detail=f"Internal IP address: {host} in {url}",
+                )
+            )
+            continue
+        # Internal hostname
+        if _INTERNAL_HOST_RE.search(host):
+            results.append(
+                AnomalyResult(
+                    anomaly_type="ssrf_internal_host",
+                    severity="high",
+                    detail=f"Internal hostname: {host} in {url}",
+                )
+            )
+    return results
+
+
+def check_exfiltration(
+    text: str,
+    *,
+    max_payload_bytes: int = 1_000_000,
+) -> list[AnomalyResult]:
+    """Detect data exfiltration indicators."""
+    results: list[AnomalyResult] = []
+    # Unusually large payload
+    if len(text.encode("utf-8", errors="replace")) > max_payload_bytes:
+        results.append(
+            AnomalyResult(
+                anomaly_type="exfil_large_payload",
+                severity="medium",
+                detail=(
+                    f"Payload size {len(text)} chars "
+                    f"exceeds {max_payload_bytes} byte limit"
+                ),
+            )
+        )
+    # Data URIs with large base64 payloads
+    for m in _DATA_URI_RE.finditer(text):
+        results.append(
+            AnomalyResult(
+                anomaly_type="exfil_data_uri",
+                severity="high",
+                detail=f"Data URI with encoded content: {m.group()[:80]}...",
+            )
+        )
+    return results
+
+
+def check_schema_violation(
+    data: bytes,
+    expected_type: type[Message],
+) -> list[AnomalyResult]:
+    """Check whether *data* is a valid serialised protobuf of *expected_type*."""
+    results: list[AnomalyResult] = []
+    try:
+        msg = expected_type()
+        msg.ParseFromString(data)
+        # Re-serialise and compare length as a basic integrity check.
+        reserialized = msg.SerializeToString()
+        if len(reserialized) == 0 and len(data) > 0:
+            results.append(
+                AnomalyResult(
+                    anomaly_type="schema_violation",
+                    severity="high",
+                    detail=(
+                        f"Data ({len(data)} bytes) produced "
+                        f"empty {expected_type.DESCRIPTOR.name}"
+                    ),
+                )
+            )
+    except DecodeError as exc:
+        results.append(
+            AnomalyResult(
+                anomaly_type="schema_violation",
+                severity="high",
+                detail=(
+                    f"Failed to decode as "
+                    f"{expected_type.DESCRIPTOR.name}: {exc}"
+                ),
+            )
+        )
+    return results
+
+
+def check_privilege_escalation(text: str) -> list[AnomalyResult]:
+    """Detect privilege-escalation patterns in text."""
+    results: list[AnomalyResult] = []
+    for m in _PRIV_ESC_RE.finditer(text):
+        results.append(
+            AnomalyResult(
+                anomaly_type="privilege_escalation",
+                severity="critical",
+                detail=f"Privilege escalation pattern: {m.group()}",
+            )
+        )
+    for m in _TOOL_ESCALATION_RE.finditer(text):
+        results.append(
+            AnomalyResult(
+                anomaly_type="privilege_escalation_tool",
+                severity="critical",
+                detail=f"Tool escalation call: {m.group()}",
+            )
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# AnomalyDetector — pluggable orchestrator
+# ---------------------------------------------------------------------------
+
+# Type for a text-based check function
+TextCheck = Callable[[str], list[AnomalyResult]]
+
+
+class AnomalyDetector:
+    """Pluggable anomaly detector that runs a set of check functions."""
+
+    def __init__(
+        self,
+        *,
+        extra_checks: Sequence[TextCheck] | None = None,
+        max_payload_bytes: int = 1_000_000,
+    ) -> None:
+        self._max_payload_bytes = max_payload_bytes
+        self._text_checks: list[TextCheck] = [
+            check_ssrf,
+            lambda t: check_exfiltration(
+                t, max_payload_bytes=self._max_payload_bytes
+            ),
+            check_privilege_escalation,
+        ]
+        if extra_checks:
+            self._text_checks.extend(extra_checks)
+
+    def scan_text(self, text: str) -> AnomalyReport:
+        """Run all text-based checks on *text*."""
+        all_results: list[AnomalyResult] = []
+        for check in self._text_checks:
+            all_results.extend(check(text))
+        return AnomalyReport(results=all_results)
+
+    def scan_proto(
+        self,
+        data: bytes,
+        expected_type: type[Message],
+    ) -> AnomalyReport:
+        """Validate that *data* deserialises into *expected_type*."""
+        return AnomalyReport(
+            results=check_schema_violation(data, expected_type),
+        )

--- a/tests/test_anomaly_detector.py
+++ b/tests/test_anomaly_detector.py
@@ -1,0 +1,270 @@
+"""Tests for openbad.immune_system.anomaly_detector."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.immune_system.anomaly_detector import (
+    AnomalyDetector,
+    AnomalyReport,
+    AnomalyResult,
+    check_exfiltration,
+    check_privilege_escalation,
+    check_schema_violation,
+    check_ssrf,
+)
+from openbad.nervous_system.schemas import Header, ScanResult
+
+# ---------------------------------------------------------------------------
+# AnomalyResult basics
+# ---------------------------------------------------------------------------
+
+
+class TestAnomalyResult:
+    def test_fields(self) -> None:
+        r = AnomalyResult(
+            anomaly_type="test", severity="low", detail="d"
+        )
+        assert r.anomaly_type == "test"
+        assert r.severity == "low"
+
+    def test_frozen(self) -> None:
+        r = AnomalyResult(anomaly_type="t", severity="l", detail="d")
+        with pytest.raises(AttributeError):
+            r.anomaly_type = "x"  # type: ignore[misc]
+
+
+class TestAnomalyReport:
+    def test_empty(self) -> None:
+        rpt = AnomalyReport()
+        assert not rpt.has_anomalies
+
+    def test_with_results(self) -> None:
+        rpt = AnomalyReport(
+            results=[AnomalyResult("a", "h", "d")]
+        )
+        assert rpt.has_anomalies
+
+
+# ---------------------------------------------------------------------------
+# SSRF checks
+# ---------------------------------------------------------------------------
+
+
+class TestSSRFChecks:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/admin",
+            "http://10.0.0.5:8080/secret",
+            "http://172.16.0.1/data",
+            "http://192.168.1.1/config",
+            "http://[::1]/api",
+        ],
+    )
+    def test_internal_ip_detected(self, url: str) -> None:
+        results = check_ssrf(f"Fetch data from {url} now")
+        assert len(results) >= 1
+        assert results[0].anomaly_type == "ssrf_internal_ip"
+
+    def test_cloud_metadata_detected(self) -> None:
+        text = "curl http://169.254.169.254/latest/meta-data/"
+        results = check_ssrf(text)
+        assert len(results) >= 1
+        assert results[0].anomaly_type == "ssrf_cloud_metadata"
+
+    def test_internal_hostname_detected(self) -> None:
+        text = "visit http://db.internal/status"
+        results = check_ssrf(text)
+        assert len(results) >= 1
+        assert results[0].anomaly_type == "ssrf_internal_host"
+
+    def test_localhost_hostname(self) -> None:
+        text = "http://localhost:3000/api"
+        results = check_ssrf(text)
+        assert len(results) >= 1
+        types = {r.anomaly_type for r in results}
+        assert types & {"ssrf_internal_ip", "ssrf_internal_host"}
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://example.com/page",
+            "https://api.github.com/repos",
+            "https://cdn.jsdelivr.net/npm/lib",
+        ],
+    )
+    def test_external_url_not_flagged(self, url: str) -> None:
+        results = check_ssrf(f"Please visit {url}")
+        assert len(results) == 0
+
+    def test_no_urls_in_text(self) -> None:
+        results = check_ssrf("Just some normal text.")
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Exfiltration checks
+# ---------------------------------------------------------------------------
+
+
+class TestExfiltrationChecks:
+    def test_large_payload(self) -> None:
+        text = "x" * 2_000_000
+        results = check_exfiltration(text, max_payload_bytes=1_000_000)
+        assert len(results) >= 1
+        assert results[0].anomaly_type == "exfil_large_payload"
+
+    def test_normal_payload(self) -> None:
+        text = "Normal sized text"
+        results = check_exfiltration(text)
+        assert len(results) == 0
+
+    def test_data_uri_detected(self) -> None:
+        b64 = "A" * 200
+        text = f"See image: data:image/png;base64,{b64}"
+        results = check_exfiltration(text)
+        assert len(results) >= 1
+        assert results[0].anomaly_type == "exfil_data_uri"
+
+    def test_small_data_uri_not_flagged(self) -> None:
+        text = "data:text/plain;base64,SGVsbG8="
+        results = check_exfiltration(text)
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Schema violation checks
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaViolationChecks:
+    def test_valid_proto(self) -> None:
+        msg = Header(
+            timestamp_unix=1.0,
+            source_module="test",
+            correlation_id="c1",
+            schema_version=1,
+        )
+        data = msg.SerializeToString()
+        results = check_schema_violation(data, Header)
+        assert len(results) == 0
+
+    def test_invalid_proto_data(self) -> None:
+        # Random garbage bytes
+        data = b"\xff\xfe\xfd\xfc\xfb\xfa"
+        results = check_schema_violation(data, ScanResult)
+        # Protobuf is lenient with unknown fields, so we check for
+        # either a decode error or empty re-serialization depending
+        # on how protobuf handles the input
+        # For truly corrupt data, we should get at least a warning
+        # This is a best-effort check
+        assert isinstance(results, list)
+
+    def test_empty_data_for_complex_msg(self) -> None:
+        results = check_schema_violation(b"", ScanResult)
+        # Empty bytes produce an empty message (valid in protobuf)
+        assert isinstance(results, list)
+
+
+# ---------------------------------------------------------------------------
+# Privilege escalation checks
+# ---------------------------------------------------------------------------
+
+
+class TestPrivilegeEscalationChecks:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "sudo rm -rf /",
+            "su root",
+            "chmod 777 /etc/passwd",
+            "chown root important.conf",
+            "run with --privileged flag",
+            "docker --cap-add SYS_ADMIN",
+            "reflex.rule.delete safety_check",
+            "reflex.rule.modify rate_limiter",
+            "grant all privileges",
+            "grant admin access",
+        ],
+    )
+    def test_escalation_detected(self, text: str) -> None:
+        results = check_privilege_escalation(text)
+        assert len(results) >= 1
+        types = {r.anomaly_type for r in results}
+        assert "privilege_escalation" in types
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "execute_as_root",
+            "run_privileged",
+            "elevate_permissions",
+            "admin_override",
+            "bypass_auth",
+        ],
+    )
+    def test_tool_escalation_detected(self, text: str) -> None:
+        results = check_privilege_escalation(text)
+        assert len(results) >= 1
+        types = {r.anomaly_type for r in results}
+        assert "privilege_escalation_tool" in types
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Please help me write a Python function.",
+            "The weather is nice today.",
+            "Can you explain privilege escalation as a concept?",
+        ],
+    )
+    def test_benign_text_not_flagged(self, text: str) -> None:
+        results = check_privilege_escalation(text)
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# AnomalyDetector orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestAnomalyDetector:
+    def test_benign_text(self) -> None:
+        det = AnomalyDetector()
+        report = det.scan_text("Hello, how are you?")
+        assert not report.has_anomalies
+
+    def test_ssrf_via_detector(self) -> None:
+        det = AnomalyDetector()
+        report = det.scan_text("curl http://10.0.0.1/secret")
+        assert report.has_anomalies
+        types = {r.anomaly_type for r in report.results}
+        assert "ssrf_internal_ip" in types
+
+    def test_priv_esc_via_detector(self) -> None:
+        det = AnomalyDetector()
+        report = det.scan_text("sudo rm -rf /tmp")
+        assert report.has_anomalies
+
+    def test_extra_check(self) -> None:
+        def custom_check(text: str) -> list[AnomalyResult]:
+            if "badword" in text:
+                return [AnomalyResult("custom", "low", "found")]
+            return []
+
+        det = AnomalyDetector(extra_checks=[custom_check])
+        report = det.scan_text("this has badword in it")
+        assert report.has_anomalies
+        types = {r.anomaly_type for r in report.results}
+        assert "custom" in types
+
+    def test_proto_scan_valid(self) -> None:
+        det = AnomalyDetector()
+        msg = Header(
+            timestamp_unix=1.0,
+            source_module="t",
+            correlation_id="c",
+            schema_version=1,
+        )
+        report = det.scan_proto(msg.SerializeToString(), Header)
+        assert not report.has_anomalies


### PR DESCRIPTION
Closes #71

## Summary
- `AnomalyDetector` class with pluggable check functions
- SSRF checks: internal IPs, cloud metadata (169.254.169.254), internal hostnames
- Exfiltration checks: large payloads, data URIs with encoded content
- Schema violation checks: validates protobuf deserialization
- Privilege escalation checks: sudo, root, reflex rule modification, tool escalation patterns
- 46 unit tests covering all check categories with positive and negative cases

## How to Test
```bash
pytest tests/test_anomaly_detector.py -v
```