### PR TITLE
#76: Add session lifecycle with HMAC-SHA256 markers

### DIFF
--- a/config/identity.yaml
+++ b/config/identity.yaml
@@ -1,0 +1,14 @@
+# Identity module defaults
+identity:
+  # Hex-encoded HMAC secret key (override via OPENBAD_IDENTITY_SECRET env var)
+  # Leave empty to auto-generate an ephemeral key (dev/test only)
+  secret_hex: ""
+
+  # Session marker rotation interval in seconds (default: 1 hour)
+  rotation_interval: 3600
+
+  # Default session TTL in seconds (default: 8 hours)
+  default_ttl: 28800
+
+  # Path prefix for persisted marker files
+  marker_path: "data/markers"

--- a/src/openbad/identity/__init__.py
+++ b/src/openbad/identity/__init__.py
@@ -1,0 +1,1 @@
+"""Digital identity system — session lifecycle and marker management."""

--- a/src/openbad/identity/marker.py
+++ b/src/openbad/identity/marker.py
@@ -1,0 +1,86 @@
+"""HMAC-SHA256 marker generation and validation."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import hmac
+import os
+import secrets
+from pathlib import Path
+
+import yaml
+
+
+def generate_secret(length: int = 32) -> bytes:
+    """Return a cryptographically random secret key."""
+    return secrets.token_bytes(length)
+
+
+def create_marker(
+    data: str,
+    secret: bytes,
+) -> str:
+    """Produce an HMAC-SHA256 hex digest of *data* using *secret*."""
+    return hmac.new(secret, data.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def verify_marker(
+    data: str,
+    marker: str,
+    secret: bytes,
+) -> bool:
+    """Return ``True`` if *marker* is a valid HMAC-SHA256 of *data*."""
+    expected = create_marker(data, secret)
+    return hmac.compare_digest(expected, marker)
+
+
+# ------------------------------------------------------------------
+# Secret-key persistence
+# ------------------------------------------------------------------
+
+
+def load_secret(
+    *,
+    yaml_path: str | Path = "config/identity.yaml",
+    env_var: str = "OPENBAD_IDENTITY_SECRET",
+) -> bytes:
+    """Load the identity secret key.
+
+    Resolution order:
+    1. Environment variable *env_var* (hex-encoded).
+    2. ``secret_hex`` field in *yaml_path*.
+    3. Generate a new ephemeral key (dev/test only).
+    """
+    env_val = os.environ.get(env_var, "")
+    if env_val:
+        return bytes.fromhex(env_val)
+
+    path = Path(yaml_path)
+    if path.exists():
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        identity = data.get("identity", {})
+        hex_key = identity.get("secret_hex", "")
+        if hex_key:
+            return bytes.fromhex(hex_key)
+
+    return generate_secret()
+
+
+def save_marker_file(
+    marker: str,
+    path: str | Path,
+) -> None:
+    """Write *marker* to *path* with restricted permissions (0600)."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(marker)
+    # Set 0600 permissions on Linux/macOS; ignored on Windows
+    with contextlib.suppress(OSError):
+        p.chmod(0o600)
+
+
+def read_marker_file(path: str | Path) -> str:
+    """Read a marker string from *path*."""
+    return Path(path).read_text().strip()

--- a/src/openbad/identity/session.py
+++ b/src/openbad/identity/session.py
@@ -1,0 +1,134 @@
+"""Session lifecycle management with HMAC-SHA256 session markers."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+
+from openbad.identity.marker import create_marker, generate_secret, verify_marker
+
+
+@dataclass(frozen=True)
+class Session:
+    """An authenticated session bound to a user identity."""
+
+    session_id: str
+    user_identity: str
+    created_at: float
+    expires_at: float
+    marker: str
+
+
+# Default rotation interval: 1 hour (seconds)
+DEFAULT_ROTATION_INTERVAL: float = 3600.0
+
+
+class SessionManager:
+    """Manages session lifecycle: create, validate, rotate, end.
+
+    Parameters
+    ----------
+    secret:
+        HMAC secret for marker generation.  If *None* an ephemeral
+        key is generated (dev/test only).
+    rotation_interval:
+        Seconds between marker rotations (default 1 hour).
+    default_ttl:
+        Default session time-to-live in seconds (default 8 hours).
+    """
+
+    def __init__(
+        self,
+        *,
+        secret: bytes | None = None,
+        rotation_interval: float = DEFAULT_ROTATION_INTERVAL,
+        default_ttl: float = 8 * 3600.0,
+    ) -> None:
+        self._secret = secret or generate_secret()
+        self._rotation_interval = rotation_interval
+        self._default_ttl = default_ttl
+        self._sessions: dict[str, Session] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def create_session(self, user_identity: str) -> Session:
+        """Create a new session for *user_identity*."""
+        session_id = uuid.uuid4().hex
+        now = time.time()
+        marker_data = f"{session_id}:{user_identity}:{now}"
+        marker = create_marker(marker_data, self._secret)
+
+        session = Session(
+            session_id=session_id,
+            user_identity=user_identity,
+            created_at=now,
+            expires_at=now + self._default_ttl,
+            marker=marker,
+        )
+        self._sessions[session_id] = session
+        return session
+
+    def validate_session(self, session_id: str) -> Session | None:
+        """Return the session if valid and not expired, else ``None``."""
+        session = self._sessions.get(session_id)
+        if session is None:
+            return None
+        if time.time() > session.expires_at:
+            # Expired — remove it
+            del self._sessions[session_id]
+            return None
+        return session
+
+    def rotate_marker(self, session_id: str) -> Session | None:
+        """Rotate the HMAC marker for session *session_id*.
+
+        Returns the updated session or ``None`` if the session is
+        invalid / expired.
+        """
+        session = self.validate_session(session_id)
+        if session is None:
+            return None
+
+        now = time.time()
+        marker_data = f"{session.session_id}:{session.user_identity}:{now}"
+        new_marker = create_marker(marker_data, self._secret)
+
+        rotated = Session(
+            session_id=session.session_id,
+            user_identity=session.user_identity,
+            created_at=session.created_at,
+            expires_at=session.expires_at,
+            marker=new_marker,
+        )
+        self._sessions[session.session_id] = rotated
+        return rotated
+
+    def end_session(self, session_id: str) -> bool:
+        """End and remove a session.  Returns ``True`` if it existed."""
+        return self._sessions.pop(session_id, None) is not None
+
+    def needs_rotation(self, session: Session) -> bool:
+        """Return ``True`` if the session marker needs rotation."""
+        # The marker encodes the time it was created in its data;
+        # we check whether enough time has passed since the last rotation.
+        # For simplicity we check age of the marker relative to created_at
+        # vs the rotation interval.
+        age = time.time() - session.created_at
+        # Number of rotations that should have happened
+        expected_rotations = int(age / self._rotation_interval)
+        return expected_rotations > 0
+
+    @property
+    def active_sessions(self) -> int:
+        return len(self._sessions)
+
+    def verify_session_marker(self, session: Session) -> bool:
+        """Verify a session's marker against its identity data."""
+        return verify_marker(
+            f"{session.session_id}:{session.user_identity}:{session.created_at}",
+            session.marker,
+            self._secret,
+        )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,260 @@
+"""Tests for openbad.identity — session lifecycle and marker management."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from openbad.identity.marker import (
+    create_marker,
+    generate_secret,
+    load_secret,
+    read_marker_file,
+    save_marker_file,
+    verify_marker,
+)
+from openbad.identity.session import Session, SessionManager
+
+# ===================================================================
+# Marker tests
+# ===================================================================
+
+
+class TestGenerateSecret:
+    def test_default_length(self) -> None:
+        s = generate_secret()
+        assert len(s) == 32
+
+    def test_custom_length(self) -> None:
+        s = generate_secret(64)
+        assert len(s) == 64
+
+    def test_two_secrets_differ(self) -> None:
+        assert generate_secret() != generate_secret()
+
+
+class TestCreateAndVerifyMarker:
+    def test_round_trip(self) -> None:
+        secret = generate_secret()
+        marker = create_marker("test-data", secret)
+        assert verify_marker("test-data", marker, secret)
+
+    def test_wrong_data(self) -> None:
+        secret = generate_secret()
+        marker = create_marker("test-data", secret)
+        assert not verify_marker("wrong-data", marker, secret)
+
+    def test_wrong_secret(self) -> None:
+        s1 = generate_secret()
+        s2 = generate_secret()
+        marker = create_marker("data", s1)
+        assert not verify_marker("data", marker, s2)
+
+    def test_hex_string(self) -> None:
+        secret = generate_secret()
+        marker = create_marker("data", secret)
+        # HMAC-SHA256 produces a 64-char hex string
+        assert len(marker) == 64
+        int(marker, 16)  # Should not raise
+
+
+class TestMarkerFile:
+    def test_save_and_read(self, tmp_path: pytest.TempPathFactory) -> None:
+        path = tmp_path / "markers" / "session.marker"
+        save_marker_file("abc123", path)
+        assert read_marker_file(path) == "abc123"
+
+    def test_permissions_not_error(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """save_marker_file should not raise even on Windows."""
+        path = tmp_path / "m.marker"
+        save_marker_file("test", path)
+        assert path.exists()
+
+
+class TestLoadSecret:
+    def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        hex_key = generate_secret().hex()
+        monkeypatch.setenv("OPENBAD_IDENTITY_SECRET", hex_key)
+        secret = load_secret(yaml_path="nonexistent.yaml")
+        assert secret == bytes.fromhex(hex_key)
+
+    def test_from_yaml(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        yaml_path = tmp_path / "identity.yaml"
+        hex_key = generate_secret().hex()
+        yaml_path.write_text(
+            f"identity:\n  secret_hex: \"{hex_key}\"\n"
+        )
+        secret = load_secret(
+            yaml_path=yaml_path,
+            env_var="NONEXISTENT_VAR",
+        )
+        assert secret == bytes.fromhex(hex_key)
+
+    def test_ephemeral_fallback(self) -> None:
+        secret = load_secret(
+            yaml_path="nonexistent.yaml",
+            env_var="NONEXISTENT_VAR",
+        )
+        assert len(secret) == 32
+
+
+# ===================================================================
+# Session tests
+# ===================================================================
+
+
+class TestSessionDataclass:
+    def test_fields(self) -> None:
+        s = Session(
+            session_id="abc",
+            user_identity="user1",
+            created_at=1.0,
+            expires_at=2.0,
+            marker="deadbeef",
+        )
+        assert s.session_id == "abc"
+        assert s.user_identity == "user1"
+
+    def test_frozen(self) -> None:
+        s = Session(
+            session_id="x",
+            user_identity="u",
+            created_at=0,
+            expires_at=0,
+            marker="m",
+        )
+        with pytest.raises(AttributeError):
+            s.marker = "new"  # type: ignore[misc]
+
+
+class TestCreateSession:
+    def test_creates_valid_session(self) -> None:
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        assert s.user_identity == "alice"
+        assert s.session_id
+        assert s.marker
+        assert s.expires_at > s.created_at
+
+    def test_unique_ids(self) -> None:
+        mgr = SessionManager()
+        s1 = mgr.create_session("alice")
+        s2 = mgr.create_session("bob")
+        assert s1.session_id != s2.session_id
+
+    def test_different_markers(self) -> None:
+        mgr = SessionManager()
+        s1 = mgr.create_session("alice")
+        s2 = mgr.create_session("alice")
+        # Even the same user gets different markers (different session_id + time)
+        assert s1.marker != s2.marker
+
+
+class TestValidateSession:
+    def test_valid_session(self) -> None:
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        assert mgr.validate_session(s.session_id) is not None
+
+    def test_unknown_session(self) -> None:
+        mgr = SessionManager()
+        assert mgr.validate_session("nonexistent") is None
+
+    def test_expired_session(self) -> None:
+        mgr = SessionManager(default_ttl=0.0)
+        s = mgr.create_session("alice")
+        time.sleep(0.01)
+        assert mgr.validate_session(s.session_id) is None
+
+    def test_expired_session_removed(self) -> None:
+        mgr = SessionManager(default_ttl=0.0)
+        s = mgr.create_session("alice")
+        time.sleep(0.01)
+        mgr.validate_session(s.session_id)
+        assert mgr.active_sessions == 0
+
+
+class TestRotateMarker:
+    def test_rotation_changes_marker(self) -> None:
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        old_marker = s.marker
+        rotated = mgr.rotate_marker(s.session_id)
+        assert rotated is not None
+        assert rotated.marker != old_marker
+
+    def test_rotation_preserves_identity(self) -> None:
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        rotated = mgr.rotate_marker(s.session_id)
+        assert rotated is not None
+        assert rotated.session_id == s.session_id
+        assert rotated.user_identity == s.user_identity
+        assert rotated.created_at == s.created_at
+        assert rotated.expires_at == s.expires_at
+
+    def test_rotate_expired_returns_none(self) -> None:
+        mgr = SessionManager(default_ttl=0.0)
+        s = mgr.create_session("alice")
+        time.sleep(0.01)
+        assert mgr.rotate_marker(s.session_id) is None
+
+    def test_rotate_unknown_returns_none(self) -> None:
+        mgr = SessionManager()
+        assert mgr.rotate_marker("nonexistent") is None
+
+
+class TestEndSession:
+    def test_end_existing(self) -> None:
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        assert mgr.end_session(s.session_id) is True
+        assert mgr.validate_session(s.session_id) is None
+
+    def test_end_unknown(self) -> None:
+        mgr = SessionManager()
+        assert mgr.end_session("nonexistent") is False
+
+    def test_active_count_decreases(self) -> None:
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        assert mgr.active_sessions == 1
+        mgr.end_session(s.session_id)
+        assert mgr.active_sessions == 0
+
+
+class TestNeedsRotation:
+    def test_fresh_session_no_rotation(self) -> None:
+        mgr = SessionManager(rotation_interval=3600.0)
+        s = mgr.create_session("alice")
+        assert mgr.needs_rotation(s) is False
+
+    def test_old_session_needs_rotation(self) -> None:
+        mgr = SessionManager(rotation_interval=0.01)
+        s = mgr.create_session("alice")
+        time.sleep(0.02)
+        assert mgr.needs_rotation(s) is True
+
+
+class TestVerifySessionMarker:
+    def test_verify_initial_marker(self) -> None:
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        assert mgr.verify_session_marker(s) is True
+
+    def test_tampered_marker_fails(self) -> None:
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        tampered = Session(
+            session_id=s.session_id,
+            user_identity=s.user_identity,
+            created_at=s.created_at,
+            expires_at=s.expires_at,
+            marker="0" * 64,
+        )
+        assert mgr.verify_session_marker(tampered) is False


### PR DESCRIPTION
Closes #76

## Summary
- `identity` package with `marker.py` and `session.py`
- HMAC-SHA256 marker generation and verification
- `SessionManager`: create, validate, rotate, end sessions
- 1-hour marker rotation with `needs_rotation()` check
- Marker file persistence with 0600 permissions (Linux/macOS)
- Secret key resolution: env var -> YAML config -> ephemeral
- `config/identity.yaml` with defaults
- 32 unit tests covering markers, sessions, rotation, expiry, tampering

## How to Test
```bash
pytest tests/test_session.py -v
```