### PR TITLE
#77: Add action permissioning with tier-based access control

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -1,0 +1,27 @@
+# Action → permission tier mappings
+permissions:
+  READ:
+    - file.read
+    - config.read
+    - telemetry.query
+    - session.validate
+    - status.check
+  WRITE:
+    - file.write
+    - db.insert
+    - db.update
+    - db.delete
+    - cache.set
+    - log.write
+  PUBLISH:
+    - mqtt.publish
+    - api.call
+    - webhook.send
+    - notification.push
+  SYSTEM:
+    - systemd.restart
+    - systemd.stop
+    - ebpf.load
+    - ebpf.unload
+    - config.write
+    - identity.elevate

--- a/src/openbad/identity/permissions.py
+++ b/src/openbad/identity/permissions.py
@@ -1,0 +1,201 @@
+"""Action permissioning — tier-based access control for agent operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import yaml
+
+from openbad.identity.session import SessionManager
+
+
+class ActionTier(Enum):
+    """Permission tier for agent actions."""
+
+    READ = "READ"
+    WRITE = "WRITE"
+    PUBLISH = "PUBLISH"
+    SYSTEM = "SYSTEM"
+
+
+@dataclass(frozen=True)
+class Permission:
+    """Describes the permission requirements for an action."""
+
+    action: str
+    tier: ActionTier
+    requires_identity: bool
+    requires_confirmation: bool
+    requires_elevated_auth: bool
+
+
+@dataclass(frozen=True)
+class PermissionResult:
+    """Outcome of a permission check."""
+
+    allowed: bool
+    action: str
+    tier: ActionTier
+    reason: str = ""
+
+
+# Tier → requirement flags
+_TIER_REQUIREMENTS: dict[ActionTier, dict[str, bool]] = {
+    ActionTier.READ: {
+        "requires_identity": False,
+        "requires_confirmation": False,
+        "requires_elevated_auth": False,
+    },
+    ActionTier.WRITE: {
+        "requires_identity": True,
+        "requires_confirmation": False,
+        "requires_elevated_auth": False,
+    },
+    ActionTier.PUBLISH: {
+        "requires_identity": True,
+        "requires_confirmation": True,
+        "requires_elevated_auth": False,
+    },
+    ActionTier.SYSTEM: {
+        "requires_identity": True,
+        "requires_confirmation": True,
+        "requires_elevated_auth": True,
+    },
+}
+
+
+def load_action_mappings(
+    yaml_path: str | Path = "config/permissions.yaml",
+) -> dict[str, ActionTier]:
+    """Load action → tier mappings from a YAML file."""
+    path = Path(yaml_path)
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    mappings: dict[str, ActionTier] = {}
+    for tier_name, actions in data.get("permissions", {}).items():
+        tier = ActionTier(tier_name.upper())
+        if isinstance(actions, list):
+            for action in actions:
+                mappings[action] = tier
+    return mappings
+
+
+class PermissionClassifier:
+    """Classifies agent actions into permission tiers.
+
+    Parameters
+    ----------
+    action_mappings:
+        Explicit action → tier overrides.
+    yaml_path:
+        Path to YAML file with additional mappings.
+    default_tier:
+        Default tier when an action is not explicitly mapped.
+    """
+
+    def __init__(
+        self,
+        *,
+        action_mappings: dict[str, ActionTier] | None = None,
+        yaml_path: str | Path | None = None,
+        default_tier: ActionTier = ActionTier.WRITE,
+    ) -> None:
+        self._mappings: dict[str, ActionTier] = {}
+        self._default_tier = default_tier
+
+        if yaml_path is not None:
+            self._mappings.update(load_action_mappings(yaml_path))
+        if action_mappings is not None:
+            self._mappings.update(action_mappings)
+
+    def classify(self, action_name: str) -> Permission:
+        """Classify *action_name* into a :class:`Permission`."""
+        tier = self._mappings.get(action_name, self._default_tier)
+        reqs = _TIER_REQUIREMENTS[tier]
+        return Permission(
+            action=action_name,
+            tier=tier,
+            requires_identity=reqs["requires_identity"],
+            requires_confirmation=reqs["requires_confirmation"],
+            requires_elevated_auth=reqs["requires_elevated_auth"],
+        )
+
+    def check_permission(
+        self,
+        session_manager: SessionManager,
+        session_id: str | None,
+        action_name: str,
+        *,
+        user_confirmed: bool = False,
+        elevated_auth: bool = False,
+    ) -> PermissionResult:
+        """Check whether *action_name* is permitted for the given session.
+
+        Parameters
+        ----------
+        session_manager:
+            Manager that validates session tokens.
+        session_id:
+            Session identifier (may be ``None`` for READ actions).
+        action_name:
+            The action being attempted.
+        user_confirmed:
+            Whether the user has confirmed the action.
+        elevated_auth:
+            Whether elevated authentication has been provided.
+        """
+        perm = self.classify(action_name)
+
+        # READ — always allowed
+        if perm.tier is ActionTier.READ:
+            return PermissionResult(
+                allowed=True,
+                action=action_name,
+                tier=perm.tier,
+            )
+
+        # Identity required (WRITE, PUBLISH, SYSTEM)
+        if perm.requires_identity:
+            if session_id is None:
+                return PermissionResult(
+                    allowed=False,
+                    action=action_name,
+                    tier=perm.tier,
+                    reason="Valid session required",
+                )
+            session = session_manager.validate_session(session_id)
+            if session is None:
+                return PermissionResult(
+                    allowed=False,
+                    action=action_name,
+                    tier=perm.tier,
+                    reason="Session invalid or expired",
+                )
+
+        # Confirmation required (PUBLISH, SYSTEM)
+        if perm.requires_confirmation and not user_confirmed:
+            return PermissionResult(
+                allowed=False,
+                action=action_name,
+                tier=perm.tier,
+                reason="User confirmation required",
+            )
+
+        # Elevated auth required (SYSTEM)
+        if perm.requires_elevated_auth and not elevated_auth:
+            return PermissionResult(
+                allowed=False,
+                action=action_name,
+                tier=perm.tier,
+                reason="Elevated authentication required",
+            )
+
+        return PermissionResult(
+            allowed=True,
+            action=action_name,
+            tier=perm.tier,
+        )

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,310 @@
+"""Tests for openbad.identity.permissions — action permissioning."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.identity.permissions import (
+    ActionTier,
+    Permission,
+    PermissionClassifier,
+    PermissionResult,
+    load_action_mappings,
+)
+from openbad.identity.session import SessionManager
+
+# ---------------------------------------------------------------------------
+# ActionTier enum
+# ---------------------------------------------------------------------------
+
+
+class TestActionTier:
+    def test_values(self) -> None:
+        assert ActionTier.READ.value == "READ"
+        assert ActionTier.WRITE.value == "WRITE"
+        assert ActionTier.PUBLISH.value == "PUBLISH"
+        assert ActionTier.SYSTEM.value == "SYSTEM"
+
+
+# ---------------------------------------------------------------------------
+# Permission dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestPermission:
+    def test_read_permission(self) -> None:
+        p = Permission("file.read", ActionTier.READ, False, False, False)
+        assert not p.requires_identity
+        assert not p.requires_confirmation
+        assert not p.requires_elevated_auth
+
+    def test_frozen(self) -> None:
+        p = Permission("x", ActionTier.READ, False, False, False)
+        with pytest.raises(AttributeError):
+            p.tier = ActionTier.WRITE  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# load_action_mappings
+# ---------------------------------------------------------------------------
+
+
+class TestLoadActionMappings:
+    def test_load_from_yaml(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        yaml_path = tmp_path / "perms.yaml"
+        yaml_path.write_text(
+            "permissions:\n"
+            "  READ:\n"
+            "    - file.read\n"
+            "  SYSTEM:\n"
+            "    - ebpf.load\n"
+        )
+        mappings = load_action_mappings(yaml_path)
+        assert mappings["file.read"] is ActionTier.READ
+        assert mappings["ebpf.load"] is ActionTier.SYSTEM
+
+    def test_missing_file(self) -> None:
+        mappings = load_action_mappings("nonexistent.yaml")
+        assert mappings == {}
+
+
+# ---------------------------------------------------------------------------
+# PermissionClassifier.classify
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    def test_read_action(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"file.read": ActionTier.READ}
+        )
+        p = pc.classify("file.read")
+        assert p.tier is ActionTier.READ
+        assert not p.requires_identity
+
+    def test_write_action(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"file.write": ActionTier.WRITE}
+        )
+        p = pc.classify("file.write")
+        assert p.tier is ActionTier.WRITE
+        assert p.requires_identity
+        assert not p.requires_confirmation
+
+    def test_publish_action(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"mqtt.publish": ActionTier.PUBLISH}
+        )
+        p = pc.classify("mqtt.publish")
+        assert p.tier is ActionTier.PUBLISH
+        assert p.requires_identity
+        assert p.requires_confirmation
+        assert not p.requires_elevated_auth
+
+    def test_system_action(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"ebpf.load": ActionTier.SYSTEM}
+        )
+        p = pc.classify("ebpf.load")
+        assert p.tier is ActionTier.SYSTEM
+        assert p.requires_identity
+        assert p.requires_confirmation
+        assert p.requires_elevated_auth
+
+    def test_unknown_action_gets_default(self) -> None:
+        pc = PermissionClassifier(default_tier=ActionTier.WRITE)
+        p = pc.classify("unknown.action")
+        assert p.tier is ActionTier.WRITE
+
+    def test_custom_default_tier(self) -> None:
+        pc = PermissionClassifier(default_tier=ActionTier.READ)
+        p = pc.classify("anything")
+        assert p.tier is ActionTier.READ
+
+    def test_yaml_mappings(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        yaml_path = tmp_path / "p.yaml"
+        yaml_path.write_text(
+            "permissions:\n"
+            "  PUBLISH:\n"
+            "    - api.call\n"
+        )
+        pc = PermissionClassifier(yaml_path=yaml_path)
+        p = pc.classify("api.call")
+        assert p.tier is ActionTier.PUBLISH
+
+
+# ---------------------------------------------------------------------------
+# check_permission — READ (always allowed)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPermissionRead:
+    def test_read_no_session(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"file.read": ActionTier.READ}
+        )
+        mgr = SessionManager()
+        r = pc.check_permission(mgr, None, "file.read")
+        assert r.allowed is True
+        assert r.tier is ActionTier.READ
+
+    def test_read_with_session(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"file.read": ActionTier.READ}
+        )
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        r = pc.check_permission(mgr, s.session_id, "file.read")
+        assert r.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# check_permission — WRITE (identity required)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPermissionWrite:
+    def test_write_with_session(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"file.write": ActionTier.WRITE}
+        )
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        r = pc.check_permission(mgr, s.session_id, "file.write")
+        assert r.allowed is True
+
+    def test_write_no_session(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"file.write": ActionTier.WRITE}
+        )
+        mgr = SessionManager()
+        r = pc.check_permission(mgr, None, "file.write")
+        assert r.allowed is False
+        assert "session required" in r.reason.lower()
+
+    def test_write_invalid_session(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"file.write": ActionTier.WRITE}
+        )
+        mgr = SessionManager()
+        r = pc.check_permission(mgr, "bogus", "file.write")
+        assert r.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# check_permission — PUBLISH (identity + confirmation)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPermissionPublish:
+    def test_publish_fully_authorised(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"mqtt.publish": ActionTier.PUBLISH}
+        )
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        r = pc.check_permission(
+            mgr, s.session_id, "mqtt.publish",
+            user_confirmed=True,
+        )
+        assert r.allowed is True
+
+    def test_publish_no_confirmation(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"mqtt.publish": ActionTier.PUBLISH}
+        )
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        r = pc.check_permission(
+            mgr, s.session_id, "mqtt.publish",
+            user_confirmed=False,
+        )
+        assert r.allowed is False
+        assert "confirmation" in r.reason.lower()
+
+    def test_publish_no_session(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"mqtt.publish": ActionTier.PUBLISH}
+        )
+        mgr = SessionManager()
+        r = pc.check_permission(mgr, None, "mqtt.publish")
+        assert r.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# check_permission — SYSTEM (identity + confirmation + elevated)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPermissionSystem:
+    def test_system_fully_authorised(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"ebpf.load": ActionTier.SYSTEM}
+        )
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        r = pc.check_permission(
+            mgr, s.session_id, "ebpf.load",
+            user_confirmed=True,
+            elevated_auth=True,
+        )
+        assert r.allowed is True
+
+    def test_system_no_elevated(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"ebpf.load": ActionTier.SYSTEM}
+        )
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        r = pc.check_permission(
+            mgr, s.session_id, "ebpf.load",
+            user_confirmed=True,
+            elevated_auth=False,
+        )
+        assert r.allowed is False
+        assert "elevated" in r.reason.lower()
+
+    def test_system_no_confirmation(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"ebpf.load": ActionTier.SYSTEM}
+        )
+        mgr = SessionManager()
+        s = mgr.create_session("alice")
+        r = pc.check_permission(
+            mgr, s.session_id, "ebpf.load",
+            user_confirmed=False,
+            elevated_auth=True,
+        )
+        assert r.allowed is False
+        assert "confirmation" in r.reason.lower()
+
+    def test_system_no_session(self) -> None:
+        pc = PermissionClassifier(
+            action_mappings={"ebpf.load": ActionTier.SYSTEM}
+        )
+        mgr = SessionManager()
+        r = pc.check_permission(mgr, None, "ebpf.load")
+        assert r.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# PermissionResult
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionResult:
+    def test_allowed_result(self) -> None:
+        r = PermissionResult(True, "file.read", ActionTier.READ)
+        assert r.allowed
+        assert r.reason == ""
+
+    def test_denied_result(self) -> None:
+        r = PermissionResult(
+            False, "ebpf.load", ActionTier.SYSTEM, "Denied"
+        )
+        assert not r.allowed
+        assert r.reason == "Denied"


### PR DESCRIPTION
Closes #77

## Summary
- `ActionTier` enum: READ, WRITE, PUBLISH, SYSTEM
- `Permission` and `PermissionResult` frozen dataclasses
- `PermissionClassifier`: classify actions and check permissions against sessions
- READ: no session needed; WRITE: valid session; PUBLISH: session + confirmation; SYSTEM: session + confirmation + elevated auth
- YAML-driven action-to-tier mappings (`config/permissions.yaml`)
- 26 unit tests covering all tiers, authorization flows, denial cases

## How to Test
```bash
pytest tests/test_permissions.py -v
```