### PR TITLE
#78: Add identity grounding with multi-source resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pyyaml>=6.0",
     "aiohttp>=3.9",
     "cryptography>=42.0",
+    "bcrypt>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/openbad/identity/grounding.py
+++ b/src/openbad/identity/grounding.py
@@ -1,0 +1,229 @@
+"""Identity grounding — multi-source operator identity resolution."""
+
+from __future__ import annotations
+
+import getpass
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+import bcrypt
+
+# ---------------------------------------------------------------------------
+# Enums & data classes
+# ---------------------------------------------------------------------------
+
+
+class SourceType(Enum):
+    """Categories of identity sources."""
+
+    HARDWARE_TOKEN = "hardware_token"  # noqa: S105
+    BIOMETRIC = "biometric"
+    PASSPHRASE = "passphrase"  # noqa: S105
+    ENVIRONMENT = "environment"
+
+
+# Strength weights used for confidence scoring (0.0–1.0 contribution each).
+_SOURCE_STRENGTH: dict[SourceType, float] = {
+    SourceType.HARDWARE_TOKEN: 1.0,
+    SourceType.BIOMETRIC: 0.9,
+    SourceType.PASSPHRASE: 0.7,
+    SourceType.ENVIRONMENT: 0.4,
+}
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Outcome of a single identity-source verification."""
+
+    verified: bool
+    source_type: SourceType
+    user_id: str = ""
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class GroundedIdentity:
+    """An operator identity established from multiple sources."""
+
+    identity_id: str
+    user_id: str
+    sources_used: list[SourceType] = field(default_factory=list)
+    confidence: float = 0.0
+    timestamp: float = field(default_factory=time.time)
+
+
+# ---------------------------------------------------------------------------
+# IdentitySource protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class IdentitySource(Protocol):
+    """Interface that every identity source must implement."""
+
+    @property
+    def source_type(self) -> SourceType: ...
+
+    def verify(self) -> VerificationResult: ...
+
+
+# ---------------------------------------------------------------------------
+# Concrete sources
+# ---------------------------------------------------------------------------
+
+
+class HardwareTokenSource:
+    """Stub for USB/TPM hardware token (interface only in Phase 3)."""
+
+    source_type = SourceType.HARDWARE_TOKEN
+
+    def verify(self) -> VerificationResult:
+        return VerificationResult(
+            verified=False,
+            source_type=self.source_type,
+            detail="Hardware token verification not implemented",
+        )
+
+
+class BiometricSource:
+    """Stub for biometric proxy (voice fingerprint, etc.)."""
+
+    source_type = SourceType.BIOMETRIC
+
+    def verify(self) -> VerificationResult:
+        return VerificationResult(
+            verified=False,
+            source_type=self.source_type,
+            detail="Biometric verification not implemented",
+        )
+
+
+class PassphraseSource:
+    """Passphrase-based identity source (bcrypt-hashed)."""
+
+    source_type = SourceType.PASSPHRASE
+
+    def __init__(
+        self,
+        passphrase_hash: bytes,
+        user_id: str,
+        *,
+        passphrase_input: str | None = None,
+    ) -> None:
+        self._hash = passphrase_hash
+        self._user_id = user_id
+        self._input = passphrase_input
+
+    @staticmethod
+    def hash_passphrase(passphrase: str) -> bytes:
+        """Return a bcrypt hash of *passphrase*."""
+        return bcrypt.hashpw(passphrase.encode(), bcrypt.gensalt())
+
+    def verify(self) -> VerificationResult:
+        if self._input is None:
+            return VerificationResult(
+                verified=False,
+                source_type=self.source_type,
+                detail="No passphrase provided",
+            )
+        ok = bcrypt.checkpw(self._input.encode(), self._hash)
+        return VerificationResult(
+            verified=ok,
+            source_type=self.source_type,
+            user_id=self._user_id if ok else "",
+            detail="" if ok else "Passphrase mismatch",
+        )
+
+
+class EnvironmentSource:
+    """Identity from login-user / SSH / sudo context."""
+
+    source_type = SourceType.ENVIRONMENT
+
+    def __init__(self, *, expected_user: str | None = None) -> None:
+        self._expected = expected_user
+
+    def verify(self) -> VerificationResult:
+        current_user = os.environ.get("USER") or getpass.getuser()
+        if self._expected is not None and current_user != self._expected:
+            return VerificationResult(
+                verified=False,
+                source_type=self.source_type,
+                detail=f"Expected user '{self._expected}', got '{current_user}'",
+            )
+        return VerificationResult(
+            verified=True,
+            source_type=self.source_type,
+            user_id=current_user,
+        )
+
+
+# ---------------------------------------------------------------------------
+# IdentityGrounder
+# ---------------------------------------------------------------------------
+
+
+class IdentityGrounder:
+    """Establishes operator identity from multiple signals.
+
+    Parameters
+    ----------
+    min_sources:
+        Minimum number of verified sources required (default 2).
+    """
+
+    def __init__(self, *, min_sources: int = 2) -> None:
+        if min_sources < 1:
+            raise ValueError("min_sources must be >= 1")
+        self._min_sources = min_sources
+
+    @property
+    def min_sources(self) -> int:
+        return self._min_sources
+
+    def ground_identity(
+        self,
+        sources: list[IdentitySource],
+    ) -> GroundedIdentity | None:
+        """Attempt to establish a grounded identity from *sources*.
+
+        Returns ``None`` if fewer than *min_sources* verify successfully.
+        """
+        verified: list[VerificationResult] = []
+        for src in sources:
+            result = src.verify()
+            if result.verified:
+                verified.append(result)
+
+        if len(verified) < self._min_sources:
+            return None
+
+        # Resolve user_id: pick from the first source that supplied one.
+        user_id = ""
+        for v in verified:
+            if v.user_id:
+                user_id = v.user_id
+                break
+
+        confidence = self._compute_confidence(verified)
+        return GroundedIdentity(
+            identity_id=uuid.uuid4().hex,
+            user_id=user_id,
+            sources_used=[v.source_type for v in verified],
+            confidence=confidence,
+        )
+
+    @staticmethod
+    def _compute_confidence(verified: list[VerificationResult]) -> float:
+        """Compute a 0.0–1.0 confidence from verified source strengths."""
+        if not verified:
+            return 0.0
+        total = sum(
+            _SOURCE_STRENGTH.get(v.source_type, 0.5) for v in verified
+        )
+        max_possible = sum(_SOURCE_STRENGTH.values())
+        return min(total / max_possible, 1.0)

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -1,0 +1,315 @@
+"""Tests for openbad.identity.grounding — multi-source identity resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.identity.grounding import (
+    BiometricSource,
+    EnvironmentSource,
+    GroundedIdentity,
+    HardwareTokenSource,
+    IdentityGrounder,
+    IdentitySource,
+    PassphraseSource,
+    SourceType,
+    VerificationResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — lightweight stubs for tests
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysOk:
+    """Source that always verifies."""
+
+    source_type = SourceType.PASSPHRASE
+
+    def __init__(self, user_id: str = "test") -> None:
+        self._user_id = user_id
+
+    def verify(self) -> VerificationResult:
+        return VerificationResult(
+            verified=True,
+            source_type=self.source_type,
+            user_id=self._user_id,
+        )
+
+
+class _AlwaysFail:
+    """Source that always fails."""
+
+    source_type = SourceType.HARDWARE_TOKEN
+
+    def verify(self) -> VerificationResult:
+        return VerificationResult(
+            verified=False,
+            source_type=self.source_type,
+            detail="always fails",
+        )
+
+
+# ---------------------------------------------------------------------------
+# SourceType / VerificationResult
+# ---------------------------------------------------------------------------
+
+
+class TestSourceType:
+    def test_values(self) -> None:
+        assert SourceType.HARDWARE_TOKEN.value == "hardware_token"
+        assert SourceType.BIOMETRIC.value == "biometric"
+        assert SourceType.PASSPHRASE.value == "passphrase"
+        assert SourceType.ENVIRONMENT.value == "environment"
+
+
+class TestVerificationResult:
+    def test_frozen(self) -> None:
+        v = VerificationResult(True, SourceType.PASSPHRASE, "alice")
+        with pytest.raises(AttributeError):
+            v.verified = False  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# GroundedIdentity
+# ---------------------------------------------------------------------------
+
+
+class TestGroundedIdentity:
+    def test_defaults(self) -> None:
+        gi = GroundedIdentity(identity_id="abc", user_id="alice")
+        assert gi.sources_used == []
+        assert gi.confidence == 0.0
+        assert gi.timestamp > 0
+
+
+# ---------------------------------------------------------------------------
+# HardwareTokenSource (stub)
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareTokenSource:
+    def test_not_implemented(self) -> None:
+        src = HardwareTokenSource()
+        result = src.verify()
+        assert result.verified is False
+        assert result.source_type is SourceType.HARDWARE_TOKEN
+        assert "not implemented" in result.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# BiometricSource (stub)
+# ---------------------------------------------------------------------------
+
+
+class TestBiometricSource:
+    def test_not_implemented(self) -> None:
+        src = BiometricSource()
+        result = src.verify()
+        assert result.verified is False
+        assert result.source_type is SourceType.BIOMETRIC
+
+
+# ---------------------------------------------------------------------------
+# PassphraseSource
+# ---------------------------------------------------------------------------
+
+
+class TestPassphraseSource:
+    def test_correct_passphrase(self) -> None:
+        pw = "hunter2"
+        hashed = PassphraseSource.hash_passphrase(pw)
+        src = PassphraseSource(hashed, "alice", passphrase_input=pw)
+        result = src.verify()
+        assert result.verified is True
+        assert result.user_id == "alice"
+
+    def test_wrong_passphrase(self) -> None:
+        hashed = PassphraseSource.hash_passphrase("correct")
+        src = PassphraseSource(hashed, "alice", passphrase_input="wrong")  # noqa: S106
+        result = src.verify()
+        assert result.verified is False
+        assert result.user_id == ""
+
+    def test_no_input(self) -> None:
+        hashed = PassphraseSource.hash_passphrase("x")
+        src = PassphraseSource(hashed, "alice")
+        result = src.verify()
+        assert result.verified is False
+        assert "no passphrase" in result.detail.lower()
+
+    def test_hash_is_bytes(self) -> None:
+        h = PassphraseSource.hash_passphrase("test")
+        assert isinstance(h, bytes)
+        assert h.startswith(b"$2")
+
+    def test_conforms_to_protocol(self) -> None:
+        hashed = PassphraseSource.hash_passphrase("x")
+        src = PassphraseSource(hashed, "a", passphrase_input="x")  # noqa: S106
+        assert isinstance(src, IdentitySource)
+
+
+# ---------------------------------------------------------------------------
+# EnvironmentSource
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentSource:
+    def test_no_expected_user(self) -> None:
+        src = EnvironmentSource()
+        result = src.verify()
+        assert result.verified is True
+        assert result.user_id != ""
+
+    def test_expected_user_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("USER", "testuser")
+        src = EnvironmentSource(expected_user="testuser")
+        result = src.verify()
+        assert result.verified is True
+        assert result.user_id == "testuser"
+
+    def test_expected_user_mismatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("USER", "someone_else")
+        src = EnvironmentSource(expected_user="alice")
+        result = src.verify()
+        assert result.verified is False
+
+    def test_conforms_to_protocol(self) -> None:
+        assert isinstance(EnvironmentSource(), IdentitySource)
+
+
+# ---------------------------------------------------------------------------
+# IdentityGrounder — basic
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityGrounder:
+    def test_min_sources_default(self) -> None:
+        g = IdentityGrounder()
+        assert g.min_sources == 2
+
+    def test_min_sources_invalid(self) -> None:
+        with pytest.raises(ValueError, match="min_sources"):
+            IdentityGrounder(min_sources=0)
+
+    def test_two_ok_sources(self) -> None:
+        g = IdentityGrounder(min_sources=2)
+        result = g.ground_identity([_AlwaysOk("alice"), _AlwaysOk("alice")])
+        assert result is not None
+        assert result.user_id == "alice"
+        assert len(result.sources_used) == 2
+        assert result.confidence > 0.0
+
+    def test_one_ok_insufficient(self) -> None:
+        g = IdentityGrounder(min_sources=2)
+        result = g.ground_identity([_AlwaysOk("alice")])
+        assert result is None
+
+    def test_all_fail(self) -> None:
+        g = IdentityGrounder(min_sources=1)
+        result = g.ground_identity([_AlwaysFail(), _AlwaysFail()])
+        assert result is None
+
+    def test_mixed_sources(self) -> None:
+        g = IdentityGrounder(min_sources=1)
+        result = g.ground_identity([_AlwaysFail(), _AlwaysOk("bob")])
+        assert result is not None
+        assert result.user_id == "bob"
+        assert len(result.sources_used) == 1
+
+    def test_single_source_grounding(self) -> None:
+        g = IdentityGrounder(min_sources=1)
+        result = g.ground_identity([_AlwaysOk("alice")])
+        assert result is not None
+
+    def test_identity_id_is_unique(self) -> None:
+        g = IdentityGrounder(min_sources=1)
+        r1 = g.ground_identity([_AlwaysOk("a")])
+        r2 = g.ground_identity([_AlwaysOk("a")])
+        assert r1 is not None and r2 is not None
+        assert r1.identity_id != r2.identity_id
+
+
+# ---------------------------------------------------------------------------
+# Confidence scoring
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceScoring:
+    def test_stronger_sources_higher_confidence(self) -> None:
+        g = IdentityGrounder(min_sources=1)
+
+        class _HwOk:
+            source_type = SourceType.HARDWARE_TOKEN
+
+            def verify(self) -> VerificationResult:
+                return VerificationResult(True, self.source_type, "u")
+
+        class _EnvOk:
+            source_type = SourceType.ENVIRONMENT
+
+            def verify(self) -> VerificationResult:
+                return VerificationResult(True, self.source_type, "u")
+
+        hw = g.ground_identity([_HwOk()])
+        env = g.ground_identity([_EnvOk()])
+        assert hw is not None and env is not None
+        assert hw.confidence > env.confidence
+
+    def test_more_sources_higher_confidence(self) -> None:
+        g = IdentityGrounder(min_sources=1)
+        r1 = g.ground_identity([_AlwaysOk("a")])
+        r2 = g.ground_identity([_AlwaysOk("a"), _AlwaysOk("a")])
+        assert r1 is not None and r2 is not None
+        assert r2.confidence > r1.confidence
+
+    def test_all_sources_cap_at_one(self) -> None:
+        g = IdentityGrounder(min_sources=1)
+
+        class _FullStrength:
+            source_type = SourceType.HARDWARE_TOKEN
+
+            def verify(self) -> VerificationResult:
+                return VerificationResult(True, self.source_type, "u")
+
+        # Even with redundant max-strength sources, capped at 1.0.
+        r = g.ground_identity(
+            [_FullStrength(), _FullStrength(), _FullStrength(), _FullStrength()]
+        )
+        assert r is not None
+        assert r.confidence <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Integration-style: passphrase + environment
+# ---------------------------------------------------------------------------
+
+
+class TestGroundingWithRealSources:
+    def test_passphrase_plus_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("USER", "alice")
+        pw = "s3cret"
+        hashed = PassphraseSource.hash_passphrase(pw)
+        sources: list[IdentitySource] = [
+            PassphraseSource(hashed, "alice", passphrase_input=pw),
+            EnvironmentSource(expected_user="alice"),
+        ]
+        g = IdentityGrounder(min_sources=2)
+        result = g.ground_identity(sources)
+        assert result is not None
+        assert result.user_id == "alice"
+        assert SourceType.PASSPHRASE in result.sources_used
+        assert SourceType.ENVIRONMENT in result.sources_used
+
+    def test_passphrase_wrong_and_env_ok(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("USER", "alice")
+        hashed = PassphraseSource.hash_passphrase("correct")
+        sources: list[IdentitySource] = [
+            PassphraseSource(hashed, "alice", passphrase_input="wrong"),  # noqa: S106
+            EnvironmentSource(expected_user="alice"),
+        ]
+        g = IdentityGrounder(min_sources=2)
+        result = g.ground_identity(sources)
+        assert result is None  # Only 1 of 2 verified


### PR DESCRIPTION
Closes #78

## Summary
- `SourceType` enum, `VerificationResult`, `GroundedIdentity` dataclasses
- `IdentitySource` protocol with `verify()` method
- `HardwareTokenSource` and `BiometricSource` stubs (Phase 3 interface-only)
- `PassphraseSource`: bcrypt-hashed passphrase verification (never stores plaintext)
- `EnvironmentSource`: login user / SSH / env context verification
- `IdentityGrounder`: multi-source grounding with configurable min_sources (default 2)
- Confidence scoring based on source strength weights
- Added `bcrypt>=4.0` dependency
- 27 unit tests covering all sources, grounding logic, confidence, multi-source integration

## How to Test
```bash
pytest tests/test_grounding.py -v
```