### PR TITLE
#81: Add Ollama provider adapter with retry logic and streaming

### DIFF
--- a/src/openbad/cognitive/providers/ollama.py
+++ b/src/openbad/cognitive/providers/ollama.py
@@ -1,0 +1,183 @@
+"""Ollama provider adapter — local SLM inference via the Ollama HTTP API."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import aiohttp
+
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ModelInfo,
+    ProviderAdapter,
+)
+
+_DEFAULT_BASE_URL = "http://localhost:11434"
+_DEFAULT_MODEL = "llama3.2"
+_DEFAULT_TIMEOUT_S = 30
+_MAX_RETRIES = 2
+_RETRY_BACKOFF_S = 0.5
+
+
+class OllamaProvider(ProviderAdapter):
+    """Adapter for the Ollama local inference server.
+
+    Parameters
+    ----------
+    base_url:
+        Ollama HTTP endpoint (default ``http://localhost:11434``).
+    default_model:
+        Model to use when none is specified (default ``llama3.2``).
+    timeout_s:
+        HTTP request timeout in seconds.
+    max_retries:
+        Number of retry attempts for transient errors.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = _DEFAULT_BASE_URL,
+        default_model: str = _DEFAULT_MODEL,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        max_retries: int = _MAX_RETRIES,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._default_model = default_model
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._max_retries = max_retries
+
+    # ------------------------------------------------------------------ #
+    # ProviderAdapter interface
+    # ------------------------------------------------------------------ #
+
+    async def complete(
+        self,
+        prompt: str,
+        model_id: str | None = None,
+        **kwargs: Any,
+    ) -> CompletionResult:
+        model = model_id or self._default_model
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            **kwargs,
+        }
+        t0 = time.monotonic()
+        data = await self._post("/api/generate", payload)
+        latency_ms = (time.monotonic() - t0) * 1000
+
+        return CompletionResult(
+            content=data.get("response", ""),
+            model_id=model,
+            provider="ollama",
+            tokens_used=data.get("eval_count", 0),
+            latency_ms=latency_ms,
+            finish_reason=data.get("done_reason", ""),
+        )
+
+    async def stream(
+        self,
+        prompt: str,
+        model_id: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        model = model_id or self._default_model
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "stream": True,
+            **kwargs,
+        }
+        url = f"{self._base_url}/api/generate"
+        async with (
+            aiohttp.ClientSession(timeout=self._timeout) as session,
+            session.post(url, json=payload) as resp,
+        ):
+            resp.raise_for_status()
+            async for line in resp.content:
+                text = line.decode().strip()
+                if not text:
+                    continue
+                chunk = json.loads(text)
+                token = chunk.get("response", "")
+                if token:
+                    yield token
+
+    async def list_models(self) -> list[ModelInfo]:
+        data = await self._get("/api/tags")
+        models: list[ModelInfo] = []
+        for m in data.get("models", []):
+            models.append(
+                ModelInfo(
+                    model_id=m.get("name", ""),
+                    provider="ollama",
+                    context_window=m.get("details", {}).get(
+                        "context_length", 0
+                    ),
+                )
+            )
+        return models
+
+    async def health_check(self) -> HealthStatus:
+        t0 = time.monotonic()
+        try:
+            models = await self.list_models()
+            latency_ms = (time.monotonic() - t0) * 1000
+            return HealthStatus(
+                provider="ollama",
+                available=True,
+                latency_ms=latency_ms,
+                models_available=len(models),
+            )
+        except (aiohttp.ClientError, TimeoutError, OSError):
+            return HealthStatus(provider="ollama", available=False)
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+
+    async def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """POST with retry logic."""
+        url = f"{self._base_url}{path}"
+        last_exc: BaseException | None = None
+        for attempt in range(1, self._max_retries + 2):
+            try:
+                async with (
+                    aiohttp.ClientSession(timeout=self._timeout) as session,
+                    session.post(url, json=payload) as resp,
+                ):
+                    resp.raise_for_status()
+                    return await resp.json(content_type=None)
+            except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+                last_exc = exc
+                if attempt <= self._max_retries:
+                    import asyncio
+
+                    await asyncio.sleep(_RETRY_BACKOFF_S * attempt)
+        raise last_exc  # type: ignore[misc]
+
+    async def _get(self, path: str) -> dict[str, Any]:
+        """GET with retry logic."""
+        url = f"{self._base_url}{path}"
+        last_exc: BaseException | None = None
+        for attempt in range(1, self._max_retries + 2):
+            try:
+                async with (
+                    aiohttp.ClientSession(timeout=self._timeout) as session,
+                    session.get(url) as resp,
+                ):
+                    resp.raise_for_status()
+                    return await resp.json(content_type=None)
+            except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+                last_exc = exc
+                if attempt <= self._max_retries:
+                    import asyncio
+
+                    await asyncio.sleep(_RETRY_BACKOFF_S * attempt)
+        raise last_exc  # type: ignore[misc]

--- a/tests/test_ollama_provider.py
+++ b/tests/test_ollama_provider.py
@@ -1,0 +1,299 @@
+"""Tests for OllamaProvider — all HTTP calls are mocked."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ModelInfo,
+)
+from openbad.cognitive.providers.ollama import _DEFAULT_BASE_URL, OllamaProvider
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+
+def _json_response(data: dict[str, Any], status: int = 200) -> AsyncMock:
+    """Create a mock aiohttp response returning *data* as JSON."""
+    resp = AsyncMock()
+    resp.status = status
+    resp.raise_for_status = MagicMock(
+        side_effect=None
+        if status < 400
+        else aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=status,
+            message="error",
+        )
+    )
+    resp.json = AsyncMock(return_value=data)
+    # streaming
+    resp.content = _async_iter_bytes(data)
+    # context-manager support
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+async def _aiter_lines(lines: list[bytes]):
+    for line in lines:
+        yield line
+
+
+def _async_iter_bytes(data: dict[str, Any]):
+    """Return an async-iterable of bytes representing a single JSON chunk."""
+    raw = json.dumps(data).encode() + b"\n"
+    return _aiter_lines([raw])
+
+
+def _make_session(resp: AsyncMock) -> AsyncMock:
+    """Create a mock aiohttp.ClientSession that returns *resp* for any verb."""
+    session = AsyncMock()
+    session.post = MagicMock(return_value=resp)
+    session.get = MagicMock(return_value=resp)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+# ------------------------------------------------------------------ #
+# Tests — construction
+# ------------------------------------------------------------------ #
+
+
+class TestInit:
+    def test_defaults(self) -> None:
+        p = OllamaProvider()
+        assert p._base_url == _DEFAULT_BASE_URL
+        assert p._default_model == "llama3.2"
+        assert p._max_retries == 2
+
+    def test_custom(self) -> None:
+        p = OllamaProvider(
+            base_url="http://myhost:9999/",
+            default_model="phi3",
+            timeout_s=5,
+            max_retries=0,
+        )
+        assert p._base_url == "http://myhost:9999"
+        assert p._default_model == "phi3"
+        assert p._max_retries == 0
+
+
+# ------------------------------------------------------------------ #
+# Tests — complete()
+# ------------------------------------------------------------------ #
+
+
+class TestComplete:
+    @pytest.fixture()
+    def provider(self) -> OllamaProvider:
+        return OllamaProvider(max_retries=0)
+
+    async def test_basic_complete(self, provider: OllamaProvider) -> None:
+        body = {"response": "Hello!", "eval_count": 10, "done_reason": "stop"}
+        resp = _json_response(body)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await provider.complete("Say hi")
+        assert isinstance(result, CompletionResult)
+        assert result.content == "Hello!"
+        assert result.model_id == "llama3.2"
+        assert result.provider == "ollama"
+        assert result.tokens_used == 10
+        assert result.finish_reason == "stop"
+        assert result.latency_ms > 0
+
+    async def test_complete_custom_model(self, provider: OllamaProvider) -> None:
+        body = {"response": "done", "eval_count": 1, "done_reason": "stop"}
+        resp = _json_response(body)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await provider.complete("test", model_id="phi3")
+        assert result.model_id == "phi3"
+
+    async def test_complete_missing_fields(self, provider: OllamaProvider) -> None:
+        """Missing optional fields should produce safe defaults."""
+        body: dict[str, Any] = {}
+        resp = _json_response(body)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await provider.complete("test")
+        assert result.content == ""
+        assert result.tokens_used == 0
+        assert result.finish_reason == ""
+
+    async def test_complete_server_error_raises(
+        self, provider: OllamaProvider
+    ) -> None:
+        resp = _json_response({}, status=500)
+        session = _make_session(resp)
+        with (
+            patch("aiohttp.ClientSession", return_value=session),
+            pytest.raises(aiohttp.ClientResponseError),
+        ):
+            await provider.complete("fail")
+
+
+# ------------------------------------------------------------------ #
+# Tests — stream()
+# ------------------------------------------------------------------ #
+
+
+class TestStream:
+    @pytest.fixture()
+    def provider(self) -> OllamaProvider:
+        return OllamaProvider(max_retries=0)
+
+    async def test_stream_tokens(self, provider: OllamaProvider) -> None:
+        lines = [
+            json.dumps({"response": "Hello"}).encode() + b"\n",
+            json.dumps({"response": " world"}).encode() + b"\n",
+            json.dumps({"response": "", "done": True}).encode() + b"\n",
+        ]
+        resp = AsyncMock()
+        resp.raise_for_status = MagicMock()
+        resp.content = _aiter_lines(lines)
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            chunks = [c async for c in provider.stream("Say hi")]
+        assert chunks == ["Hello", " world"]
+
+    async def test_stream_skips_blank_lines(self, provider: OllamaProvider) -> None:
+        lines = [b"\n", json.dumps({"response": "ok"}).encode() + b"\n", b"  \n"]
+        resp = AsyncMock()
+        resp.raise_for_status = MagicMock()
+        resp.content = _aiter_lines(lines)
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            chunks = [c async for c in provider.stream("hi")]
+        assert chunks == ["ok"]
+
+
+# ------------------------------------------------------------------ #
+# Tests — list_models()
+# ------------------------------------------------------------------ #
+
+
+class TestListModels:
+    @pytest.fixture()
+    def provider(self) -> OllamaProvider:
+        return OllamaProvider(max_retries=0)
+
+    async def test_list_models(self, provider: OllamaProvider) -> None:
+        body = {
+            "models": [
+                {
+                    "name": "llama3.2",
+                    "details": {"context_length": 8192},
+                },
+                {
+                    "name": "phi3",
+                    "details": {},
+                },
+            ]
+        }
+        resp = _json_response(body)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            models = await provider.list_models()
+        assert len(models) == 2
+        assert all(isinstance(m, ModelInfo) for m in models)
+        assert models[0].model_id == "llama3.2"
+        assert models[0].context_window == 8192
+        assert models[1].context_window == 0
+
+    async def test_list_models_empty(self, provider: OllamaProvider) -> None:
+        resp = _json_response({"models": []})
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            models = await provider.list_models()
+        assert models == []
+
+
+# ------------------------------------------------------------------ #
+# Tests — health_check()
+# ------------------------------------------------------------------ #
+
+
+class TestHealthCheck:
+    @pytest.fixture()
+    def provider(self) -> OllamaProvider:
+        return OllamaProvider(max_retries=0)
+
+    async def test_healthy(self, provider: OllamaProvider) -> None:
+        body = {"models": [{"name": "llama3.2", "details": {}}]}
+        resp = _json_response(body)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            status = await provider.health_check()
+        assert isinstance(status, HealthStatus)
+        assert status.available is True
+        assert status.models_available == 1
+        assert status.latency_ms > 0
+
+    async def test_unhealthy(self, provider: OllamaProvider) -> None:
+        with patch(
+            "aiohttp.ClientSession",
+            side_effect=aiohttp.ClientConnectorError(
+                connection_key=MagicMock(), os_error=OSError("refused")
+            ),
+        ):
+            status = await provider.health_check()
+        assert status.available is False
+        assert status.models_available == 0
+
+
+# ------------------------------------------------------------------ #
+# Tests — retry logic
+# ------------------------------------------------------------------ #
+
+
+class TestRetry:
+    async def test_retries_transient_failure(self) -> None:
+        """Should succeed on second attempt after a transient error."""
+        p = OllamaProvider(max_retries=1)
+        good_resp = _json_response(
+            {"response": "ok", "eval_count": 1, "done_reason": "stop"}
+        )
+        bad_resp = _json_response({}, status=500)
+
+        call_count = 0
+
+        def _session_factory(*_a: Any, **_kw: Any) -> AsyncMock:
+            nonlocal call_count
+            call_count += 1
+            return _make_session(bad_resp if call_count == 1 else good_resp)
+
+        with (
+            patch("aiohttp.ClientSession", side_effect=_session_factory),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await p.complete("retry me")
+        assert result.content == "ok"
+        assert call_count == 2
+
+    async def test_exhausts_retries(self) -> None:
+        """Should raise after all retries fail."""
+        p = OllamaProvider(max_retries=1)
+        bad_resp = _json_response({}, status=500)
+        session = _make_session(bad_resp)
+        with (
+            patch("aiohttp.ClientSession", return_value=session),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(aiohttp.ClientResponseError),
+        ):
+            await p.complete("fail forever")


### PR DESCRIPTION
Closes #81

## Summary
- `OllamaProvider(ProviderAdapter)`: full ABC implementation for local Ollama inference
- `complete()`: POST `/api/generate` with non-streaming response
- `stream()`: streaming async iterator via `/api/generate`  
- `list_models()`: GET `/api/tags`  
- `health_check()`: connectivity + model count
- Retry logic with exponential backoff for transient errors
- Configurable base URL, default model, timeout, max retries
- Also fixes corrupted `test_stub_stream` line from #80
- 14 new unit tests (all HTTP mocked)

## How to Test
```bash
pytest tests/test_ollama_provider.py -v
```