### PR TITLE
#82: Add OpenAI-compatible provider adapters for 7 providers

### DIFF
--- a/src/openbad/cognitive/providers/openai_compat.py
+++ b/src/openbad/cognitive/providers/openai_compat.py
@@ -1,0 +1,328 @@
+"""OpenAI-compatible provider adapters.
+
+Supports OpenAI, OpenRouter, Groq, xAI, Mistral, OpenAI-Codex, and
+arbitrary custom endpoints that speak the Chat Completions API.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import aiohttp
+
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ModelInfo,
+    ProviderAdapter,
+)
+
+_RETRY_BACKOFF_S = 0.5
+
+
+class ProviderUnavailableError(Exception):
+    """Raised when a provider cannot be used (e.g. missing API key)."""
+
+
+class OpenAICompatProvider(ProviderAdapter):
+    """Base adapter for any OpenAI Chat-Completions-compatible API.
+
+    Parameters
+    ----------
+    provider_name:
+        Logical name used in logs and ``CompletionResult.provider``.
+    base_url:
+        API root URL (no trailing slash).
+    api_key_env:
+        Environment variable that holds the API key.
+    default_model:
+        Model ID to use when none is specified.
+    timeout_s:
+        HTTP request timeout in seconds.
+    max_retries:
+        Retries for transient HTTP errors.
+    extra_headers:
+        Additional headers merged into every request.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider_name: str,
+        base_url: str,
+        api_key_env: str = "",
+        default_model: str = "",
+        timeout_s: float = 30,
+        max_retries: int = 2,
+        extra_headers: dict[str, str] | None = None,
+    ) -> None:
+        self._provider_name = provider_name
+        self._base_url = base_url.rstrip("/")
+        self._api_key_env = api_key_env
+        self._default_model = default_model
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._max_retries = max_retries
+        self._extra_headers = extra_headers or {}
+
+    # ------------------------------------------------------------------ #
+    # Key helpers
+    # ------------------------------------------------------------------ #
+
+    def _resolve_api_key(self) -> str:
+        """Return the API key or raise ``ProviderUnavailable``."""
+        if not self._api_key_env:
+            return ""
+        key = os.environ.get(self._api_key_env, "")
+        if not key:
+            msg = (
+                f"Provider '{self._provider_name}' requires env var "
+                f"'{self._api_key_env}' but it is not set."
+            )
+            raise ProviderUnavailableError(msg)
+        return key
+
+    def _headers(self) -> dict[str, str]:
+        key = self._resolve_api_key()
+        h: dict[str, str] = {"Content-Type": "application/json"}
+        if key:
+            h["Authorization"] = f"Bearer {key}"
+        h.update(self._extra_headers)
+        return h
+
+    # ------------------------------------------------------------------ #
+    # ProviderAdapter interface
+    # ------------------------------------------------------------------ #
+
+    async def complete(
+        self,
+        prompt: str,
+        model_id: str | None = None,
+        **kwargs: Any,
+    ) -> CompletionResult:
+        model = model_id or self._default_model
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            **kwargs,
+        }
+        t0 = time.monotonic()
+        data = await self._post("/v1/chat/completions", payload)
+        latency_ms = (time.monotonic() - t0) * 1000
+
+        choice = data.get("choices", [{}])[0] if data.get("choices") else {}
+        usage = data.get("usage", {})
+
+        return CompletionResult(
+            content=choice.get("message", {}).get("content", ""),
+            model_id=data.get("model", model),
+            provider=self._provider_name,
+            tokens_used=usage.get("total_tokens", 0),
+            latency_ms=latency_ms,
+            finish_reason=choice.get("finish_reason", ""),
+        )
+
+    async def stream(
+        self,
+        prompt: str,
+        model_id: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        model = model_id or self._default_model
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": True,
+            **kwargs,
+        }
+        url = f"{self._base_url}/v1/chat/completions"
+        headers = self._headers()
+        async with (
+            aiohttp.ClientSession(timeout=self._timeout) as session,
+            session.post(url, json=payload, headers=headers) as resp,
+        ):
+            resp.raise_for_status()
+            async for line in resp.content:
+                text = line.decode().strip()
+                if not text or not text.startswith("data:"):
+                    continue
+                data_str = text[len("data:"):].strip()
+                if data_str == "[DONE]":
+                    break
+                chunk = json.loads(data_str)
+                delta = (
+                    chunk.get("choices", [{}])[0]
+                    .get("delta", {})
+                    .get("content", "")
+                )
+                if delta:
+                    yield delta
+
+    async def list_models(self) -> list[ModelInfo]:
+        data = await self._get("/v1/models")
+        models: list[ModelInfo] = []
+        for m in data.get("data", []):
+            models.append(
+                ModelInfo(
+                    model_id=m.get("id", ""),
+                    provider=self._provider_name,
+                )
+            )
+        return models
+
+    async def health_check(self) -> HealthStatus:
+        t0 = time.monotonic()
+        try:
+            models = await self.list_models()
+            latency_ms = (time.monotonic() - t0) * 1000
+            return HealthStatus(
+                provider=self._provider_name,
+                available=True,
+                latency_ms=latency_ms,
+                models_available=len(models),
+            )
+        except (aiohttp.ClientError, TimeoutError, OSError, ProviderUnavailableError):
+            return HealthStatus(provider=self._provider_name, available=False)
+
+    # ------------------------------------------------------------------ #
+    # HTTP with retry
+    # ------------------------------------------------------------------ #
+
+    async def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self._base_url}{path}"
+        headers = self._headers()
+        last_exc: BaseException | None = None
+        for attempt in range(1, self._max_retries + 2):
+            try:
+                async with (
+                    aiohttp.ClientSession(timeout=self._timeout) as session,
+                    session.post(url, json=payload, headers=headers) as resp,
+                ):
+                    resp.raise_for_status()
+                    return await resp.json(content_type=None)
+            except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+                last_exc = exc
+                if attempt <= self._max_retries:
+                    import asyncio
+
+                    await asyncio.sleep(_RETRY_BACKOFF_S * attempt)
+        raise last_exc  # type: ignore[misc]
+
+    async def _get(self, path: str) -> dict[str, Any]:
+        url = f"{self._base_url}{path}"
+        headers = self._headers()
+        last_exc: BaseException | None = None
+        for attempt in range(1, self._max_retries + 2):
+            try:
+                async with (
+                    aiohttp.ClientSession(timeout=self._timeout) as session,
+                    session.get(url, headers=headers) as resp,
+                ):
+                    resp.raise_for_status()
+                    return await resp.json(content_type=None)
+            except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+                last_exc = exc
+                if attempt <= self._max_retries:
+                    import asyncio
+
+                    await asyncio.sleep(_RETRY_BACKOFF_S * attempt)
+        raise last_exc  # type: ignore[misc]
+
+
+# ------------------------------------------------------------------ #
+# Concrete thin adapters
+# ------------------------------------------------------------------ #
+
+
+def openai_provider(**overrides: Any) -> OpenAICompatProvider:
+    """Standard OpenAI API."""
+    defaults = {
+        "provider_name": "openai",
+        "base_url": "https://api.openai.com",
+        "api_key_env": "OPENAI_API_KEY",
+        "default_model": "gpt-4o-mini",
+    }
+    defaults.update(overrides)
+    return OpenAICompatProvider(**defaults)
+
+
+def openai_codex_provider(**overrides: Any) -> OpenAICompatProvider:
+    """OpenAI Codex (OAuth-token-based)."""
+    defaults = {
+        "provider_name": "openai-codex",
+        "base_url": "https://api.openai.com",
+        "api_key_env": "OPENAI_CODEX_TOKEN",
+        "default_model": "codex",
+    }
+    defaults.update(overrides)
+    return OpenAICompatProvider(**defaults)
+
+
+def openrouter_provider(**overrides: Any) -> OpenAICompatProvider:
+    """OpenRouter aggregator."""
+    defaults = {
+        "provider_name": "openrouter",
+        "base_url": "https://openrouter.ai/api",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "default_model": "openai/gpt-4o-mini",
+    }
+    defaults.update(overrides)
+    return OpenAICompatProvider(**defaults)
+
+
+def groq_provider(**overrides: Any) -> OpenAICompatProvider:
+    """Groq inference API."""
+    defaults = {
+        "provider_name": "groq",
+        "base_url": "https://api.groq.com/openai",
+        "api_key_env": "GROQ_API_KEY",
+        "default_model": "llama-3.1-8b-instant",
+    }
+    defaults.update(overrides)
+    return OpenAICompatProvider(**defaults)
+
+
+def xai_provider(**overrides: Any) -> OpenAICompatProvider:
+    """xAI (Grok) API."""
+    defaults = {
+        "provider_name": "xai",
+        "base_url": "https://api.x.ai",
+        "api_key_env": "XAI_API_KEY",
+        "default_model": "grok-3-mini",
+    }
+    defaults.update(overrides)
+    return OpenAICompatProvider(**defaults)
+
+
+def mistral_provider(**overrides: Any) -> OpenAICompatProvider:
+    """Mistral AI API."""
+    defaults = {
+        "provider_name": "mistral",
+        "base_url": "https://api.mistral.ai",
+        "api_key_env": "MISTRAL_API_KEY",
+        "default_model": "mistral-small-latest",
+    }
+    defaults.update(overrides)
+    return OpenAICompatProvider(**defaults)
+
+
+def custom_provider(
+    *,
+    base_url: str,
+    api_key_env: str = "",
+    default_model: str = "",
+    **overrides: Any,
+) -> OpenAICompatProvider:
+    """User-configured custom OpenAI-compatible endpoint."""
+    defaults: dict[str, Any] = {
+        "provider_name": "custom",
+        "base_url": base_url,
+        "api_key_env": api_key_env,
+        "default_model": default_model,
+    }
+    defaults.update(overrides)
+    return OpenAICompatProvider(**defaults)

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1,0 +1,326 @@
+"""Tests for OpenAI-compatible provider adapters — all HTTP mocked."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ModelInfo,
+)
+from openbad.cognitive.providers.openai_compat import (
+    OpenAICompatProvider,
+    ProviderUnavailableError,
+    custom_provider,
+    groq_provider,
+    mistral_provider,
+    openai_codex_provider,
+    openai_provider,
+    openrouter_provider,
+    xai_provider,
+)
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+_CHAT_RESPONSE: dict[str, Any] = {
+    "model": "gpt-4o-mini",
+    "choices": [
+        {
+            "message": {"role": "assistant", "content": "Hello!"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"total_tokens": 15},
+}
+
+_MODELS_RESPONSE: dict[str, Any] = {
+    "data": [
+        {"id": "gpt-4o-mini"},
+        {"id": "gpt-4o"},
+    ]
+}
+
+
+def _json_response(data: dict[str, Any], status: int = 200) -> AsyncMock:
+    resp = AsyncMock()
+    resp.status = status
+    resp.raise_for_status = MagicMock(
+        side_effect=None
+        if status < 400
+        else aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=status, message="err",
+        )
+    )
+    resp.json = AsyncMock(return_value=data)
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+def _sse_response(events: list[str]) -> AsyncMock:
+    """Mock streaming SSE response."""
+    async def _aiter():
+        for ev in events:
+            yield ev.encode()
+    resp = AsyncMock()
+    resp.raise_for_status = MagicMock()
+    resp.content = _aiter()
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+def _make_session(resp: AsyncMock) -> AsyncMock:
+    session = AsyncMock()
+    session.post = MagicMock(return_value=resp)
+    session.get = MagicMock(return_value=resp)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _provider(**kw: Any) -> OpenAICompatProvider:
+    """Create a test provider with a fake key env var."""
+    defaults: dict[str, Any] = {
+        "provider_name": "test",
+        "base_url": "https://api.test.com",
+        "api_key_env": "",
+        "default_model": "test-model",
+        "max_retries": 0,
+    }
+    defaults.update(kw)
+    return OpenAICompatProvider(**defaults)
+
+
+# ------------------------------------------------------------------ #
+# Tests — construction & API key resolution
+# ------------------------------------------------------------------ #
+
+
+class TestInit:
+    def test_defaults(self) -> None:
+        p = _provider()
+        assert p._provider_name == "test"
+        assert p._base_url == "https://api.test.com"
+
+    def test_missing_api_key_raises(self) -> None:
+        p = _provider(api_key_env="MISSING_KEY_12345")
+        with pytest.raises(ProviderUnavailableError, match="MISSING_KEY_12345"):
+            p._resolve_api_key()
+
+    def test_api_key_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_KEY_ABC", "sk-test")  # noqa: S106
+        p = _provider(api_key_env="TEST_KEY_ABC")
+        assert p._resolve_api_key() == "sk-test"  # noqa: S105
+
+    def test_no_key_env_returns_empty(self) -> None:
+        p = _provider(api_key_env="")
+        assert p._resolve_api_key() == ""
+
+
+# ------------------------------------------------------------------ #
+# Tests — complete()
+# ------------------------------------------------------------------ #
+
+
+class TestComplete:
+    async def test_basic_complete(self) -> None:
+        p = _provider()
+        resp = _json_response(_CHAT_RESPONSE)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await p.complete("Say hi")
+        assert isinstance(result, CompletionResult)
+        assert result.content == "Hello!"
+        assert result.provider == "test"
+        assert result.tokens_used == 15
+        assert result.finish_reason == "stop"
+        assert result.latency_ms > 0
+
+    async def test_complete_custom_model(self) -> None:
+        p = _provider()
+        resp = _json_response(_CHAT_RESPONSE)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await p.complete("test", model_id="custom-model")
+        # The response model comes from server JSON
+        assert result.model_id == "gpt-4o-mini"
+
+    async def test_complete_empty_choices(self) -> None:
+        body: dict[str, Any] = {"choices": [], "usage": {}}
+        resp = _json_response(body)
+        session = _make_session(resp)
+        p = _provider()
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await p.complete("test")
+        assert result.content == ""
+        assert result.tokens_used == 0
+
+    async def test_complete_missing_key_raises(self) -> None:
+        p = _provider(api_key_env="NO_SUCH_KEY_99")
+        with pytest.raises(ProviderUnavailableError):
+            await p.complete("test")
+
+    async def test_complete_server_error(self) -> None:
+        p = _provider()
+        resp = _json_response({}, status=500)
+        session = _make_session(resp)
+        with (
+            patch("aiohttp.ClientSession", return_value=session),
+            pytest.raises(aiohttp.ClientResponseError),
+        ):
+            await p.complete("fail")
+
+
+# ------------------------------------------------------------------ #
+# Tests — stream()
+# ------------------------------------------------------------------ #
+
+
+class TestStream:
+    async def test_stream_tokens(self) -> None:
+        events = [
+            'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+            "data: [DONE]\n",
+        ]
+        resp = _sse_response(events)
+        session = _make_session(resp)
+        p = _provider()
+        with patch("aiohttp.ClientSession", return_value=session):
+            chunks = [c async for c in p.stream("hi")]
+        assert chunks == ["Hello", " world"]
+
+    async def test_stream_skips_non_data_lines(self) -> None:
+        events = [
+            ": keep-alive\n",
+            "\n",
+            'data: {"choices":[{"delta":{"content":"ok"}}]}\n',
+            "data: [DONE]\n",
+        ]
+        resp = _sse_response(events)
+        session = _make_session(resp)
+        p = _provider()
+        with patch("aiohttp.ClientSession", return_value=session):
+            chunks = [c async for c in p.stream("hi")]
+        assert chunks == ["ok"]
+
+    async def test_stream_missing_key(self) -> None:
+        p = _provider(api_key_env="MISSING_KEY_STREAM")
+        with pytest.raises(ProviderUnavailableError):
+            async for _ in p.stream("fail"):
+                pass  # pragma: no cover
+
+
+# ------------------------------------------------------------------ #
+# Tests — list_models()
+# ------------------------------------------------------------------ #
+
+
+class TestListModels:
+    async def test_list(self) -> None:
+        resp = _json_response(_MODELS_RESPONSE)
+        session = _make_session(resp)
+        p = _provider()
+        with patch("aiohttp.ClientSession", return_value=session):
+            models = await p.list_models()
+        assert len(models) == 2
+        assert all(isinstance(m, ModelInfo) for m in models)
+        assert models[0].model_id == "gpt-4o-mini"
+
+    async def test_list_empty(self) -> None:
+        resp = _json_response({"data": []})
+        session = _make_session(resp)
+        p = _provider()
+        with patch("aiohttp.ClientSession", return_value=session):
+            models = await p.list_models()
+        assert models == []
+
+
+# ------------------------------------------------------------------ #
+# Tests — health_check()
+# ------------------------------------------------------------------ #
+
+
+class TestHealthCheck:
+    async def test_healthy(self) -> None:
+        resp = _json_response(_MODELS_RESPONSE)
+        session = _make_session(resp)
+        p = _provider()
+        with patch("aiohttp.ClientSession", return_value=session):
+            status = await p.health_check()
+        assert isinstance(status, HealthStatus)
+        assert status.available is True
+        assert status.models_available == 2
+
+    async def test_unhealthy_network(self) -> None:
+        p = _provider()
+        with patch(
+            "aiohttp.ClientSession",
+            side_effect=aiohttp.ClientConnectorError(
+                connection_key=MagicMock(), os_error=OSError("refused"),
+            ),
+        ):
+            status = await p.health_check()
+        assert status.available is False
+
+    async def test_unhealthy_missing_key(self) -> None:
+        """Missing key → ProviderUnavailable → health reports unavailable."""
+        p = _provider(api_key_env="MISSING_KEY_HEALTH")
+        status = await p.health_check()
+        assert status.available is False
+
+
+# ------------------------------------------------------------------ #
+# Tests — factory functions
+# ------------------------------------------------------------------ #
+
+
+class TestFactories:
+    def test_openai(self) -> None:
+        p = openai_provider()
+        assert p._provider_name == "openai"
+        assert "openai.com" in p._base_url
+        assert p._api_key_env == "OPENAI_API_KEY"
+
+    def test_openai_codex(self) -> None:
+        p = openai_codex_provider()
+        assert p._provider_name == "openai-codex"
+        assert p._default_model == "codex"
+
+    def test_openrouter(self) -> None:
+        p = openrouter_provider()
+        assert p._provider_name == "openrouter"
+        assert "openrouter.ai" in p._base_url
+
+    def test_groq(self) -> None:
+        p = groq_provider()
+        assert p._provider_name == "groq"
+        assert "groq.com" in p._base_url
+
+    def test_xai(self) -> None:
+        p = xai_provider()
+        assert p._provider_name == "xai"
+        assert "x.ai" in p._base_url
+
+    def test_mistral(self) -> None:
+        p = mistral_provider()
+        assert p._provider_name == "mistral"
+        assert "mistral.ai" in p._base_url
+
+    def test_custom(self) -> None:
+        p = custom_provider(base_url="http://myhost:8080")
+        assert p._provider_name == "custom"
+        assert p._base_url == "http://myhost:8080"
+
+    def test_factory_override(self) -> None:
+        p = openai_provider(default_model="gpt-4o", max_retries=5)
+        assert p._default_model == "gpt-4o"
+        assert p._max_retries == 5


### PR DESCRIPTION
Closes #82

## Summary
- `OpenAICompatProvider(ProviderAdapter)`: base class for Chat Completions API
- Factory functions for 7 providers: openai, openai-codex, openrouter, groq, xai, mistral, custom
- SSE streaming, retry with backoff, `ProviderUnavailableError` for missing keys
- 25 unit tests (all HTTP mocked)

## How to Test
```bash
pytest tests/test_openai_compat.py -v
```