### PR TITLE
#83: Add Anthropic Messages API provider adapter

### DIFF
--- a/src/openbad/cognitive/providers/anthropic.py
+++ b/src/openbad/cognitive/providers/anthropic.py
@@ -1,0 +1,221 @@
+"""Anthropic Messages API provider adapter for Claude models."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import aiohttp
+
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ModelInfo,
+    ProviderAdapter,
+)
+
+_DEFAULT_BASE_URL = "https://api.anthropic.com"
+_DEFAULT_MODEL = "claude-sonnet-4-20250514"
+_ANTHROPIC_VERSION = "2023-06-01"
+_RETRY_BACKOFF_S = 0.5
+
+# Known Anthropic models (no discovery endpoint available).
+_KNOWN_MODELS: list[dict[str, Any]] = [
+    {"id": "claude-sonnet-4-20250514", "context_window": 200_000},
+    {"id": "claude-opus-4-20250514", "context_window": 200_000},
+    {"id": "claude-3-5-haiku-20241022", "context_window": 200_000},
+    {"id": "claude-3-5-sonnet-20241022", "context_window": 200_000},
+]
+
+
+class AnthropicKeyMissingError(Exception):
+    """Raised when the Anthropic API key is not set."""
+
+
+class AnthropicProvider(ProviderAdapter):
+    """Adapter for the Anthropic Messages API.
+
+    Parameters
+    ----------
+    base_url:
+        API root (default ``https://api.anthropic.com``).
+    api_key_env:
+        Environment variable holding the API key.
+    default_model:
+        Model to use when none specified.
+    timeout_s:
+        HTTP timeout in seconds.
+    max_retries:
+        Retry attempts for transient errors.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = _DEFAULT_BASE_URL,
+        api_key_env: str = "ANTHROPIC_API_KEY",
+        default_model: str = _DEFAULT_MODEL,
+        timeout_s: float = 30,
+        max_retries: int = 2,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key_env = api_key_env
+        self._default_model = default_model
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._max_retries = max_retries
+
+    # ------------------------------------------------------------------ #
+    # Key / header helpers
+    # ------------------------------------------------------------------ #
+
+    def _resolve_api_key(self) -> str:
+        key = os.environ.get(self._api_key_env, "")
+        if not key:
+            msg = (
+                f"Anthropic provider requires env var "
+                f"'{self._api_key_env}' but it is not set."
+            )
+            raise AnthropicKeyMissingError(msg)
+        return key
+
+    def _headers(self) -> dict[str, str]:
+        key = self._resolve_api_key()
+        return {
+            "Content-Type": "application/json",
+            "x-api-key": key,
+            "anthropic-version": _ANTHROPIC_VERSION,
+        }
+
+    # ------------------------------------------------------------------ #
+    # ProviderAdapter interface
+    # ------------------------------------------------------------------ #
+
+    async def complete(
+        self,
+        prompt: str,
+        model_id: str | None = None,
+        **kwargs: Any,
+    ) -> CompletionResult:
+        model = model_id or self._default_model
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": kwargs.pop("max_tokens", 4096),
+            **kwargs,
+        }
+        t0 = time.monotonic()
+        data = await self._post("/v1/messages", payload)
+        latency_ms = (time.monotonic() - t0) * 1000
+
+        content_blocks = data.get("content", [])
+        text = "".join(
+            b.get("text", "") for b in content_blocks if b.get("type") == "text"
+        )
+        usage = data.get("usage", {})
+
+        return CompletionResult(
+            content=text,
+            model_id=data.get("model", model),
+            provider="anthropic",
+            tokens_used=usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
+            latency_ms=latency_ms,
+            finish_reason=data.get("stop_reason", ""),
+        )
+
+    async def stream(
+        self,
+        prompt: str,
+        model_id: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        model = model_id or self._default_model
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": kwargs.pop("max_tokens", 4096),
+            "stream": True,
+            **kwargs,
+        }
+        url = f"{self._base_url}/v1/messages"
+        headers = self._headers()
+        async with (
+            aiohttp.ClientSession(timeout=self._timeout) as session,
+            session.post(url, json=payload, headers=headers) as resp,
+        ):
+            resp.raise_for_status()
+            async for line in resp.content:
+                text = line.decode().strip()
+                if not text or not text.startswith("data:"):
+                    continue
+                data_str = text[len("data:"):].strip()
+                if not data_str:
+                    continue
+                chunk = json.loads(data_str)
+                if chunk.get("type") == "content_block_delta":
+                    delta_text = chunk.get("delta", {}).get("text", "")
+                    if delta_text:
+                        yield delta_text
+
+    async def list_models(self) -> list[ModelInfo]:
+        return [
+            ModelInfo(
+                model_id=m["id"],
+                provider="anthropic",
+                context_window=m.get("context_window", 0),
+            )
+            for m in _KNOWN_MODELS
+        ]
+
+    async def health_check(self) -> HealthStatus:
+        t0 = time.monotonic()
+        try:
+            self._resolve_api_key()
+            # Light-weight ping: send a minimal messages request that will
+            # return quickly.  We use max_tokens=1 to keep cost minimal.
+            payload: dict[str, Any] = {
+                "model": self._default_model,
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 1,
+            }
+            await self._post("/v1/messages", payload)
+            latency_ms = (time.monotonic() - t0) * 1000
+            return HealthStatus(
+                provider="anthropic",
+                available=True,
+                latency_ms=latency_ms,
+                models_available=len(_KNOWN_MODELS),
+            )
+        except (
+            aiohttp.ClientError,
+            TimeoutError,
+            OSError,
+            AnthropicKeyMissingError,
+        ):
+            return HealthStatus(provider="anthropic", available=False)
+
+    # ------------------------------------------------------------------ #
+    # HTTP with retry
+    # ------------------------------------------------------------------ #
+
+    async def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self._base_url}{path}"
+        headers = self._headers()
+        last_exc: BaseException | None = None
+        for attempt in range(1, self._max_retries + 2):
+            try:
+                async with (
+                    aiohttp.ClientSession(timeout=self._timeout) as session,
+                    session.post(url, json=payload, headers=headers) as resp,
+                ):
+                    resp.raise_for_status()
+                    return await resp.json(content_type=None)
+            except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+                last_exc = exc
+                if attempt <= self._max_retries:
+                    import asyncio
+
+                    await asyncio.sleep(_RETRY_BACKOFF_S * attempt)
+        raise last_exc  # type: ignore[misc]

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -1,0 +1,229 @@
+"""Tests for AnthropicProvider — all HTTP calls mocked."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from openbad.cognitive.providers.anthropic import (
+    AnthropicKeyMissingError,
+    AnthropicProvider,
+)
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ModelInfo,
+)
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+_MESSAGES_RESPONSE: dict[str, Any] = {
+    "model": "claude-sonnet-4-20250514",
+    "content": [{"type": "text", "text": "Hello!"}],
+    "usage": {"input_tokens": 5, "output_tokens": 10},
+    "stop_reason": "end_turn",
+}
+
+
+def _json_response(data: dict[str, Any], status: int = 200) -> AsyncMock:
+    resp = AsyncMock()
+    resp.status = status
+    resp.raise_for_status = MagicMock(
+        side_effect=None
+        if status < 400
+        else aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=status, message="err",
+        )
+    )
+    resp.json = AsyncMock(return_value=data)
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+def _sse_response(events: list[str]) -> AsyncMock:
+    async def _aiter():
+        for ev in events:
+            yield ev.encode()
+    resp = AsyncMock()
+    resp.raise_for_status = MagicMock()
+    resp.content = _aiter()
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+def _make_session(resp: AsyncMock) -> AsyncMock:
+    session = AsyncMock()
+    session.post = MagicMock(return_value=resp)
+    session.get = MagicMock(return_value=resp)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+@pytest.fixture()
+def provider(monkeypatch: pytest.MonkeyPatch) -> AnthropicProvider:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")  # noqa: S106
+    return AnthropicProvider(max_retries=0)
+
+
+# ------------------------------------------------------------------ #
+# Tests — init and key resolution
+# ------------------------------------------------------------------ #
+
+
+class TestInit:
+    def test_defaults(self, provider: AnthropicProvider) -> None:
+        assert provider._default_model == "claude-sonnet-4-20250514"
+        assert "anthropic.com" in provider._base_url
+
+    def test_missing_key_raises(self) -> None:
+        p = AnthropicProvider(api_key_env="MISSING_ANT_KEY_XYZ")
+        with pytest.raises(AnthropicKeyMissingError, match="MISSING_ANT_KEY_XYZ"):
+            p._resolve_api_key()
+
+    def test_headers_include_version(self, provider: AnthropicProvider) -> None:
+        h = provider._headers()
+        assert h["anthropic-version"] == "2023-06-01"
+        assert h["x-api-key"] == "sk-ant-test"  # noqa: S105
+
+
+# ------------------------------------------------------------------ #
+# Tests — complete()
+# ------------------------------------------------------------------ #
+
+
+class TestComplete:
+    async def test_basic(self, provider: AnthropicProvider) -> None:
+        resp = _json_response(_MESSAGES_RESPONSE)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await provider.complete("Say hi")
+        assert isinstance(result, CompletionResult)
+        assert result.content == "Hello!"
+        assert result.provider == "anthropic"
+        assert result.tokens_used == 15
+        assert result.finish_reason == "end_turn"
+        assert result.latency_ms > 0
+
+    async def test_custom_model(self, provider: AnthropicProvider) -> None:
+        resp = _json_response(_MESSAGES_RESPONSE)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await provider.complete("test", model_id="claude-3-5-haiku-20241022")
+        assert result.model_id == "claude-sonnet-4-20250514"  # from response
+
+    async def test_empty_content(self, provider: AnthropicProvider) -> None:
+        body: dict[str, Any] = {"content": [], "usage": {}, "stop_reason": ""}
+        resp = _json_response(body)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await provider.complete("test")
+        assert result.content == ""
+        assert result.tokens_used == 0
+
+    async def test_missing_key(self) -> None:
+        p = AnthropicProvider(api_key_env="NO_KEY_HERE_123")
+        with pytest.raises(AnthropicKeyMissingError):
+            await p.complete("fail")
+
+    async def test_server_error(self, provider: AnthropicProvider) -> None:
+        resp = _json_response({}, status=500)
+        session = _make_session(resp)
+        with (
+            patch("aiohttp.ClientSession", return_value=session),
+            pytest.raises(aiohttp.ClientResponseError),
+        ):
+            await provider.complete("fail")
+
+
+# ------------------------------------------------------------------ #
+# Tests — stream()
+# ------------------------------------------------------------------ #
+
+
+class TestStream:
+    async def test_stream_content_block_delta(
+        self, provider: AnthropicProvider
+    ) -> None:
+        events = [
+            'data: {"type": "content_block_start"}\n',
+            'data: {"type": "content_block_delta", "delta": {"text": "Hello"}}\n',
+            'data: {"type": "content_block_delta", "delta": {"text": " world"}}\n',
+            'data: {"type": "message_stop"}\n',
+        ]
+        resp = _sse_response(events)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            chunks = [c async for c in provider.stream("hi")]
+        assert chunks == ["Hello", " world"]
+
+    async def test_stream_skips_non_data(self, provider: AnthropicProvider) -> None:
+        events = [
+            "event: ping\n",
+            "\n",
+            'data: {"type": "content_block_delta", "delta": {"text": "ok"}}\n',
+        ]
+        resp = _sse_response(events)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            chunks = [c async for c in provider.stream("hi")]
+        assert chunks == ["ok"]
+
+    async def test_stream_missing_key(self) -> None:
+        p = AnthropicProvider(api_key_env="NO_KEY_STREAM_ANT")
+        with pytest.raises(AnthropicKeyMissingError):
+            async for _ in p.stream("fail"):
+                pass  # pragma: no cover
+
+
+# ------------------------------------------------------------------ #
+# Tests — list_models()
+# ------------------------------------------------------------------ #
+
+
+class TestListModels:
+    async def test_known_models(self, provider: AnthropicProvider) -> None:
+        models = await provider.list_models()
+        assert len(models) >= 4
+        assert all(isinstance(m, ModelInfo) for m in models)
+        ids = [m.model_id for m in models]
+        assert "claude-sonnet-4-20250514" in ids
+        assert all(m.provider == "anthropic" for m in models)
+
+
+# ------------------------------------------------------------------ #
+# Tests — health_check()
+# ------------------------------------------------------------------ #
+
+
+class TestHealthCheck:
+    async def test_healthy(self, provider: AnthropicProvider) -> None:
+        resp = _json_response(_MESSAGES_RESPONSE)
+        session = _make_session(resp)
+        with patch("aiohttp.ClientSession", return_value=session):
+            status = await provider.health_check()
+        assert isinstance(status, HealthStatus)
+        assert status.available is True
+        assert status.models_available >= 4
+
+    async def test_unhealthy_network(self, provider: AnthropicProvider) -> None:
+        with patch(
+            "aiohttp.ClientSession",
+            side_effect=aiohttp.ClientConnectorError(
+                connection_key=MagicMock(), os_error=OSError("refused"),
+            ),
+        ):
+            status = await provider.health_check()
+        assert status.available is False
+
+    async def test_unhealthy_missing_key(self) -> None:
+        p = AnthropicProvider(api_key_env="MISSING_ANT_HEALTH")
+        status = await p.health_check()
+        assert status.available is False


### PR DESCRIPTION
Closes #83

## Summary
- `AnthropicProvider(ProviderAdapter)` for Claude models via Messages API
- `x-api-key` + `anthropic-version` headers, `content_block_delta` SSE streaming
- Known model list (no discovery endpoint), health check via minimal ping
- Retry with backoff, `AnthropicKeyMissingError` for missing keys
- 15 unit tests (all HTTP mocked)

## How to Test
```bash
pytest tests/test_anthropic_provider.py -v
```