### PR TITLE
#85: Add model router with priority-based fallback chains

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -1,0 +1,30 @@
+# Default model routing configuration for OpenBaD
+
+cortisol_threshold: 0.8
+budget_limit: 0  # 0 = unlimited
+health_ttl_s: 60
+
+chains:
+  critical:
+    - provider: anthropic
+      model: claude-sonnet-4-20250514
+    - provider: openai
+      model: gpt-4o
+    - provider: ollama
+      model: llama3.2
+
+  high:
+    - provider: openai
+      model: gpt-4o-mini
+    - provider: ollama
+      model: llama3.2
+
+  medium:
+    - provider: ollama
+      model: llama3.2
+    - provider: openai
+      model: gpt-4o-mini
+
+  low:
+    - provider: ollama
+      model: llama3.2

--- a/src/openbad/cognitive/model_router.py
+++ b/src/openbad/cognitive/model_router.py
@@ -1,0 +1,258 @@
+"""Model router — priority-based provider selection with fallback chains."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any
+
+import yaml
+
+from openbad.cognitive.providers.base import ProviderAdapter
+from openbad.cognitive.providers.registry import ProviderRegistry
+
+
+class Priority(IntEnum):
+    """Request priority levels."""
+
+    CRITICAL = 4
+    HIGH = 3
+    MEDIUM = 2
+    LOW = 1
+
+
+@dataclass(frozen=True)
+class RouteStep:
+    """A single step in a fallback chain: provider name + model ID."""
+
+    provider: str
+    model_id: str
+
+
+@dataclass(frozen=True)
+class FallbackChain:
+    """Ordered list of provider/model pairs to try."""
+
+    steps: tuple[RouteStep, ...]
+
+    def __iter__(self):
+        return iter(self.steps)
+
+    def __len__(self) -> int:
+        return len(self.steps)
+
+
+@dataclass
+class RoutingDecision:
+    """Record of a routing decision for observability."""
+
+    priority: Priority
+    provider: str
+    model_id: str
+    fallback_index: int
+    cortisol_downgrade: bool = False
+    budget_exhausted: bool = False
+    latency_ms: float = 0.0
+
+
+@dataclass
+class ProviderHealth:
+    """Cached health state for a provider."""
+
+    available: bool = True
+    last_check: float = 0.0
+    avg_latency_ms: float = 0.0
+    failure_count: int = 0
+
+
+class ModelRouter:
+    """Routes requests to providers based on priority, health, and budget.
+
+    Parameters
+    ----------
+    registry:
+        Provider registry to look up adapters.
+    chains:
+        Priority → FallbackChain mapping.
+    cortisol_threshold:
+        When cortisol exceeds this, downgrade to cheaper models.
+    budget_limit:
+        Maximum spend in arbitrary units; 0 = unlimited.
+    health_ttl_s:
+        How long a health check result is cached.
+    """
+
+    def __init__(
+        self,
+        registry: ProviderRegistry,
+        chains: dict[Priority, FallbackChain] | None = None,
+        cortisol_threshold: float = 0.8,
+        budget_limit: float = 0,
+        health_ttl_s: float = 60,
+    ) -> None:
+        self._registry = registry
+        self._chains = chains or _default_chains()
+        self._cortisol_threshold = cortisol_threshold
+        self._budget_limit = budget_limit
+        self._health_ttl_s = health_ttl_s
+        self._health: dict[str, ProviderHealth] = {}
+        self._spend: float = 0.0
+        self._latencies: dict[str, list[float]] = {}
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    async def route(
+        self,
+        priority: Priority,
+        cortisol: float = 0.0,
+    ) -> tuple[ProviderAdapter, str, RoutingDecision]:
+        """Select the best provider/model for the given priority.
+
+        Returns (adapter, model_id, decision).
+        Raises ``RuntimeError`` if no provider is available.
+        """
+        effective_priority = priority
+        cortisol_downgrade = False
+        budget_exhausted = self._is_budget_exhausted()
+
+        if budget_exhausted:
+            effective_priority = Priority.LOW
+        elif cortisol > self._cortisol_threshold:
+            effective_priority = Priority(max(priority - 1, Priority.LOW))
+            cortisol_downgrade = priority != effective_priority
+
+        fallback = self._chains.get(Priority.LOW, FallbackChain(steps=()))
+        chain = self._chains.get(effective_priority, fallback)
+
+        for idx, step in enumerate(chain):
+            adapter = self._registry.get(step.provider)
+            if adapter is None:
+                continue
+            if not await self._is_healthy(step.provider, adapter):
+                continue
+
+            decision = RoutingDecision(
+                priority=priority,
+                provider=step.provider,
+                model_id=step.model_id,
+                fallback_index=idx,
+                cortisol_downgrade=cortisol_downgrade,
+                budget_exhausted=budget_exhausted,
+            )
+            return adapter, step.model_id, decision
+
+        msg = f"No available provider for priority {priority.name}"
+        raise RuntimeError(msg)
+
+    def record_latency(self, provider: str, latency_ms: float) -> None:
+        """Record a latency observation for a provider."""
+        self._latencies.setdefault(provider, [])
+        self._latencies[provider].append(latency_ms)
+        # Keep last 100 observations
+        if len(self._latencies[provider]) > 100:
+            self._latencies[provider] = self._latencies[provider][-100:]
+        # Update health record
+        h = self._health.get(provider)
+        if h:
+            h.avg_latency_ms = sum(self._latencies[provider]) / len(
+                self._latencies[provider]
+            )
+
+    def record_spend(self, amount: float) -> None:
+        """Record spend towards the budget."""
+        self._spend += amount
+
+    def mark_unhealthy(self, provider: str) -> None:
+        """Mark a provider as unhealthy."""
+        h = self._health.setdefault(provider, ProviderHealth())
+        h.available = False
+        h.failure_count += 1
+        h.last_check = time.monotonic()
+
+    def get_avg_latency(self, provider: str) -> float:
+        """Return average latency for a provider, 0 if no data."""
+        obs = self._latencies.get(provider, [])
+        return sum(obs) / len(obs) if obs else 0.0
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+
+    def _is_budget_exhausted(self) -> bool:
+        return self._budget_limit > 0 and self._spend >= self._budget_limit
+
+    async def _is_healthy(self, name: str, adapter: ProviderAdapter) -> bool:
+        h = self._health.get(name)
+        now = time.monotonic()
+        if h and (now - h.last_check) < self._health_ttl_s:
+            return h.available
+
+        status = await adapter.health_check()
+        self._health[name] = ProviderHealth(
+            available=status.available,
+            last_check=now,
+            avg_latency_ms=status.latency_ms,
+        )
+        return status.available
+
+
+# ------------------------------------------------------------------ #
+# Default chains
+# ------------------------------------------------------------------ #
+
+
+def _default_chains() -> dict[Priority, FallbackChain]:
+    return {
+        Priority.CRITICAL: FallbackChain(
+            steps=(
+                RouteStep("anthropic", "claude-sonnet-4-20250514"),
+                RouteStep("openai", "gpt-4o"),
+                RouteStep("ollama", "llama3.2"),
+            )
+        ),
+        Priority.HIGH: FallbackChain(
+            steps=(
+                RouteStep("openai", "gpt-4o-mini"),
+                RouteStep("ollama", "llama3.2"),
+            )
+        ),
+        Priority.MEDIUM: FallbackChain(
+            steps=(
+                RouteStep("ollama", "llama3.2"),
+                RouteStep("openai", "gpt-4o-mini"),
+            )
+        ),
+        Priority.LOW: FallbackChain(
+            steps=(RouteStep("ollama", "llama3.2"),)
+        ),
+    }
+
+
+# ------------------------------------------------------------------ #
+# YAML config loader
+# ------------------------------------------------------------------ #
+
+
+def load_routing_config(path: str) -> dict[str, Any]:
+    """Load routing configuration from a YAML file."""
+    with open(path) as f:  # noqa: PTH123
+        return yaml.safe_load(f)
+
+
+def configure_chains(config: dict[str, Any]) -> dict[Priority, FallbackChain]:
+    """Build fallback chains from a config dict."""
+    chains: dict[Priority, FallbackChain] = {}
+    priority_map = {p.name.lower(): p for p in Priority}
+    for name, steps_list in config.get("chains", {}).items():
+        pri = priority_map.get(name.lower())
+        if pri is None:
+            continue
+        steps = tuple(
+            RouteStep(provider=s["provider"], model_id=s["model"])
+            for s in steps_list
+        )
+        chains[pri] = FallbackChain(steps=steps)
+    return chains

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -1,0 +1,327 @@
+"""Tests for ModelRouter — priority routing, fallback, cortisol, budget."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openbad.cognitive.model_router import (
+    FallbackChain,
+    ModelRouter,
+    Priority,
+    RouteStep,
+    configure_chains,
+    load_routing_config,
+)
+from openbad.cognitive.providers.base import HealthStatus, ProviderAdapter
+from openbad.cognitive.providers.registry import ProviderRegistry
+
+# ---------------------------------------------------------------- #
+# Helpers
+# ---------------------------------------------------------------- #
+
+
+def _mock_adapter(healthy: bool = True, latency: float = 50.0) -> ProviderAdapter:
+    adapter = AsyncMock(spec=ProviderAdapter)
+    adapter.health_check = AsyncMock(
+        return_value=HealthStatus(provider="mock", available=healthy, latency_ms=latency)
+    )
+    return adapter
+
+
+def _build_router(
+    providers: dict[str, ProviderAdapter] | None = None,
+    chains: dict[Priority, FallbackChain] | None = None,
+    cortisol_threshold: float = 0.8,
+    budget_limit: float = 0,
+    health_ttl_s: float = 0,
+) -> ModelRouter:
+    reg = ProviderRegistry()
+    for name, adapter in (providers or {}).items():
+        reg.register(name, adapter)
+    return ModelRouter(
+        registry=reg,
+        chains=chains,
+        cortisol_threshold=cortisol_threshold,
+        budget_limit=budget_limit,
+        health_ttl_s=health_ttl_s,
+    )
+
+
+# ---------------------------------------------------------------- #
+# Priority routing
+# ---------------------------------------------------------------- #
+
+
+class TestPriorityRouting:
+    async def test_critical_uses_first_chain(self) -> None:
+        chains = {
+            Priority.CRITICAL: FallbackChain(
+                steps=(RouteStep("anthropic", "claude"), RouteStep("ollama", "llama"))
+            ),
+        }
+        router = _build_router(
+            providers={"anthropic": _mock_adapter(), "ollama": _mock_adapter()},
+            chains=chains,
+        )
+        adapter, model, decision = await router.route(Priority.CRITICAL)
+        assert decision.provider == "anthropic"
+        assert model == "claude"
+        assert decision.fallback_index == 0
+
+    async def test_low_routes_to_ollama(self) -> None:
+        chains = {
+            Priority.LOW: FallbackChain(
+                steps=(RouteStep("ollama", "llama"),)
+            ),
+        }
+        router = _build_router(
+            providers={"ollama": _mock_adapter()}, chains=chains,
+        )
+        adapter, model, decision = await router.route(Priority.LOW)
+        assert decision.provider == "ollama"
+        assert model == "llama"
+
+    async def test_medium_prefers_ollama_then_openai(self) -> None:
+        chains = {
+            Priority.MEDIUM: FallbackChain(
+                steps=(RouteStep("ollama", "llama"), RouteStep("openai", "gpt"))
+            ),
+        }
+        router = _build_router(
+            providers={"ollama": _mock_adapter(), "openai": _mock_adapter()},
+            chains=chains,
+        )
+        _, model, decision = await router.route(Priority.MEDIUM)
+        assert decision.provider == "ollama"
+
+
+# ---------------------------------------------------------------- #
+# Fallback
+# ---------------------------------------------------------------- #
+
+
+class TestFallback:
+    async def test_fallback_when_primary_unhealthy(self) -> None:
+        chains = {
+            Priority.HIGH: FallbackChain(
+                steps=(RouteStep("openai", "gpt"), RouteStep("ollama", "llama"))
+            ),
+        }
+        router = _build_router(
+            providers={
+                "openai": _mock_adapter(healthy=False),
+                "ollama": _mock_adapter(),
+            },
+            chains=chains,
+        )
+        _, model, decision = await router.route(Priority.HIGH)
+        assert decision.provider == "ollama"
+        assert decision.fallback_index == 1
+
+    async def test_fallback_when_provider_not_registered(self) -> None:
+        chains = {
+            Priority.HIGH: FallbackChain(
+                steps=(RouteStep("missing", "x"), RouteStep("ollama", "llama"))
+            ),
+        }
+        router = _build_router(
+            providers={"ollama": _mock_adapter()}, chains=chains,
+        )
+        _, _, decision = await router.route(Priority.HIGH)
+        assert decision.provider == "ollama"
+
+    async def test_no_provider_raises(self) -> None:
+        chains = {
+            Priority.HIGH: FallbackChain(
+                steps=(RouteStep("missing", "x"),)
+            ),
+        }
+        router = _build_router(providers={}, chains=chains)
+        with pytest.raises(RuntimeError, match="No available provider"):
+            await router.route(Priority.HIGH)
+
+
+# ---------------------------------------------------------------- #
+# Cortisol downgrade
+# ---------------------------------------------------------------- #
+
+
+class TestCortisolDowngrade:
+    async def test_cortisol_downgrades_priority(self) -> None:
+        chains = {
+            Priority.HIGH: FallbackChain(
+                steps=(RouteStep("openai", "gpt"),)
+            ),
+            Priority.MEDIUM: FallbackChain(
+                steps=(RouteStep("ollama", "llama"),)
+            ),
+        }
+        router = _build_router(
+            providers={"openai": _mock_adapter(), "ollama": _mock_adapter()},
+            chains=chains,
+            cortisol_threshold=0.5,
+        )
+        _, _, decision = await router.route(Priority.HIGH, cortisol=0.9)
+        assert decision.cortisol_downgrade is True
+        assert decision.provider == "ollama"
+
+    async def test_no_downgrade_below_threshold(self) -> None:
+        chains = {
+            Priority.HIGH: FallbackChain(
+                steps=(RouteStep("openai", "gpt"),)
+            ),
+        }
+        router = _build_router(
+            providers={"openai": _mock_adapter()},
+            chains=chains,
+            cortisol_threshold=0.8,
+        )
+        _, _, decision = await router.route(Priority.HIGH, cortisol=0.3)
+        assert decision.cortisol_downgrade is False
+        assert decision.provider == "openai"
+
+    async def test_low_cannot_downgrade_further(self) -> None:
+        chains = {
+            Priority.LOW: FallbackChain(
+                steps=(RouteStep("ollama", "llama"),)
+            ),
+        }
+        router = _build_router(
+            providers={"ollama": _mock_adapter()},
+            chains=chains,
+            cortisol_threshold=0.5,
+        )
+        _, _, decision = await router.route(Priority.LOW, cortisol=0.9)
+        assert decision.cortisol_downgrade is False
+        assert decision.provider == "ollama"
+
+
+# ---------------------------------------------------------------- #
+# Budget exhaustion
+# ---------------------------------------------------------------- #
+
+
+class TestBudgetExhaustion:
+    async def test_budget_forces_low_priority(self) -> None:
+        chains = {
+            Priority.CRITICAL: FallbackChain(
+                steps=(RouteStep("openai", "gpt"),)
+            ),
+            Priority.LOW: FallbackChain(
+                steps=(RouteStep("ollama", "llama"),)
+            ),
+        }
+        router = _build_router(
+            providers={"openai": _mock_adapter(), "ollama": _mock_adapter()},
+            chains=chains,
+            budget_limit=10.0,
+        )
+        router.record_spend(15.0)
+        _, _, decision = await router.route(Priority.CRITICAL)
+        assert decision.budget_exhausted is True
+        assert decision.provider == "ollama"
+
+    async def test_within_budget_routes_normally(self) -> None:
+        chains = {
+            Priority.CRITICAL: FallbackChain(
+                steps=(RouteStep("openai", "gpt"),)
+            ),
+        }
+        router = _build_router(
+            providers={"openai": _mock_adapter()},
+            chains=chains,
+            budget_limit=100.0,
+        )
+        router.record_spend(5.0)
+        _, _, decision = await router.route(Priority.CRITICAL)
+        assert decision.budget_exhausted is False
+        assert decision.provider == "openai"
+
+
+# ---------------------------------------------------------------- #
+# Latency tracking
+# ---------------------------------------------------------------- #
+
+
+class TestLatencyTracking:
+    def test_record_and_retrieve(self) -> None:
+        router = _build_router()
+        router.record_latency("openai", 100.0)
+        router.record_latency("openai", 200.0)
+        assert router.get_avg_latency("openai") == 150.0
+
+    def test_unknown_provider_returns_zero(self) -> None:
+        router = _build_router()
+        assert router.get_avg_latency("unknown") == 0.0
+
+
+# ---------------------------------------------------------------- #
+# Health caching
+# ---------------------------------------------------------------- #
+
+
+class TestHealthCache:
+    async def test_cached_unhealthy_skipped(self) -> None:
+        chains = {
+            Priority.HIGH: FallbackChain(
+                steps=(RouteStep("openai", "gpt"), RouteStep("ollama", "llama"))
+            ),
+        }
+        router = _build_router(
+            providers={"openai": _mock_adapter(), "ollama": _mock_adapter()},
+            chains=chains,
+            health_ttl_s=300,
+        )
+        router.mark_unhealthy("openai")
+        _, _, decision = await router.route(Priority.HIGH)
+        assert decision.provider == "ollama"
+
+
+# ---------------------------------------------------------------- #
+# YAML config
+# ---------------------------------------------------------------- #
+
+
+class TestYamlConfig:
+    def test_load_and_parse(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "routing.yaml"
+        cfg_file.write_text(
+            "chains:\n"
+            "  high:\n"
+            "    - provider: openai\n"
+            "      model: gpt-4o\n"
+            "  low:\n"
+            "    - provider: ollama\n"
+            "      model: llama3.2\n"
+        )
+        config = load_routing_config(str(cfg_file))
+        chains = configure_chains(config)
+        assert Priority.HIGH in chains
+        assert Priority.LOW in chains
+        assert chains[Priority.HIGH].steps[0].provider == "openai"
+
+    def test_default_config_loads(self) -> None:
+        cfg_path = Path(__file__).resolve().parent.parent / "config" / "model_routing.yaml"
+        if cfg_path.exists():
+            config = load_routing_config(str(cfg_path))
+            chains = configure_chains(config)
+            assert Priority.CRITICAL in chains
+            assert len(chains[Priority.CRITICAL]) >= 2
+
+
+# ---------------------------------------------------------------- #
+# FallbackChain
+# ---------------------------------------------------------------- #
+
+
+class TestFallbackChain:
+    def test_len_and_iter(self) -> None:
+        chain = FallbackChain(
+            steps=(RouteStep("a", "m1"), RouteStep("b", "m2"))
+        )
+        assert len(chain) == 2
+        names = [s.provider for s in chain]
+        assert names == ["a", "b"]


### PR DESCRIPTION
Closes #85

## Summary
- `ModelRouter` with priority-based routing (Critical/High/Medium/Low)
- `FallbackChain` with ordered `RouteStep` tuples
- Cortisol-driven downgrade: high cortisol → cheaper models
- Budget exhaustion: forces all routing to Ollama (LOW priority)
- Health-aware routing with TTL-based caching
- Latency tracking per provider
- `configure_chains()` + YAML config loader
- Default chains in `config/model_routing.yaml`  
- 17 unit tests

## How to Test
```bash
pytest tests/test_model_router.py -v
```