### PR TITLE
#86: Add Chain-of-Thought reasoning strategy

### DIFF
--- a/src/openbad/cognitive/reasoning/__init__.py
+++ b/src/openbad/cognitive/reasoning/__init__.py
@@ -1,0 +1,1 @@
+"""Reasoning strategies package."""

--- a/src/openbad/cognitive/reasoning/base.py
+++ b/src/openbad/cognitive/reasoning/base.py
@@ -1,0 +1,43 @@
+"""Base ABC and shared types for reasoning strategies."""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from openbad.cognitive.model_router import ModelRouter
+
+
+@dataclass(frozen=True)
+class ReasoningStep:
+    """A single step in a reasoning trace."""
+
+    step_number: int
+    thought: str
+    conclusion: str
+
+
+@dataclass(frozen=True)
+class ReasoningResult:
+    """Output of a reasoning strategy."""
+
+    final_answer: str
+    steps: tuple[ReasoningStep, ...] = ()
+    total_tokens: int = 0
+    total_latency_ms: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class ReasoningStrategy(abc.ABC):
+    """Abstract base for all reasoning strategies."""
+
+    @abc.abstractmethod
+    async def reason(
+        self,
+        prompt: str,
+        context: str,
+        model_router: ModelRouter,
+    ) -> ReasoningResult:
+        """Execute the reasoning strategy and return a result."""

--- a/src/openbad/cognitive/reasoning/chain_of_thought.py
+++ b/src/openbad/cognitive/reasoning/chain_of_thought.py
@@ -1,0 +1,111 @@
+"""Chain-of-Thought (CoT) reasoning strategy."""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from openbad.cognitive.model_router import Priority
+from openbad.cognitive.reasoning.base import ReasoningResult, ReasoningStep, ReasoningStrategy
+
+if TYPE_CHECKING:
+    from openbad.cognitive.model_router import ModelRouter
+
+
+_COT_SYSTEM_PROMPT = (
+    "You are a careful analytical reasoner. "
+    "Think step-by-step. For each step, output exactly:\n"
+    "STEP <n>:\nTHOUGHT: <your reasoning>\nCONCLUSION: <what you determined>\n\n"
+    "After all steps, output:\nFINAL ANSWER: <your final answer>"
+)
+
+_STEP_PATTERN = re.compile(
+    r"STEP\s+(\d+)\s*:\s*\n"
+    r"THOUGHT:\s*(.+?)\n"
+    r"CONCLUSION:\s*(.+?)(?=\nSTEP|\nFINAL|\Z)",
+    re.DOTALL,
+)
+
+_FINAL_PATTERN = re.compile(r"FINAL ANSWER:\s*(.+)", re.DOTALL)
+
+
+@dataclass
+class ChainOfThoughtConfig:
+    """Configuration for CoT reasoning."""
+
+    priority: Priority = Priority.MEDIUM
+    max_steps: int = 10
+    system_prompt: str = _COT_SYSTEM_PROMPT
+
+
+class ChainOfThought(ReasoningStrategy):
+    """Chain-of-Thought: sequential step-by-step reasoning."""
+
+    def __init__(self, config: ChainOfThoughtConfig | None = None) -> None:
+        self._config = config or ChainOfThoughtConfig()
+
+    async def reason(
+        self,
+        prompt: str,
+        context: str,
+        model_router: ModelRouter,
+    ) -> ReasoningResult:
+        """Send a step-by-step prompt to the model and parse the trace."""
+        adapter, model_id, decision = await model_router.route(
+            self._config.priority,
+        )
+
+        full_prompt = (
+            f"{self._config.system_prompt}\n\n"
+            f"Context:\n{context}\n\n"
+            f"Problem:\n{prompt}"
+        )
+
+        t0 = time.monotonic()
+        result = await adapter.complete(full_prompt, model=model_id)
+        latency = (time.monotonic() - t0) * 1000
+
+        model_router.record_latency(decision.provider, latency)
+
+        steps = _parse_steps(result.content, self._config.max_steps)
+        final = _parse_final_answer(result.content)
+
+        return ReasoningResult(
+            final_answer=final,
+            steps=tuple(steps),
+            total_tokens=result.tokens_used,
+            total_latency_ms=latency,
+            metadata={
+                "model_id": model_id,
+                "provider": decision.provider,
+                "raw_response": result.content,
+            },
+        )
+
+
+def _parse_steps(text: str, max_steps: int) -> list[ReasoningStep]:
+    """Extract structured reasoning steps from the model response."""
+    steps: list[ReasoningStep] = []
+    for match in _STEP_PATTERN.finditer(text):
+        if len(steps) >= max_steps:
+            break
+        steps.append(
+            ReasoningStep(
+                step_number=int(match.group(1)),
+                thought=match.group(2).strip(),
+                conclusion=match.group(3).strip(),
+            )
+        )
+    return steps
+
+
+def _parse_final_answer(text: str) -> str:
+    """Extract the final answer from the model response."""
+    match = _FINAL_PATTERN.search(text)
+    if match:
+        return match.group(1).strip()
+    # If no structured answer, return the last non-empty line
+    lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
+    return lines[-1] if lines else ""

--- a/tests/test_chain_of_thought.py
+++ b/tests/test_chain_of_thought.py
@@ -1,0 +1,152 @@
+"""Tests for Chain-of-Thought reasoning strategy."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openbad.cognitive.model_router import ModelRouter, Priority, RoutingDecision
+from openbad.cognitive.providers.base import CompletionResult
+from openbad.cognitive.reasoning.base import ReasoningResult, ReasoningStep, ReasoningStrategy
+from openbad.cognitive.reasoning.chain_of_thought import (
+    ChainOfThought,
+    ChainOfThoughtConfig,
+    _parse_final_answer,
+    _parse_steps,
+)
+
+# ------------------------------------------------------------------ #
+# Fixtures
+# ------------------------------------------------------------------ #
+
+_MOCK_COT_RESPONSE = (
+    "STEP 1:\n"
+    "THOUGHT: The problem asks for 2+2.\n"
+    "CONCLUSION: Basic addition needed.\n\n"
+    "STEP 2:\n"
+    "THOUGHT: 2+2 equals 4.\n"
+    "CONCLUSION: The answer is 4.\n\n"
+    "FINAL ANSWER: 4"
+)
+
+
+def _mock_router(response_text: str = _MOCK_COT_RESPONSE) -> ModelRouter:
+    adapter = AsyncMock()
+    adapter.complete = AsyncMock(
+        return_value=CompletionResult(
+            content=response_text,
+            model_id="llama3.2",
+            provider="ollama",
+            tokens_used=100,
+        )
+    )
+    decision = RoutingDecision(
+        priority=Priority.MEDIUM,
+        provider="ollama",
+        model_id="llama3.2",
+        fallback_index=0,
+    )
+    router = MagicMock(spec=ModelRouter)
+    router.route = AsyncMock(return_value=(adapter, "llama3.2", decision))
+    router.record_latency = MagicMock()
+    return router
+
+
+# ------------------------------------------------------------------ #
+# Tests — parsing
+# ------------------------------------------------------------------ #
+
+
+class TestParsing:
+    def test_parse_steps(self) -> None:
+        steps = _parse_steps(_MOCK_COT_RESPONSE, max_steps=10)
+        assert len(steps) == 2
+        assert steps[0].step_number == 1
+        assert "2+2" in steps[0].thought
+        assert steps[1].conclusion == "The answer is 4."
+
+    def test_parse_steps_max(self) -> None:
+        steps = _parse_steps(_MOCK_COT_RESPONSE, max_steps=1)
+        assert len(steps) == 1
+
+    def test_parse_final_answer(self) -> None:
+        answer = _parse_final_answer(_MOCK_COT_RESPONSE)
+        assert answer == "4"
+
+    def test_parse_final_answer_fallback(self) -> None:
+        answer = _parse_final_answer("Some rambling text\nThe result is 42")
+        assert answer == "The result is 42"
+
+    def test_parse_final_answer_empty(self) -> None:
+        answer = _parse_final_answer("")
+        assert answer == ""
+
+
+# ------------------------------------------------------------------ #
+# Tests — reasoning
+# ------------------------------------------------------------------ #
+
+
+class TestChainOfThought:
+    async def test_basic_reasoning(self) -> None:
+        cot = ChainOfThought()
+        router = _mock_router()
+        result = await cot.reason("What is 2+2?", "math context", router)
+
+        assert isinstance(result, ReasoningResult)
+        assert result.final_answer == "4"
+        assert len(result.steps) == 2
+        assert result.total_tokens == 100
+        assert result.total_latency_ms > 0
+        assert result.metadata["provider"] == "ollama"
+
+    async def test_custom_priority(self) -> None:
+        config = ChainOfThoughtConfig(priority=Priority.HIGH)
+        cot = ChainOfThought(config=config)
+        router = _mock_router()
+        await cot.reason("test", "ctx", router)
+        router.route.assert_awaited_once_with(Priority.HIGH)
+
+    async def test_records_latency(self) -> None:
+        cot = ChainOfThought()
+        router = _mock_router()
+        await cot.reason("test", "ctx", router)
+        router.record_latency.assert_called_once()
+        args = router.record_latency.call_args
+        assert args[0][0] == "ollama"
+        assert args[0][1] > 0
+
+    async def test_no_steps_still_returns_answer(self) -> None:
+        cot = ChainOfThought()
+        router = _mock_router("Just the answer: 42")
+        result = await cot.reason("test", "ctx", router)
+        assert result.final_answer == "Just the answer: 42"
+        assert len(result.steps) == 0
+
+    async def test_max_steps_config(self) -> None:
+        config = ChainOfThoughtConfig(max_steps=1)
+        cot = ChainOfThought(config=config)
+        router = _mock_router()
+        result = await cot.reason("test", "ctx", router)
+        assert len(result.steps) == 1
+
+
+# ------------------------------------------------------------------ #
+# Tests — ABC conformance
+# ------------------------------------------------------------------ #
+
+
+class TestABC:
+    def test_is_reasoning_strategy(self) -> None:
+        assert issubclass(ChainOfThought, ReasoningStrategy)
+
+    def test_reasoning_step_frozen(self) -> None:
+        s = ReasoningStep(step_number=1, thought="t", conclusion="c")
+        with pytest.raises(AttributeError):
+            s.thought = "x"  # type: ignore[misc]
+
+    def test_reasoning_result_frozen(self) -> None:
+        r = ReasoningResult(final_answer="a")
+        with pytest.raises(AttributeError):
+            r.final_answer = "b"  # type: ignore[misc]


### PR DESCRIPTION
Closes #86

## Summary
- `ReasoningStrategy` ABC in `reasoning/base.py` with `ReasoningStep` and `ReasoningResult` dataclasses
- `ChainOfThought` strategy: sends structured system prompt, parses STEP/THOUGHT/CONCLUSION/FINAL ANSWER trace
- Works with any provider via `ModelRouter`  
- Configurable priority, max steps, system prompt  
- 13 unit tests (parsing, reasoning, ABC conformance)

## How to Test
```bash
pytest tests/test_chain_of_thought.py -v
```