### PR TITLE
#89: Add context window manager with budget allocation and compression

### DIFF
--- a/src/openbad/cognitive/context_manager.py
+++ b/src/openbad/cognitive/context_manager.py
@@ -1,0 +1,200 @@
+"""Context window manager — token budgets, compression, usage tracking."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from enum import Enum
+
+# ------------------------------------------------------------------ #
+# Data types
+# ------------------------------------------------------------------ #
+
+class CompressionStrategy(Enum):
+    """How context is compressed when it exceeds the budget."""
+
+    TRUNCATE = "truncate"
+    SUMMARIZE = "summarize"
+
+
+@dataclass(frozen=True)
+class ContextBudget:
+    """Token allocation for a single request."""
+
+    max_tokens: int
+    system_tokens: int
+    context_tokens: int
+    response_tokens: int
+
+
+@dataclass(frozen=True)
+class CompressedContext:
+    """Result of context compression."""
+
+    text: str
+    original_tokens: int
+    compressed_tokens: int
+    strategy: CompressionStrategy
+
+
+@dataclass
+class UsageRecord:
+    """Cumulative token usage for a provider."""
+
+    total_tokens: int = 0
+    request_count: int = 0
+    last_update: float = 0.0
+
+
+# ------------------------------------------------------------------ #
+# Token counting
+# ------------------------------------------------------------------ #
+
+_CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(text: str) -> int:
+    """Approximate token count (chars / 4 heuristic)."""
+    return max(1, len(text) // _CHARS_PER_TOKEN) if text else 0
+
+
+# ------------------------------------------------------------------ #
+# Default model limits
+# ------------------------------------------------------------------ #
+
+_DEFAULT_LIMITS: dict[str, int] = {
+    "slm": 8_192,
+    "llm": 32_768,
+}
+
+
+# ------------------------------------------------------------------ #
+# ContextWindowManager
+# ------------------------------------------------------------------ #
+
+
+class ContextWindowManager:
+    """Manages token budgets, context compression, and usage tracking.
+
+    Parameters
+    ----------
+    model_limits:
+        Mapping of model_id (or category) to max context window tokens.
+    default_limit:
+        Fallback context window size for unknown models.
+    system_budget_ratio:
+        Fraction of context reserved for the system prompt.
+    response_budget_ratio:
+        Fraction of context reserved for the response.
+    """
+
+    def __init__(
+        self,
+        model_limits: dict[str, int] | None = None,
+        default_limit: int = 8_192,
+        system_budget_ratio: float = 0.15,
+        response_budget_ratio: float = 0.25,
+    ) -> None:
+        self._limits = {**_DEFAULT_LIMITS, **(model_limits or {})}
+        self._default_limit = default_limit
+        self._sys_ratio = system_budget_ratio
+        self._resp_ratio = response_budget_ratio
+        self._usage: dict[str, UsageRecord] = {}
+        self._request_usage: dict[str, int] = {}
+
+    # ------------------------------------------------------------------ #
+    # Budget allocation
+    # ------------------------------------------------------------------ #
+
+    def allocate(self, model_id: str, system_prompt: str = "") -> ContextBudget:
+        """Calculate token budget for a request to *model_id*."""
+        max_tokens = self._limits.get(model_id, self._default_limit)
+        system_tokens = max(
+            estimate_tokens(system_prompt),
+            int(max_tokens * self._sys_ratio),
+        )
+        response_tokens = int(max_tokens * self._resp_ratio)
+        context_tokens = max(0, max_tokens - system_tokens - response_tokens)
+        return ContextBudget(
+            max_tokens=max_tokens,
+            system_tokens=system_tokens,
+            context_tokens=context_tokens,
+            response_tokens=response_tokens,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Compression
+    # ------------------------------------------------------------------ #
+
+    def compress(
+        self,
+        context: str,
+        target_tokens: int,
+        strategy: CompressionStrategy = CompressionStrategy.TRUNCATE,
+    ) -> CompressedContext:
+        """Compress *context* to fit within *target_tokens*."""
+        original_tokens = estimate_tokens(context)
+        if original_tokens <= target_tokens:
+            return CompressedContext(
+                text=context,
+                original_tokens=original_tokens,
+                compressed_tokens=original_tokens,
+                strategy=strategy,
+            )
+
+        if strategy == CompressionStrategy.TRUNCATE:
+            text = self._truncate(context, target_tokens)
+        else:
+            # Summarize falls back to truncation (no live model call here)
+            text = self._truncate(context, target_tokens)
+
+        return CompressedContext(
+            text=text,
+            original_tokens=original_tokens,
+            compressed_tokens=estimate_tokens(text),
+            strategy=strategy,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Usage tracking
+    # ------------------------------------------------------------------ #
+
+    def track_usage(
+        self, provider: str, tokens_used: int, request_id: str = ""
+    ) -> None:
+        """Record token usage for a provider (and optionally per request)."""
+        rec = self._usage.setdefault(provider, UsageRecord())
+        rec.total_tokens += tokens_used
+        rec.request_count += 1
+        rec.last_update = time.monotonic()
+        if request_id:
+            self._request_usage[request_id] = (
+                self._request_usage.get(request_id, 0) + tokens_used
+            )
+
+    def get_provider_usage(self, provider: str) -> UsageRecord:
+        """Return cumulative usage for a provider."""
+        return self._usage.get(provider, UsageRecord())
+
+    def get_request_usage(self, request_id: str) -> int:
+        """Return tokens used by a specific request."""
+        return self._request_usage.get(request_id, 0)
+
+    def fits(self, text: str, budget: ContextBudget) -> bool:
+        """Check whether *text* fits within the context portion of a budget."""
+        return estimate_tokens(text) <= budget.context_tokens
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _truncate(context: str, target_tokens: int) -> str:
+        """Keep the most recent text (tail) that fits within *target_tokens*.
+
+        Context priority: recent > historical, so we drop from the front.
+        """
+        target_chars = target_tokens * _CHARS_PER_TOKEN
+        if len(context) <= target_chars:
+            return context
+        return context[-target_chars:]

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,0 +1,166 @@
+"""Tests for ContextWindowManager — budgets, compression, usage tracking."""
+
+from __future__ import annotations
+
+from openbad.cognitive.context_manager import (
+    CompressedContext,
+    CompressionStrategy,
+    ContextBudget,
+    ContextWindowManager,
+    estimate_tokens,
+)
+
+# ------------------------------------------------------------------ #
+# Token estimation
+# ------------------------------------------------------------------ #
+
+
+class TestEstimateTokens:
+    def test_empty(self) -> None:
+        assert estimate_tokens("") == 0
+
+    def test_short_text(self) -> None:
+        assert estimate_tokens("abcd") == 1
+
+    def test_longer_text(self) -> None:
+        assert estimate_tokens("a" * 100) == 25
+
+    def test_minimum_one(self) -> None:
+        assert estimate_tokens("a") == 1
+
+
+# ------------------------------------------------------------------ #
+# Budget allocation
+# ------------------------------------------------------------------ #
+
+
+class TestAllocate:
+    def test_known_model(self) -> None:
+        mgr = ContextWindowManager(model_limits={"gpt-4o": 128_000})
+        budget = mgr.allocate("gpt-4o")
+        assert budget.max_tokens == 128_000
+        total = budget.system_tokens + budget.context_tokens + budget.response_tokens
+        assert total <= budget.max_tokens
+
+    def test_default_limit(self) -> None:
+        mgr = ContextWindowManager(default_limit=4096)
+        budget = mgr.allocate("unknown-model")
+        assert budget.max_tokens == 4096
+
+    def test_system_prompt_overrides_ratio(self) -> None:
+        mgr = ContextWindowManager(default_limit=8192)
+        big_prompt = "x" * 4000  # ~1000 tokens
+        budget = mgr.allocate("test", system_prompt=big_prompt)
+        assert budget.system_tokens >= estimate_tokens(big_prompt)
+
+    def test_budget_components_sum(self) -> None:
+        mgr = ContextWindowManager(default_limit=10000)
+        budget = mgr.allocate("test")
+        assert (
+            budget.system_tokens + budget.context_tokens + budget.response_tokens
+            <= budget.max_tokens
+        )
+
+
+# ------------------------------------------------------------------ #
+# Compression
+# ------------------------------------------------------------------ #
+
+
+class TestCompression:
+    def test_no_compression_needed(self) -> None:
+        mgr = ContextWindowManager()
+        result = mgr.compress("short text", target_tokens=100)
+        assert isinstance(result, CompressedContext)
+        assert result.text == "short text"
+        assert result.compressed_tokens == result.original_tokens
+
+    def test_truncation(self) -> None:
+        mgr = ContextWindowManager()
+        long_text = "A" * 1000  # ~250 tokens
+        result = mgr.compress(long_text, target_tokens=50)
+        assert result.compressed_tokens <= 50
+        # Truncation keeps the tail (most recent)
+        assert result.text == long_text[-200:]
+
+    def test_strategy_recorded(self) -> None:
+        mgr = ContextWindowManager()
+        result = mgr.compress("short", target_tokens=100)
+        assert result.strategy == CompressionStrategy.TRUNCATE
+
+    def test_summarize_fallback(self) -> None:
+        mgr = ContextWindowManager()
+        long_text = "B" * 1000
+        result = mgr.compress(
+            long_text, target_tokens=50, strategy=CompressionStrategy.SUMMARIZE,
+        )
+        assert result.compressed_tokens <= 50
+        assert result.strategy == CompressionStrategy.SUMMARIZE
+
+
+# ------------------------------------------------------------------ #
+# Usage tracking
+# ------------------------------------------------------------------ #
+
+
+class TestUsageTracking:
+    def test_track_provider(self) -> None:
+        mgr = ContextWindowManager()
+        mgr.track_usage("openai", 100)
+        mgr.track_usage("openai", 200)
+        usage = mgr.get_provider_usage("openai")
+        assert usage.total_tokens == 300
+        assert usage.request_count == 2
+
+    def test_track_request(self) -> None:
+        mgr = ContextWindowManager()
+        mgr.track_usage("openai", 50, request_id="r1")
+        mgr.track_usage("openai", 30, request_id="r1")
+        assert mgr.get_request_usage("r1") == 80
+
+    def test_unknown_provider_returns_zero(self) -> None:
+        mgr = ContextWindowManager()
+        usage = mgr.get_provider_usage("nope")
+        assert usage.total_tokens == 0
+        assert usage.request_count == 0
+
+    def test_unknown_request_returns_zero(self) -> None:
+        mgr = ContextWindowManager()
+        assert mgr.get_request_usage("nope") == 0
+
+
+# ------------------------------------------------------------------ #
+# fits()
+# ------------------------------------------------------------------ #
+
+
+class TestFits:
+    def test_fits_true(self) -> None:
+        mgr = ContextWindowManager()
+        budget = ContextBudget(
+            max_tokens=1000, system_tokens=150, context_tokens=600, response_tokens=250,
+        )
+        assert mgr.fits("hello world", budget) is True
+
+    def test_fits_false(self) -> None:
+        mgr = ContextWindowManager()
+        budget = ContextBudget(
+            max_tokens=100, system_tokens=15, context_tokens=60, response_tokens=25,
+        )
+        long_text = "x" * 1000
+        assert mgr.fits(long_text, budget) is False
+
+
+# ------------------------------------------------------------------ #
+# Overflow handling
+# ------------------------------------------------------------------ #
+
+
+class TestOverflow:
+    def test_context_exceeding_budget_compresses(self) -> None:
+        mgr = ContextWindowManager(default_limit=1000)
+        budget = mgr.allocate("test")
+        big_context = "C" * (budget.context_tokens * 5 * 4)
+        result = mgr.compress(big_context, target_tokens=budget.context_tokens)
+        assert result.compressed_tokens <= budget.context_tokens
+        assert mgr.fits(result.text, budget)


### PR DESCRIPTION
Closes #89

## Summary
- `ContextWindowManager` with token budget allocation per model
- `ContextBudget` dataclass (system/context/response token allocation)
- Truncation compression (drop oldest, keep recent)
- Per-provider and per-request token usage tracking
- `estimate_tokens()` heuristic (chars/4)
- Configurable model limits, default SLM=8192, LLM=32768
- 19 unit tests

## How to Test
```bash
pytest tests/test_context_manager.py -v
```