### PR TITLE
#90: Add cognitive event loop and orchestrator

### DIFF
--- a/src/openbad/cognitive/event_loop.py
+++ b/src/openbad/cognitive/event_loop.py
@@ -1,0 +1,246 @@
+"""Cognitive event loop — processes reasoning requests from the nervous system."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from openbad.cognitive.context_manager import ContextWindowManager
+from openbad.cognitive.model_router import ModelRouter, Priority
+from openbad.cognitive.reasoning.base import ReasoningStrategy
+
+log = logging.getLogger(__name__)
+
+# Request timeouts per priority (seconds)
+_TIMEOUTS: dict[Priority, float] = {
+    Priority.CRITICAL: 30.0,
+    Priority.HIGH: 30.0,
+    Priority.MEDIUM: 10.0,
+    Priority.LOW: 5.0,
+}
+
+
+# ------------------------------------------------------------------ #
+# Data types
+# ------------------------------------------------------------------ #
+
+
+@dataclass
+class CognitiveRequest:
+    """An incoming reasoning request."""
+
+    request_id: str
+    prompt: str
+    context: str = ""
+    priority: Priority = Priority.MEDIUM
+    cortisol: float = 0.0
+
+
+@dataclass
+class CognitiveResponse:
+    """Result of a cognitive processing cycle."""
+
+    request_id: str
+    answer: str
+    provider: str = ""
+    model_id: str = ""
+    tokens_used: int = 0
+    latency_ms: float = 0.0
+    strategy: str = ""
+    timed_out: bool = False
+    error: str = ""
+
+
+# ------------------------------------------------------------------ #
+# Event loop
+# ------------------------------------------------------------------ #
+
+
+class CognitiveEventLoop:
+    """Subscribes to reasoning requests, orchestrates provider/strategy/context,
+    and publishes results.
+
+    Parameters
+    ----------
+    model_router:
+        Routes requests to the right provider.
+    context_manager:
+        Manages token budgets and compression.
+    strategies:
+        Mapping of Priority → ReasoningStrategy to use.
+    publish_fn:
+        Callback ``(topic, payload_dict) -> Awaitable`` for publishing results.
+    validate_fn:
+        Optional immune-system validation ``(request) -> bool``.
+    """
+
+    def __init__(
+        self,
+        model_router: ModelRouter,
+        context_manager: ContextWindowManager,
+        strategies: dict[Priority, ReasoningStrategy],
+        publish_fn: Any = None,
+        validate_fn: Any = None,
+    ) -> None:
+        self._router = model_router
+        self._ctx = context_manager
+        self._strategies = strategies
+        self._publish = publish_fn or _noop_publish
+        self._validate = validate_fn
+        self._running = False
+        self._tasks: set[asyncio.Task[None]] = set()
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    async def start(self) -> None:
+        self._running = True
+        log.info("CognitiveEventLoop started")
+
+    async def stop(self) -> None:
+        self._running = False
+        for t in self._tasks:
+            t.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        log.info("CognitiveEventLoop stopped")
+
+    # ------------------------------------------------------------------ #
+    # Request handling
+    # ------------------------------------------------------------------ #
+
+    async def handle_request(self, request: CognitiveRequest) -> CognitiveResponse:
+        """Process a single reasoning request (can be called directly or via MQTT)."""
+        if self._validate and not self._validate(request):
+                return CognitiveResponse(
+                    request_id=request.request_id,
+                    answer="",
+                    error="Request rejected by immune system",
+                )
+
+        timeout = _TIMEOUTS.get(request.priority, 10.0)
+
+        try:
+            response = await asyncio.wait_for(
+                self._process(request), timeout=timeout,
+            )
+        except TimeoutError:
+            response = CognitiveResponse(
+                request_id=request.request_id,
+                answer="",
+                timed_out=True,
+                error=f"Timed out after {timeout}s",
+            )
+
+        await self._publish(
+            "agent/cognitive/response", _response_to_dict(response),
+        )
+        return response
+
+    def submit(self, request: CognitiveRequest) -> None:
+        """Submit a request for async processing (fire-and-forget)."""
+        task = asyncio.create_task(self.handle_request(request))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    # ------------------------------------------------------------------ #
+    # MQTT message handler
+    # ------------------------------------------------------------------ #
+
+    async def on_message(self, topic: str, payload: bytes) -> None:
+        """Handle an incoming MQTT message."""
+        try:
+            data = json.loads(payload)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            log.warning("Invalid payload on %s", topic)
+            return
+
+        request = CognitiveRequest(
+            request_id=data.get("request_id", ""),
+            prompt=data.get("prompt", ""),
+            context=data.get("context", ""),
+            priority=Priority(data.get("priority", Priority.MEDIUM)),
+            cortisol=data.get("cortisol", 0.0),
+        )
+        self.submit(request)
+
+    # ------------------------------------------------------------------ #
+    # Core processing
+    # ------------------------------------------------------------------ #
+
+    async def _process(self, request: CognitiveRequest) -> CognitiveResponse:
+        t0 = time.monotonic()
+
+        # 1. Allocate context budget
+        adapter, model_id, decision = await self._router.route(
+            request.priority, cortisol=request.cortisol,
+        )
+        budget = self._ctx.allocate(model_id)
+
+        # 2. Compress context if needed
+        compressed = self._ctx.compress(
+            request.context, target_tokens=budget.context_tokens,
+        )
+
+        # 3. Select and execute reasoning strategy
+        strategy = self._strategies.get(request.priority)
+        if strategy:
+            result = await strategy.reason(
+                request.prompt, compressed.text, self._router,
+            )
+            answer = result.final_answer
+            tokens = result.total_tokens
+            strategy_name = type(strategy).__name__
+        else:
+            # Direct single-pass call
+            completion = await adapter.complete(
+                f"{compressed.text}\n\n{request.prompt}", model=model_id,
+            )
+            answer = completion.content
+            tokens = completion.tokens_used
+            strategy_name = "direct"
+
+        latency = (time.monotonic() - t0) * 1000
+
+        # 4. Track usage
+        self._ctx.track_usage(decision.provider, tokens, request.request_id)
+        self._router.record_latency(decision.provider, latency)
+
+        return CognitiveResponse(
+            request_id=request.request_id,
+            answer=answer,
+            provider=decision.provider,
+            model_id=model_id,
+            tokens_used=tokens,
+            latency_ms=latency,
+            strategy=strategy_name,
+        )
+
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+
+async def _noop_publish(_topic: str, _payload: dict[str, Any]) -> None:
+    pass
+
+
+def _response_to_dict(r: CognitiveResponse) -> dict[str, Any]:
+    return {
+        "request_id": r.request_id,
+        "answer": r.answer,
+        "provider": r.provider,
+        "model_id": r.model_id,
+        "tokens_used": r.tokens_used,
+        "latency_ms": r.latency_ms,
+        "strategy": r.strategy,
+        "timed_out": r.timed_out,
+        "error": r.error,
+    }

--- a/src/openbad/cognitive/orchestrator.py
+++ b/src/openbad/cognitive/orchestrator.py
@@ -1,0 +1,57 @@
+"""Cognitive orchestrator — wires event loop + router + context manager + strategies."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from openbad.cognitive.context_manager import ContextWindowManager
+from openbad.cognitive.event_loop import CognitiveEventLoop
+from openbad.cognitive.model_router import ModelRouter, Priority
+from openbad.cognitive.providers.registry import ProviderRegistry
+from openbad.cognitive.reasoning.base import ReasoningStrategy
+
+log = logging.getLogger(__name__)
+
+
+class CognitiveOrchestrator:
+    """High-level coordinator for the cognitive module.
+
+    Wires together the model router, context manager, reasoning strategies,
+    and the event loop.
+    """
+
+    def __init__(
+        self,
+        registry: ProviderRegistry,
+        router: ModelRouter,
+        context_manager: ContextWindowManager,
+        strategies: dict[Priority, ReasoningStrategy] | None = None,
+        publish_fn: Any = None,
+        validate_fn: Any = None,
+    ) -> None:
+        self._registry = registry
+        self._router = router
+        self._ctx = context_manager
+        self._strategies = strategies or {}
+        self._event_loop = CognitiveEventLoop(
+            model_router=router,
+            context_manager=context_manager,
+            strategies=self._strategies,
+            publish_fn=publish_fn,
+            validate_fn=validate_fn,
+        )
+
+    @property
+    def event_loop(self) -> CognitiveEventLoop:
+        return self._event_loop
+
+    async def start(self) -> None:
+        """Start the cognitive module."""
+        await self._event_loop.start()
+        log.info("CognitiveOrchestrator started")
+
+    async def stop(self) -> None:
+        """Stop the cognitive module."""
+        await self._event_loop.stop()
+        log.info("CognitiveOrchestrator stopped")

--- a/tests/test_cognitive_event_loop.py
+++ b/tests/test_cognitive_event_loop.py
@@ -1,0 +1,271 @@
+"""Tests for CognitiveEventLoop and CognitiveOrchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from openbad.cognitive.context_manager import (
+    CompressedContext,
+    CompressionStrategy,
+    ContextBudget,
+    ContextWindowManager,
+)
+from openbad.cognitive.event_loop import (
+    CognitiveEventLoop,
+    CognitiveRequest,
+    CognitiveResponse,
+)
+from openbad.cognitive.model_router import ModelRouter, Priority, RoutingDecision
+from openbad.cognitive.orchestrator import CognitiveOrchestrator
+from openbad.cognitive.providers.base import CompletionResult, HealthStatus
+from openbad.cognitive.providers.registry import ProviderRegistry
+from openbad.cognitive.reasoning.base import ReasoningResult, ReasoningStrategy
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+
+def _mock_router() -> ModelRouter:
+    adapter = AsyncMock()
+    adapter.complete = AsyncMock(
+        return_value=CompletionResult(
+            content="answer-42",
+            model_id="llama3.2",
+            provider="ollama",
+            tokens_used=50,
+        )
+    )
+    adapter.health_check = AsyncMock(
+        return_value=HealthStatus(
+            provider="ollama", available=True, latency_ms=10,
+        )
+    )
+    decision = RoutingDecision(
+        priority=Priority.MEDIUM,
+        provider="ollama",
+        model_id="llama3.2",
+        fallback_index=0,
+    )
+    router = MagicMock(spec=ModelRouter)
+    router.route = AsyncMock(return_value=(adapter, "llama3.2", decision))
+    router.record_latency = MagicMock()
+    return router
+
+
+def _mock_ctx() -> ContextWindowManager:
+    ctx = MagicMock(spec=ContextWindowManager)
+    ctx.allocate = MagicMock(
+        return_value=ContextBudget(
+            max_tokens=8192,
+            system_tokens=1200,
+            context_tokens=4900,
+            response_tokens=2048,
+        )
+    )
+    ctx.compress = MagicMock(
+        return_value=CompressedContext(
+            text="compressed ctx",
+            original_tokens=100,
+            compressed_tokens=100,
+            strategy=CompressionStrategy.TRUNCATE,
+        )
+    )
+    ctx.track_usage = MagicMock()
+    return ctx
+
+
+def _mock_strategy() -> ReasoningStrategy:
+    strategy = AsyncMock(spec=ReasoningStrategy)
+    strategy.reason = AsyncMock(
+        return_value=ReasoningResult(
+            final_answer="cot-answer", total_tokens=75,
+        )
+    )
+    return strategy
+
+
+def _event_loop(
+    strategies: dict[Priority, ReasoningStrategy] | None = None,
+    publish_fn: AsyncMock | None = None,
+    validate_fn: MagicMock | None = None,
+) -> CognitiveEventLoop:
+    return CognitiveEventLoop(
+        model_router=_mock_router(),
+        context_manager=_mock_ctx(),
+        strategies=strategies or {},
+        publish_fn=publish_fn,
+        validate_fn=validate_fn,
+    )
+
+
+# ------------------------------------------------------------------ #
+# Tests — basic processing
+# ------------------------------------------------------------------ #
+
+
+class TestHandleRequest:
+    async def test_direct_call(self) -> None:
+        loop = _event_loop()
+        req = CognitiveRequest(
+            request_id="r1", prompt="hello", priority=Priority.LOW,
+        )
+        resp = await loop.handle_request(req)
+        assert isinstance(resp, CognitiveResponse)
+        assert resp.answer == "answer-42"
+        assert resp.strategy == "direct"
+        assert resp.tokens_used == 50
+        assert resp.request_id == "r1"
+
+    async def test_strategy_used(self) -> None:
+        strategies = {Priority.MEDIUM: _mock_strategy()}
+        loop = _event_loop(strategies=strategies)
+        req = CognitiveRequest(
+            request_id="r2", prompt="think", priority=Priority.MEDIUM,
+        )
+        resp = await loop.handle_request(req)
+        assert resp.answer == "cot-answer"
+        assert resp.tokens_used == 75
+
+    async def test_publishes_result(self) -> None:
+        pub = AsyncMock()
+        loop = _event_loop(publish_fn=pub)
+        req = CognitiveRequest(request_id="r3", prompt="hi")
+        await loop.handle_request(req)
+        pub.assert_awaited_once()
+        topic, payload = pub.call_args[0]
+        assert topic == "agent/cognitive/response"
+        assert payload["request_id"] == "r3"
+
+
+# ------------------------------------------------------------------ #
+# Tests — validation
+# ------------------------------------------------------------------ #
+
+
+class TestValidation:
+    async def test_rejected_by_immune(self) -> None:
+        validate = MagicMock(return_value=False)
+        loop = _event_loop(validate_fn=validate)
+        req = CognitiveRequest(request_id="r4", prompt="bad")
+        resp = await loop.handle_request(req)
+        assert resp.error == "Request rejected by immune system"
+        assert resp.answer == ""
+
+    async def test_accepted_by_immune(self) -> None:
+        validate = MagicMock(return_value=True)
+        loop = _event_loop(validate_fn=validate)
+        req = CognitiveRequest(request_id="r5", prompt="ok")
+        resp = await loop.handle_request(req)
+        assert resp.answer == "answer-42"
+
+
+# ------------------------------------------------------------------ #
+# Tests — timeout
+# ------------------------------------------------------------------ #
+
+
+class TestTimeout:
+    async def test_timeout_enforced(self) -> None:
+        async def slow_complete(*_a, **_kw):
+            await asyncio.sleep(10)
+            return CompletionResult(
+                content="late", model_id="m", provider="p", tokens_used=0,
+            )
+
+        router = _mock_router()
+        adapter = (await router.route(Priority.LOW))[0]
+        adapter.complete = slow_complete
+
+        loop = CognitiveEventLoop(
+            model_router=router,
+            context_manager=_mock_ctx(),
+            strategies={},
+        )
+        req = CognitiveRequest(
+            request_id="t1", prompt="slow", priority=Priority.LOW,
+        )
+        resp = await loop.handle_request(req)
+        assert resp.timed_out is True
+        assert "Timed out" in resp.error
+
+
+# ------------------------------------------------------------------ #
+# Tests — MQTT message handler
+# ------------------------------------------------------------------ #
+
+
+class TestOnMessage:
+    async def test_valid_message(self) -> None:
+        loop = _event_loop()
+        await loop.start()
+        payload = json.dumps({
+            "request_id": "m1",
+            "prompt": "test",
+            "priority": 2,
+        }).encode()
+        await loop.on_message("agent/cognitive/request", payload)
+        # Give time for task
+        await asyncio.sleep(0.1)
+        await loop.stop()
+
+    async def test_invalid_json(self) -> None:
+        loop = _event_loop()
+        await loop.on_message("agent/cognitive/request", b"not json")
+        # Should not raise
+
+
+# ------------------------------------------------------------------ #
+# Tests — submit (fire-and-forget)
+# ------------------------------------------------------------------ #
+
+
+class TestSubmit:
+    async def test_submit_processes(self) -> None:
+        loop = _event_loop()
+        await loop.start()
+        req = CognitiveRequest(request_id="s1", prompt="async")
+        loop.submit(req)
+        await asyncio.sleep(0.1)
+        await loop.stop()
+
+
+# ------------------------------------------------------------------ #
+# Tests — lifecycle
+# ------------------------------------------------------------------ #
+
+
+class TestLifecycle:
+    async def test_start_stop(self) -> None:
+        loop = _event_loop()
+        await loop.start()
+        await loop.stop()
+
+
+# ------------------------------------------------------------------ #
+# Tests — orchestrator
+# ------------------------------------------------------------------ #
+
+
+class TestOrchestrator:
+    async def test_start_stop(self) -> None:
+        reg = ProviderRegistry()
+        router = _mock_router()
+        ctx = _mock_ctx()
+        orch = CognitiveOrchestrator(
+            registry=reg, router=router, context_manager=ctx,
+        )
+        await orch.start()
+        assert orch.event_loop is not None
+        await orch.stop()
+
+    async def test_event_loop_accessible(self) -> None:
+        reg = ProviderRegistry()
+        router = _mock_router()
+        ctx = _mock_ctx()
+        orch = CognitiveOrchestrator(
+            registry=reg, router=router, context_manager=ctx,
+        )
+        assert isinstance(orch.event_loop, CognitiveEventLoop)


### PR DESCRIPTION
Closes #90

## Summary
- `CognitiveEventLoop`: processes reasoning requests with strategy selection per priority
- `CognitiveRequest`/`CognitiveResponse` data types
- MQTT message handler (`on_message`) + fire-and-forget `submit()`  
- Priority-based timeouts (LOW=5s, MEDIUM=10s, HIGH/CRITICAL=30s)
- Immune system validation hook
- `CognitiveOrchestrator`: wires router + context manager + strategies + event loop with `start()`/`stop()` lifecycle
- 12 unit tests (direct call, strategy selection, timeout, validation, MQTT, lifecycle)

## How to Test
```bash
pytest tests/test_cognitive_event_loop.py -v
```