### PR TITLE
#87: Add Tree-of-Thoughts reasoning strategy

### DIFF
--- a/src/openbad/cognitive/reasoning/tree_of_thoughts.py
+++ b/src/openbad/cognitive/reasoning/tree_of_thoughts.py
@@ -1,0 +1,327 @@
+"""Tree-of-Thoughts (ToT) structured reasoning strategy."""
+
+from __future__ import annotations
+
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from openbad.cognitive.model_router import Priority
+from openbad.cognitive.reasoning.base import ReasoningResult, ReasoningStep, ReasoningStrategy
+
+if TYPE_CHECKING:
+    from openbad.cognitive.model_router import ModelRouter
+
+
+# ------------------------------------------------------------------ #
+# Data types
+# ------------------------------------------------------------------ #
+
+
+@dataclass
+class ThoughtNode:
+    """A single node in the thought tree."""
+
+    node_id: str
+    thought: str
+    score: float = 0.0
+    depth: int = 0
+    parent_id: str | None = None
+    children: list[ThoughtNode] = field(default_factory=list)
+
+
+@dataclass
+class ThoughtTree:
+    """Full tree structure for inspection and tracing."""
+
+    root_nodes: list[ThoughtNode] = field(default_factory=list)
+    best_path: list[ThoughtNode] = field(default_factory=list)
+    total_nodes_explored: int = 0
+    total_nodes_pruned: int = 0
+
+
+@dataclass
+class TreeOfThoughtsConfig:
+    """Configuration for ToT reasoning."""
+
+    priority: Priority = Priority.HIGH
+    branching_factor: int = 3
+    max_depth: int = 3
+    prune_threshold: float = 0.3
+
+
+# ------------------------------------------------------------------ #
+# Prompts
+# ------------------------------------------------------------------ #
+
+_GENERATE_PROMPT = (
+    "You are exploring possible solution paths.\n"
+    "Given the problem and current reasoning so far, "
+    "generate exactly {n} distinct candidate next-thoughts.\n"
+    "Number each candidate:\n"
+    "CANDIDATE 1: <thought>\n"
+    "CANDIDATE 2: <thought>\n"
+    "...\n\n"
+    "Problem:\n{problem}\n\n"
+    "Context:\n{context}\n\n"
+    "Reasoning so far:\n{path}"
+)
+
+_EVALUATE_PROMPT = (
+    "You are evaluating a candidate thought in a reasoning chain.\n"
+    "Rate how promising this thought is for solving the problem.\n"
+    "Output exactly: SCORE: <number between 0.0 and 1.0>\n\n"
+    "Problem:\n{problem}\n\n"
+    "Thought to evaluate:\n{thought}"
+)
+
+_SYNTHESIZE_PROMPT = (
+    "You are synthesizing a final answer from a reasoning path.\n"
+    "Given the problem and the best chain of thoughts, "
+    "produce a clear final answer.\n\n"
+    "Problem:\n{problem}\n\n"
+    "Context:\n{context}\n\n"
+    "Reasoning path:\n{path}\n\n"
+    "FINAL ANSWER:"
+)
+
+_CANDIDATE_PATTERN = re.compile(
+    r"CANDIDATE\s+\d+\s*:\s*(.+?)(?=CANDIDATE\s+\d+|$)",
+    re.DOTALL,
+)
+
+_SCORE_PATTERN = re.compile(r"SCORE\s*:\s*([\d.]+)")
+
+
+# ------------------------------------------------------------------ #
+# Strategy
+# ------------------------------------------------------------------ #
+
+
+class TreeOfThoughts(ReasoningStrategy):
+    """Tree-of-Thoughts: explore multiple solution paths, prune, converge."""
+
+    def __init__(self, config: TreeOfThoughtsConfig | None = None) -> None:
+        self._config = config or TreeOfThoughtsConfig()
+
+    async def reason(
+        self,
+        prompt: str,
+        context: str,
+        model_router: ModelRouter,
+    ) -> ReasoningResult:
+        tree = ThoughtTree()
+        total_tokens = 0
+        t0 = time.monotonic()
+
+        adapter, model_id, decision = await model_router.route(
+            self._config.priority,
+        )
+
+        # Generate root candidates
+        root_candidates = await self._generate(
+            prompt, context, "", adapter, model_id,
+        )
+        total_tokens += root_candidates[1]
+        root_nodes: list[ThoughtNode] = []
+
+        for thought_text in root_candidates[0]:
+            node = ThoughtNode(
+                node_id=uuid.uuid4().hex[:8],
+                thought=thought_text,
+                depth=0,
+            )
+            score, tokens = await self._evaluate(
+                prompt, thought_text, adapter, model_id,
+            )
+            total_tokens += tokens
+            node.score = score
+            root_nodes.append(node)
+            tree.total_nodes_explored += 1
+
+        # Prune roots
+        active = self._prune(root_nodes, tree)
+        tree.root_nodes = root_nodes
+
+        # Expand deeper levels
+        for depth in range(1, self._config.max_depth):
+            next_active: list[ThoughtNode] = []
+            for parent in active:
+                path_text = self._build_path([parent])
+                children_texts, tokens = await self._generate(
+                    prompt, context, path_text, adapter, model_id,
+                )
+                total_tokens += tokens
+
+                for child_text in children_texts:
+                    child = ThoughtNode(
+                        node_id=uuid.uuid4().hex[:8],
+                        thought=child_text,
+                        depth=depth,
+                        parent_id=parent.node_id,
+                    )
+                    score, tokens = await self._evaluate(
+                        prompt, child_text, adapter, model_id,
+                    )
+                    total_tokens += tokens
+                    child.score = score
+                    parent.children.append(child)
+                    tree.total_nodes_explored += 1
+
+                surviving = self._prune(parent.children, tree)
+                next_active.extend(surviving)
+
+            active = next_active
+            if not active:
+                break
+
+        # Find best path
+        best_leaf = self._best_leaf(tree.root_nodes)
+        best_path = self._trace_path(tree.root_nodes, best_leaf)
+        tree.best_path = best_path
+
+        # Synthesize final answer from best path
+        path_text = self._build_path(best_path)
+        synth_prompt = _SYNTHESIZE_PROMPT.format(
+            problem=prompt, context=context, path=path_text,
+        )
+        result = await adapter.complete(synth_prompt, model=model_id)
+        total_tokens += result.tokens_used
+        final_answer = result.content.strip()
+
+        latency = (time.monotonic() - t0) * 1000
+        model_router.record_latency(decision.provider, latency)
+
+        steps = tuple(
+            ReasoningStep(
+                step_number=i + 1,
+                thought=node.thought,
+                conclusion=f"score={node.score:.2f}",
+            )
+            for i, node in enumerate(best_path)
+        )
+
+        return ReasoningResult(
+            final_answer=final_answer,
+            steps=steps,
+            total_tokens=total_tokens,
+            total_latency_ms=latency,
+            metadata={
+                "model_id": model_id,
+                "provider": decision.provider,
+                "tree_nodes_explored": tree.total_nodes_explored,
+                "tree_nodes_pruned": tree.total_nodes_pruned,
+                "branching_factor": self._config.branching_factor,
+                "max_depth": self._config.max_depth,
+            },
+        )
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    async def _generate(
+        self, problem: str, context: str, path: str,
+        adapter: object, model_id: str,
+    ) -> tuple[list[str], int]:
+        """Generate candidate thoughts. Returns (candidates, tokens_used)."""
+        gen_prompt = _GENERATE_PROMPT.format(
+            n=self._config.branching_factor,
+            problem=problem,
+            context=context,
+            path=path or "(start)",
+        )
+        result = await adapter.complete(gen_prompt, model=model_id)  # type: ignore[union-attr]
+        candidates = _parse_candidates(
+            result.content, self._config.branching_factor,
+        )
+        return candidates, result.tokens_used
+
+    async def _evaluate(
+        self, problem: str, thought: str,
+        adapter: object, model_id: str,
+    ) -> tuple[float, int]:
+        """Evaluate a single thought. Returns (score, tokens_used)."""
+        eval_prompt = _EVALUATE_PROMPT.format(
+            problem=problem, thought=thought,
+        )
+        result = await adapter.complete(eval_prompt, model=model_id)  # type: ignore[union-attr]
+        score = _parse_score(result.content)
+        return score, result.tokens_used
+
+    def _prune(
+        self, nodes: list[ThoughtNode], tree: ThoughtTree,
+    ) -> list[ThoughtNode]:
+        """Remove nodes below threshold. Returns surviving nodes."""
+        surviving = [
+            n for n in nodes if n.score >= self._config.prune_threshold
+        ]
+        tree.total_nodes_pruned += len(nodes) - len(surviving)
+        return surviving
+
+    def _best_leaf(self, roots: list[ThoughtNode]) -> ThoughtNode | None:
+        """Find the highest-scoring leaf node in the tree."""
+        best: ThoughtNode | None = None
+        stack = list(roots)
+        while stack:
+            node = stack.pop()
+            if not node.children and (best is None or node.score > best.score):
+                best = node
+            stack.extend(node.children)
+        return best
+
+    def _trace_path(
+        self, roots: list[ThoughtNode], target: ThoughtNode | None,
+    ) -> list[ThoughtNode]:
+        """Trace from root to the target node."""
+        if target is None:
+            return []
+        # Build parent lookup
+        parent_map: dict[str, ThoughtNode] = {}
+        stack = list(roots)
+        while stack:
+            node = stack.pop()
+            for child in node.children:
+                parent_map[child.node_id] = node
+                stack.append(child)
+
+        path = [target]
+        current = target
+        while current.node_id in parent_map:
+            current = parent_map[current.node_id]
+            path.append(current)
+        path.reverse()
+        return path
+
+    @staticmethod
+    def _build_path(nodes: list[ThoughtNode]) -> str:
+        """Render a path as numbered text."""
+        return "\n".join(
+            f"Step {i + 1}: {n.thought}" for i, n in enumerate(nodes)
+        )
+
+
+# ------------------------------------------------------------------ #
+# Parsing
+# ------------------------------------------------------------------ #
+
+
+def _parse_candidates(text: str, expected: int) -> list[str]:
+    """Extract candidate thoughts from the model response."""
+    matches = _CANDIDATE_PATTERN.findall(text)
+    candidates = [m.strip() for m in matches if m.strip()]
+    if not candidates:
+        # Fallback: split by newlines and take first N non-empty lines
+        lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
+        candidates = lines[:expected]
+    return candidates[:expected]
+
+
+def _parse_score(text: str) -> float:
+    """Extract a numeric score from model response."""
+    match = _SCORE_PATTERN.search(text)
+    if match:
+        return min(max(float(match.group(1)), 0.0), 1.0)
+    return 0.5  # default if unparseable

--- a/tests/test_tree_of_thoughts.py
+++ b/tests/test_tree_of_thoughts.py
@@ -1,0 +1,239 @@
+"""Tests for Tree-of-Thoughts reasoning strategy."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openbad.cognitive.model_router import Priority
+from openbad.cognitive.reasoning.base import ReasoningResult, ReasoningStrategy
+from openbad.cognitive.reasoning.tree_of_thoughts import (
+    ThoughtNode,
+    ThoughtTree,
+    TreeOfThoughts,
+    TreeOfThoughtsConfig,
+    _parse_candidates,
+    _parse_score,
+)
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+
+def _mock_router(responses: list[str]) -> MagicMock:
+    """Build a mock router that returns an adapter cycling through responses."""
+    adapter = MagicMock()
+    call_idx = {"i": 0}
+
+    async def _complete(prompt: str, model: str = "") -> MagicMock:
+        idx = call_idx["i"] % len(responses)
+        call_idx["i"] += 1
+        result = MagicMock()
+        result.content = responses[idx]
+        result.tokens_used = 10
+        return result
+
+    adapter.complete = _complete
+
+    router = MagicMock()
+    decision = MagicMock()
+    decision.provider = "mock"
+    router.route = AsyncMock(return_value=(adapter, "test-model", decision))
+    router.record_latency = MagicMock()
+    return router
+
+
+# ------------------------------------------------------------------ #
+# Parsing
+# ------------------------------------------------------------------ #
+
+
+class TestParsing:
+    def test_parse_candidates(self) -> None:
+        text = (
+            "CANDIDATE 1: First idea\n"
+            "CANDIDATE 2: Second idea\n"
+            "CANDIDATE 3: Third idea\n"
+        )
+        result = _parse_candidates(text, 3)
+        assert len(result) == 3
+        assert result[0] == "First idea"
+        assert result[2] == "Third idea"
+
+    def test_parse_candidates_fallback(self) -> None:
+        text = "Line one\nLine two\nLine three"
+        result = _parse_candidates(text, 2)
+        assert len(result) == 2
+
+    def test_parse_score(self) -> None:
+        assert _parse_score("SCORE: 0.85") == 0.85
+
+    def test_parse_score_clamped(self) -> None:
+        assert _parse_score("SCORE: 1.5") == 1.0
+        assert _parse_score("SCORE: 0.0") == 0.0
+
+    def test_parse_score_default(self) -> None:
+        assert _parse_score("no score here") == 0.5
+
+
+# ------------------------------------------------------------------ #
+# ThoughtNode / ThoughtTree
+# ------------------------------------------------------------------ #
+
+
+class TestDataTypes:
+    def test_thought_node_defaults(self) -> None:
+        node = ThoughtNode(node_id="a", thought="test")
+        assert node.score == 0.0
+        assert node.depth == 0
+        assert node.parent_id is None
+        assert node.children == []
+
+    def test_thought_tree_defaults(self) -> None:
+        tree = ThoughtTree()
+        assert tree.root_nodes == []
+        assert tree.best_path == []
+        assert tree.total_nodes_explored == 0
+
+
+# ------------------------------------------------------------------ #
+# Reasoning — basic
+# ------------------------------------------------------------------ #
+
+
+class TestReason:
+    @pytest.mark.asyncio
+    async def test_basic_reasoning(self) -> None:
+        responses = [
+            # Generate root candidates
+            "CANDIDATE 1: idea A\nCANDIDATE 2: idea B\nCANDIDATE 3: idea C\n",
+            # Evaluate each root
+            "SCORE: 0.8",
+            "SCORE: 0.5",
+            "SCORE: 0.9",
+            # Generate children of surviving roots (depth 1)
+            "CANDIDATE 1: A-child1\nCANDIDATE 2: A-child2\nCANDIDATE 3: A-child3\n",
+            "SCORE: 0.7",
+            "SCORE: 0.6",
+            "SCORE: 0.4",
+            "CANDIDATE 1: B-child1\nCANDIDATE 2: B-child2\nCANDIDATE 3: B-child3\n",
+            "SCORE: 0.5",
+            "SCORE: 0.3",
+            "SCORE: 0.2",
+            "CANDIDATE 1: C-child1\nCANDIDATE 2: C-child2\nCANDIDATE 3: C-child3\n",
+            "SCORE: 0.95",
+            "SCORE: 0.4",
+            "SCORE: 0.3",
+            # Depth 2 — continues for surviving children
+            "CANDIDATE 1: deep1\nCANDIDATE 2: deep2\nCANDIDATE 3: deep3\n",
+            "SCORE: 0.85",
+            "SCORE: 0.6",
+            "SCORE: 0.5",
+            "CANDIDATE 1: deep1\nCANDIDATE 2: deep2\nCANDIDATE 3: deep3\n",
+            "SCORE: 0.7",
+            "SCORE: 0.6",
+            "SCORE: 0.5",
+            "CANDIDATE 1: deep1\nCANDIDATE 2: deep2\nCANDIDATE 3: deep3\n",
+            "SCORE: 0.7",
+            "SCORE: 0.6",
+            "SCORE: 0.5",
+            "CANDIDATE 1: deep1\nCANDIDATE 2: deep2\nCANDIDATE 3: deep3\n",
+            "SCORE: 0.7",
+            "SCORE: 0.6",
+            "SCORE: 0.5",
+            "CANDIDATE 1: deep1\nCANDIDATE 2: deep2\nCANDIDATE 3: deep3\n",
+            "SCORE: 0.7",
+            "SCORE: 0.6",
+            "SCORE: 0.5",
+            # Synthesize
+            "The answer is 42.",
+        ]
+        router = _mock_router(responses)
+        tot = TreeOfThoughts()
+        result = await tot.reason("What is the answer?", "Some context", router)
+
+        assert isinstance(result, ReasoningResult)
+        assert result.final_answer
+        assert result.total_tokens > 0
+        assert result.total_latency_ms >= 0
+        assert "tree_nodes_explored" in result.metadata
+
+    @pytest.mark.asyncio
+    async def test_pruning_occurs(self) -> None:
+        """All candidates score below threshold → everything pruned."""
+        responses = [
+            "CANDIDATE 1: bad1\nCANDIDATE 2: bad2\nCANDIDATE 3: bad3\n",
+            "SCORE: 0.1",
+            "SCORE: 0.05",
+            "SCORE: 0.2",
+            # Synthesize (best leaf from roots if any, else fallback)
+            "No good answer found.",
+        ]
+        router = _mock_router(responses)
+        tot = TreeOfThoughts()
+        result = await tot.reason("test", "ctx", router)
+        assert isinstance(result, ReasoningResult)
+        assert result.metadata["tree_nodes_pruned"] > 0
+
+    @pytest.mark.asyncio
+    async def test_custom_config(self) -> None:
+        config = TreeOfThoughtsConfig(
+            priority=Priority.CRITICAL,
+            branching_factor=2,
+            max_depth=1,
+            prune_threshold=0.5,
+        )
+        responses = [
+            "CANDIDATE 1: idea A\nCANDIDATE 2: idea B\n",
+            "SCORE: 0.9",
+            "SCORE: 0.8",
+            "Final answer here.",
+        ]
+        router = _mock_router(responses)
+        tot = TreeOfThoughts(config=config)
+        result = await tot.reason("problem", "ctx", router)
+
+        assert result.final_answer
+        assert result.metadata["branching_factor"] == 2
+        assert result.metadata["max_depth"] == 1
+        router.route.assert_called_with(Priority.CRITICAL)
+
+
+# ------------------------------------------------------------------ #
+# ABC conformance
+# ------------------------------------------------------------------ #
+
+
+class TestABCConformance:
+    def test_is_reasoning_strategy(self) -> None:
+        assert issubclass(TreeOfThoughts, ReasoningStrategy)
+
+    def test_instance(self) -> None:
+        tot = TreeOfThoughts()
+        assert isinstance(tot, ReasoningStrategy)
+
+
+# ------------------------------------------------------------------ #
+# Latency recording
+# ------------------------------------------------------------------ #
+
+
+class TestLatencyRecording:
+    @pytest.mark.asyncio
+    async def test_records_latency(self) -> None:
+        responses = [
+            "CANDIDATE 1: a\nCANDIDATE 2: b\nCANDIDATE 3: c\n",
+            "SCORE: 0.1",
+            "SCORE: 0.1",
+            "SCORE: 0.1",
+            "done",
+        ]
+        router = _mock_router(responses)
+        tot = TreeOfThoughts()
+        await tot.reason("p", "c", router)
+        router.record_latency.assert_called_once()
+        args = router.record_latency.call_args[0]
+        assert args[0] == "mock"
+        assert args[1] >= 0


### PR DESCRIPTION
Closes #87

## Summary
- `TreeOfThoughts(ReasoningStrategy)`: multi-path exploration with generate/evaluate/prune cycle
- `ThoughtNode` and `ThoughtTree` data types for full tree inspection
- Configurable: branching_factor (3), max_depth (3), prune_threshold (0.3)
- Best-path synthesis via dedicated prompt
- 13 unit tests (parsing, data types, basic reasoning, pruning, custom config, ABC, latency)

## How to Test
```bash
pytest tests/test_tree_of_thoughts.py -v
```