### PR TITLE
#115: Memory scaffold — base types, config, and package layout

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -1,0 +1,7 @@
+memory:
+  stm_max_tokens: 32768
+  stm_ttl_seconds: 3600.0
+  ltm_backend: json
+  ltm_storage_dir: data/memory
+  pruning_interval_seconds: 3600.0
+  forgetting_half_life_hours: 168.0

--- a/src/openbad/memory/__init__.py
+++ b/src/openbad/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Hierarchical memory system — STM, episodic, semantic, and procedural LTM."""

--- a/src/openbad/memory/base.py
+++ b/src/openbad/memory/base.py
@@ -1,0 +1,104 @@
+"""Base types and abstractions for the hierarchical memory system."""
+
+from __future__ import annotations
+
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class MemoryTier(Enum):
+    """Memory tier classification."""
+
+    STM = "stm"
+    EPISODIC = "episodic"
+    SEMANTIC = "semantic"
+    PROCEDURAL = "procedural"
+
+
+@dataclass
+class MemoryEntry:
+    """A single entry in the memory system."""
+
+    key: str
+    value: Any
+    tier: MemoryTier
+    entry_id: str = field(default_factory=lambda: uuid.uuid4().hex[:16])
+    created_at: float = 0.0
+    accessed_at: float = 0.0
+    access_count: int = 0
+    ttl_seconds: float | None = None
+    context: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def is_expired(self, now: float) -> bool:
+        """Check if this entry has exceeded its TTL."""
+        if self.ttl_seconds is None or self.ttl_seconds <= 0:
+            return False
+        return (now - self.created_at) > self.ttl_seconds
+
+    def touch(self, now: float) -> None:
+        """Update access timestamp and increment access count."""
+        self.accessed_at = now
+        self.access_count += 1
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "entry_id": self.entry_id,
+            "key": self.key,
+            "value": self.value,
+            "tier": self.tier.value,
+            "created_at": self.created_at,
+            "accessed_at": self.accessed_at,
+            "access_count": self.access_count,
+            "ttl_seconds": self.ttl_seconds,
+            "context": self.context,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MemoryEntry:
+        """Deserialize from dictionary."""
+        return cls(
+            entry_id=data["entry_id"],
+            key=data["key"],
+            value=data["value"],
+            tier=MemoryTier(data["tier"]),
+            created_at=data.get("created_at", 0.0),
+            accessed_at=data.get("accessed_at", 0.0),
+            access_count=data.get("access_count", 0),
+            ttl_seconds=data.get("ttl_seconds"),
+            context=data.get("context", ""),
+            metadata=data.get("metadata", {}),
+        )
+
+
+class MemoryStore(ABC):
+    """Abstract base class for memory tier stores."""
+
+    @abstractmethod
+    def write(self, entry: MemoryEntry) -> str:
+        """Write an entry to the store. Returns the entry_id."""
+
+    @abstractmethod
+    def read(self, key: str) -> MemoryEntry | None:
+        """Read an entry by key. Returns None if not found."""
+
+    @abstractmethod
+    def delete(self, key: str) -> bool:
+        """Delete an entry by key. Returns True if entry existed."""
+
+    @abstractmethod
+    def query(self, prefix: str) -> list[MemoryEntry]:
+        """Query entries by key prefix or pattern."""
+
+    @abstractmethod
+    def list_keys(self) -> list[str]:
+        """Return all keys in the store."""
+
+    @abstractmethod
+    def size(self) -> int:
+        """Return the number of entries in the store."""

--- a/src/openbad/memory/config.py
+++ b/src/openbad/memory/config.py
@@ -1,0 +1,46 @@
+"""Memory system configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class MemoryConfig:
+    """Configuration for the hierarchical memory system."""
+
+    stm_max_tokens: int = 32768
+    stm_ttl_seconds: float = 3600.0
+    ltm_backend: str = "json"
+    ltm_storage_dir: Path = field(default_factory=lambda: Path("data/memory"))
+    pruning_interval_seconds: float = 3600.0
+    forgetting_half_life_hours: float = 168.0
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> MemoryConfig:
+        """Load configuration from a YAML file."""
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        mem = data.get("memory", data)
+        return cls(
+            stm_max_tokens=mem.get("stm_max_tokens", 32768),
+            stm_ttl_seconds=mem.get("stm_ttl_seconds", 3600.0),
+            ltm_backend=mem.get("ltm_backend", "json"),
+            ltm_storage_dir=Path(mem.get("ltm_storage_dir", "data/memory")),
+            pruning_interval_seconds=mem.get("pruning_interval_seconds", 3600.0),
+            forgetting_half_life_hours=mem.get("forgetting_half_life_hours", 168.0),
+        )
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary."""
+        return {
+            "stm_max_tokens": self.stm_max_tokens,
+            "stm_ttl_seconds": self.stm_ttl_seconds,
+            "ltm_backend": self.ltm_backend,
+            "ltm_storage_dir": str(self.ltm_storage_dir),
+            "pruning_interval_seconds": self.pruning_interval_seconds,
+            "forgetting_half_life_hours": self.forgetting_half_life_hours,
+        }

--- a/tests/test_memory_base.py
+++ b/tests/test_memory_base.py
@@ -1,0 +1,213 @@
+"""Tests for memory base types and configuration."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+import yaml
+
+from openbad.memory.base import MemoryEntry, MemoryStore, MemoryTier
+
+# ------------------------------------------------------------------ #
+# MemoryTier
+# ------------------------------------------------------------------ #
+
+
+class TestMemoryTier:
+    def test_values(self) -> None:
+        assert MemoryTier.STM.value == "stm"
+        assert MemoryTier.EPISODIC.value == "episodic"
+        assert MemoryTier.SEMANTIC.value == "semantic"
+        assert MemoryTier.PROCEDURAL.value == "procedural"
+
+    def test_all_tiers(self) -> None:
+        assert len(MemoryTier) == 4
+
+
+# ------------------------------------------------------------------ #
+# MemoryEntry
+# ------------------------------------------------------------------ #
+
+
+class TestMemoryEntry:
+    def test_create_with_defaults(self) -> None:
+        entry = MemoryEntry(key="k1", value="hello", tier=MemoryTier.STM)
+        assert entry.key == "k1"
+        assert entry.value == "hello"
+        assert entry.tier is MemoryTier.STM
+        assert entry.entry_id  # auto-generated
+        assert entry.access_count == 0
+        assert entry.context == ""
+        assert entry.metadata == {}
+
+    def test_entry_id_uniqueness(self) -> None:
+        a = MemoryEntry(key="k", value="v", tier=MemoryTier.STM)
+        b = MemoryEntry(key="k", value="v", tier=MemoryTier.STM)
+        assert a.entry_id != b.entry_id
+
+    def test_is_expired_no_ttl(self) -> None:
+        entry = MemoryEntry(key="k", value="v", tier=MemoryTier.STM)
+        assert not entry.is_expired(time.time() + 99999)
+
+    def test_is_expired_zero_ttl(self) -> None:
+        entry = MemoryEntry(
+            key="k", value="v", tier=MemoryTier.STM,
+            ttl_seconds=0, created_at=1000.0,
+        )
+        assert not entry.is_expired(9999.0)
+
+    def test_is_expired_within_ttl(self) -> None:
+        entry = MemoryEntry(
+            key="k", value="v", tier=MemoryTier.STM,
+            ttl_seconds=60.0, created_at=1000.0,
+        )
+        assert not entry.is_expired(1050.0)
+
+    def test_is_expired_past_ttl(self) -> None:
+        entry = MemoryEntry(
+            key="k", value="v", tier=MemoryTier.STM,
+            ttl_seconds=60.0, created_at=1000.0,
+        )
+        assert entry.is_expired(1061.0)
+
+    def test_touch(self) -> None:
+        entry = MemoryEntry(key="k", value="v", tier=MemoryTier.STM)
+        entry.touch(100.0)
+        assert entry.accessed_at == 100.0
+        assert entry.access_count == 1
+        entry.touch(200.0)
+        assert entry.accessed_at == 200.0
+        assert entry.access_count == 2
+
+    def test_to_dict_roundtrip(self) -> None:
+        entry = MemoryEntry(
+            key="k1", value={"data": [1, 2]}, tier=MemoryTier.EPISODIC,
+            created_at=1000.0, accessed_at=1001.0, access_count=3,
+            ttl_seconds=300.0, context="task-42",
+            metadata={"source": "test"},
+        )
+        d = entry.to_dict()
+        restored = MemoryEntry.from_dict(d)
+        assert restored.key == entry.key
+        assert restored.value == entry.value
+        assert restored.tier == entry.tier
+        assert restored.entry_id == entry.entry_id
+        assert restored.created_at == entry.created_at
+        assert restored.context == entry.context
+        assert restored.metadata == entry.metadata
+
+    def test_from_dict_defaults(self) -> None:
+        d = {
+            "entry_id": "abc123",
+            "key": "k",
+            "value": "v",
+            "tier": "stm",
+        }
+        entry = MemoryEntry.from_dict(d)
+        assert entry.entry_id == "abc123"
+        assert entry.access_count == 0
+        assert entry.context == ""
+
+
+# ------------------------------------------------------------------ #
+# MemoryStore ABC
+# ------------------------------------------------------------------ #
+
+
+class TestMemoryStoreABC:
+    def test_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            MemoryStore()  # type: ignore[abstract]
+
+    def test_subclass_must_implement(self) -> None:
+        class Incomplete(MemoryStore):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+    def test_valid_subclass(self) -> None:
+        class InMemory(MemoryStore):
+            def __init__(self):
+                self._data: dict[str, MemoryEntry] = {}
+
+            def write(self, entry):
+                self._data[entry.key] = entry
+                return entry.entry_id
+
+            def read(self, key):
+                return self._data.get(key)
+
+            def delete(self, key):
+                return self._data.pop(key, None) is not None
+
+            def query(self, prefix):
+                return [e for k, e in self._data.items() if k.startswith(prefix)]
+
+            def list_keys(self):
+                return list(self._data.keys())
+
+            def size(self):
+                return len(self._data)
+
+        store = InMemory()
+        entry = MemoryEntry(key="test", value="data", tier=MemoryTier.STM)
+        eid = store.write(entry)
+        assert eid == entry.entry_id
+        assert store.read("test") is entry
+        assert store.size() == 1
+        assert store.list_keys() == ["test"]
+        assert store.query("tes") == [entry]
+        assert store.delete("test")
+        assert store.size() == 0
+
+
+# ------------------------------------------------------------------ #
+# MemoryConfig
+# ------------------------------------------------------------------ #
+
+
+class TestMemoryConfig:
+    def test_defaults(self) -> None:
+        from openbad.memory.config import MemoryConfig
+        cfg = MemoryConfig()
+        assert cfg.stm_max_tokens == 32768
+        assert cfg.stm_ttl_seconds == 3600.0
+        assert cfg.ltm_backend == "json"
+        assert cfg.pruning_interval_seconds == 3600.0
+        assert cfg.forgetting_half_life_hours == 168.0
+
+    def test_from_yaml(self, tmp_path) -> None:
+        from openbad.memory.config import MemoryConfig
+        data = {
+            "memory": {
+                "stm_max_tokens": 16384,
+                "stm_ttl_seconds": 1800.0,
+                "ltm_backend": "sqlite",
+                "ltm_storage_dir": "/tmp/mem",  # noqa: S108
+                "pruning_interval_seconds": 600.0,
+                "forgetting_half_life_hours": 72.0,
+            },
+        }
+        yaml_file = tmp_path / "mem.yaml"
+        yaml_file.write_text(yaml.dump(data))
+
+        cfg = MemoryConfig.from_yaml(yaml_file)
+        assert cfg.stm_max_tokens == 16384
+        assert cfg.ltm_backend == "sqlite"
+        assert cfg.forgetting_half_life_hours == 72.0
+
+    def test_to_dict(self) -> None:
+        from openbad.memory.config import MemoryConfig
+        cfg = MemoryConfig()
+        d = cfg.to_dict()
+        assert d["stm_max_tokens"] == 32768
+        assert d["ltm_backend"] == "json"
+
+    def test_from_yaml_empty_file(self, tmp_path) -> None:
+        from openbad.memory.config import MemoryConfig
+        yaml_file = tmp_path / "empty.yaml"
+        yaml_file.write_text("")
+        cfg = MemoryConfig.from_yaml(yaml_file)
+        assert cfg.stm_max_tokens == 32768  # defaults


### PR DESCRIPTION
Closes #115

Adds `src/openbad/memory/` package with:
- `MemoryTier` enum (STM, EPISODIC, SEMANTIC, PROCEDURAL)
- `MemoryEntry` dataclass with TTL, serialization, touch tracking
- `MemoryStore` ABC with write/read/delete/query/list_keys/size
- `MemoryConfig` dataclass with YAML loading
- `config/memory.yaml` defaults
- 18 unit tests