### PR TITLE
#116: Short-Term Memory rolling buffer with token budget and TTL

### DIFF
--- a/src/openbad/memory/stm.py
+++ b/src/openbad/memory/stm.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from openbad.memory.base import MemoryEntry, MemoryStore, MemoryTier
 

--- a/src/openbad/memory/stm.py
+++ b/src/openbad/memory/stm.py
@@ -1,0 +1,164 @@
+"""Short-Term Memory — in-memory, token-bounded rolling buffer with TTL."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+
+from openbad.memory.base import MemoryEntry, MemoryStore, MemoryTier
+
+
+def _estimate_tokens(value: Any) -> int:
+    """Estimate token count from a value (1 token ≈ 0.75 words)."""
+    text = str(value)
+    words = len(text.split())
+    return max(1, int(words / 0.75))
+
+
+class ShortTermMemory(MemoryStore):
+    """Token-bounded, volatile in-memory buffer with TTL expiry."""
+
+    def __init__(
+        self,
+        max_tokens: int = 32768,
+        default_ttl: float = 3600.0,
+        publish_fn: Callable[[str, bytes], None] | None = None,
+    ) -> None:
+        self._max_tokens = max_tokens
+        self._default_ttl = default_ttl
+        self._publish_fn = publish_fn
+        self._entries: dict[str, MemoryEntry] = {}
+        self._token_counts: dict[str, int] = {}
+        self._tokens_used: int = 0
+
+    # ------------------------------------------------------------------ #
+    # MemoryStore interface
+    # ------------------------------------------------------------------ #
+
+    def write(self, entry: MemoryEntry) -> str:
+        """Write entry, evicting oldest if over budget."""
+        now = time.time()
+        if entry.created_at == 0.0:
+            entry.created_at = now
+        if entry.ttl_seconds is None:
+            entry.ttl_seconds = self._default_ttl
+        entry.tier = MemoryTier.STM
+
+        tokens = _estimate_tokens(entry.value)
+
+        # If key already exists, remove old tokens first
+        if entry.key in self._entries:
+            self._tokens_used -= self._token_counts[entry.key]
+
+        # Evict expired first
+        self.evict_expired()
+
+        # Evict oldest entries until we have room
+        while (
+            self._tokens_used + tokens > self._max_tokens
+            and self._entries
+        ):
+            self._evict_oldest()
+
+        self._entries[entry.key] = entry
+        self._token_counts[entry.key] = tokens
+        self._tokens_used += tokens
+
+        if self._publish_fn:
+            self._publish_fn(
+                "agent/memory/stm/write",
+                entry.key.encode(),
+            )
+
+        return entry.entry_id
+
+    def read(self, key: str) -> MemoryEntry | None:
+        """Read entry by key, updating access stats."""
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        now = time.time()
+        if entry.is_expired(now):
+            self._remove(key)
+            return None
+        entry.touch(now)
+        return entry
+
+    def delete(self, key: str) -> bool:
+        """Delete entry by key."""
+        if key in self._entries:
+            self._remove(key)
+            return True
+        return False
+
+    def query(self, prefix: str) -> list[MemoryEntry]:
+        """Query entries by key prefix."""
+        now = time.time()
+        return [
+            e for k, e in self._entries.items()
+            if k.startswith(prefix) and not e.is_expired(now)
+        ]
+
+    def list_keys(self) -> list[str]:
+        """Return all non-expired keys."""
+        now = time.time()
+        return [k for k, e in self._entries.items() if not e.is_expired(now)]
+
+    def size(self) -> int:
+        """Return number of entries."""
+        return len(self._entries)
+
+    # ------------------------------------------------------------------ #
+    # STM-specific methods
+    # ------------------------------------------------------------------ #
+
+    def flush(self) -> list[str]:
+        """Clear all entries. Returns list of flushed keys."""
+        keys = list(self._entries.keys())
+        self._entries.clear()
+        self._token_counts.clear()
+        self._tokens_used = 0
+        return keys
+
+    def usage(self) -> dict[str, int | float]:
+        """Return current memory usage stats."""
+        now = time.time()
+        ages = [now - e.created_at for e in self._entries.values()]
+        return {
+            "tokens_used": self._tokens_used,
+            "tokens_max": self._max_tokens,
+            "entry_count": len(self._entries),
+            "oldest_entry_age": max(ages) if ages else 0.0,
+        }
+
+    def expired_entries(self) -> list[MemoryEntry]:
+        """Return entries that have exceeded their TTL."""
+        now = time.time()
+        return [e for e in self._entries.values() if e.is_expired(now)]
+
+    def evict_expired(self) -> int:
+        """Remove expired entries. Returns count removed."""
+        now = time.time()
+        expired_keys = [
+            k for k, e in self._entries.items() if e.is_expired(now)
+        ]
+        for k in expired_keys:
+            self._remove(k)
+        return len(expired_keys)
+
+    # ------------------------------------------------------------------ #
+    # Internal
+    # ------------------------------------------------------------------ #
+
+    def _remove(self, key: str) -> None:
+        """Remove an entry and update token count."""
+        if key in self._entries:
+            del self._entries[key]
+            self._tokens_used -= self._token_counts.pop(key, 0)
+
+    def _evict_oldest(self) -> None:
+        """Evict the oldest entry by created_at."""
+        if not self._entries:
+            return
+        oldest_key = min(self._entries, key=lambda k: self._entries[k].created_at)
+        self._remove(oldest_key)

--- a/tests/test_stm.py
+++ b/tests/test_stm.py
@@ -1,0 +1,204 @@
+"""Tests for Short-Term Memory (STM) rolling buffer."""
+
+from __future__ import annotations
+
+import time
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.stm import ShortTermMemory, _estimate_tokens
+
+# ------------------------------------------------------------------ #
+# Token estimation
+# ------------------------------------------------------------------ #
+
+
+class TestTokenEstimation:
+    def test_single_word(self) -> None:
+        assert _estimate_tokens("hello") >= 1
+
+    def test_longer_text(self) -> None:
+        tokens = _estimate_tokens("this is a test sentence with several words")
+        assert tokens > 1
+
+    def test_empty_string(self) -> None:
+        assert _estimate_tokens("") >= 1
+
+
+# ------------------------------------------------------------------ #
+# Basic CRUD
+# ------------------------------------------------------------------ #
+
+
+class TestSTMBasicOps:
+    def test_write_and_read(self) -> None:
+        stm = ShortTermMemory()
+        entry = MemoryEntry(key="k1", value="hello world", tier=MemoryTier.STM)
+        eid = stm.write(entry)
+        assert eid == entry.entry_id
+
+        result = stm.read("k1")
+        assert result is not None
+        assert result.value == "hello world"
+        assert result.access_count == 1
+
+    def test_read_missing(self) -> None:
+        stm = ShortTermMemory()
+        assert stm.read("missing") is None
+
+    def test_delete(self) -> None:
+        stm = ShortTermMemory()
+        stm.write(MemoryEntry(key="k", value="v", tier=MemoryTier.STM))
+        assert stm.delete("k")
+        assert stm.read("k") is None
+        assert not stm.delete("k")
+
+    def test_overwrite_key(self) -> None:
+        stm = ShortTermMemory(max_tokens=1000)
+        stm.write(MemoryEntry(key="k", value="old", tier=MemoryTier.STM))
+        stm.write(MemoryEntry(key="k", value="new", tier=MemoryTier.STM))
+        result = stm.read("k")
+        assert result is not None
+        assert result.value == "new"
+        assert stm.size() == 1
+
+    def test_query(self) -> None:
+        stm = ShortTermMemory()
+        stm.write(MemoryEntry(key="task/1", value="a", tier=MemoryTier.STM))
+        stm.write(MemoryEntry(key="task/2", value="b", tier=MemoryTier.STM))
+        stm.write(MemoryEntry(key="other/1", value="c", tier=MemoryTier.STM))
+        results = stm.query("task/")
+        assert len(results) == 2
+
+    def test_list_keys(self) -> None:
+        stm = ShortTermMemory()
+        stm.write(MemoryEntry(key="a", value="1", tier=MemoryTier.STM))
+        stm.write(MemoryEntry(key="b", value="2", tier=MemoryTier.STM))
+        keys = stm.list_keys()
+        assert sorted(keys) == ["a", "b"]
+
+    def test_size(self) -> None:
+        stm = ShortTermMemory()
+        assert stm.size() == 0
+        stm.write(MemoryEntry(key="k", value="v", tier=MemoryTier.STM))
+        assert stm.size() == 1
+
+
+# ------------------------------------------------------------------ #
+# Token budget & eviction
+# ------------------------------------------------------------------ #
+
+
+class TestSTMEviction:
+    def test_evicts_oldest_on_overflow(self) -> None:
+        stm = ShortTermMemory(max_tokens=10)
+        now = time.time()
+        # Write entries with current timestamps so they aren't expired
+        stm.write(MemoryEntry(
+            key="old", value="word " * 5, tier=MemoryTier.STM,
+            created_at=now,
+        ))
+        stm.write(MemoryEntry(
+            key="new", value="word " * 5, tier=MemoryTier.STM,
+            created_at=now + 1,
+        ))
+        # "old" should have been evicted to make room
+        assert stm.read("old") is None
+        assert stm.read("new") is not None
+
+    def test_usage_stats(self) -> None:
+        stm = ShortTermMemory(max_tokens=1000)
+        stm.write(MemoryEntry(key="k", value="some text", tier=MemoryTier.STM))
+        usage = stm.usage()
+        assert usage["tokens_max"] == 1000
+        assert usage["tokens_used"] > 0
+        assert usage["entry_count"] == 1
+
+
+# ------------------------------------------------------------------ #
+# TTL expiry
+# ------------------------------------------------------------------ #
+
+
+class TestSTMTTL:
+    def test_expired_entry_not_readable(self) -> None:
+        stm = ShortTermMemory(default_ttl=60.0)
+        entry = MemoryEntry(
+            key="k", value="v", tier=MemoryTier.STM,
+            created_at=time.time() - 120.0,  # 2 minutes ago
+            ttl_seconds=60.0,
+        )
+        stm.write(entry)
+        assert stm.read("k") is None
+
+    def test_expired_entries_list(self) -> None:
+        stm = ShortTermMemory(default_ttl=60.0)
+        stm.write(MemoryEntry(
+            key="exp", value="v", tier=MemoryTier.STM,
+            created_at=time.time() - 120.0, ttl_seconds=60.0,
+        ))
+        # Check immediately — before another write triggers eviction
+        expired = stm.expired_entries()
+        assert len(expired) == 1
+        assert expired[0].key == "exp"
+
+    def test_evict_expired(self) -> None:
+        stm = ShortTermMemory(default_ttl=60.0)
+        # Write the valid entry first so it isn't evicted
+        stm.write(MemoryEntry(key="ok", value="v", tier=MemoryTier.STM))
+        # Then add an expired entry (evict_expired in write sees only "ok")
+        stm.write(MemoryEntry(
+            key="exp", value="v", tier=MemoryTier.STM,
+            created_at=time.time() - 120.0, ttl_seconds=60.0,
+        ))
+        count = stm.evict_expired()
+        assert count == 1
+        assert stm.size() == 1
+
+
+# ------------------------------------------------------------------ #
+# Flush
+# ------------------------------------------------------------------ #
+
+
+class TestSTMFlush:
+    def test_flush_clears_all(self) -> None:
+        stm = ShortTermMemory()
+        stm.write(MemoryEntry(key="a", value="1", tier=MemoryTier.STM))
+        stm.write(MemoryEntry(key="b", value="2", tier=MemoryTier.STM))
+        flushed = stm.flush()
+        assert sorted(flushed) == ["a", "b"]
+        assert stm.size() == 0
+        assert stm.usage()["tokens_used"] == 0
+
+
+# ------------------------------------------------------------------ #
+# Publish callback
+# ------------------------------------------------------------------ #
+
+
+class TestSTMPublish:
+    def test_publish_fn_called(self) -> None:
+        published: list[tuple[str, bytes]] = []
+        stm = ShortTermMemory(publish_fn=lambda t, p: published.append((t, p)))
+        stm.write(MemoryEntry(key="k", value="v", tier=MemoryTier.STM))
+        assert len(published) == 1
+        assert published[0][0] == "agent/memory/stm/write"
+        assert published[0][1] == b"k"
+
+    def test_no_publish_fn(self) -> None:
+        stm = ShortTermMemory()
+        # Should not raise
+        stm.write(MemoryEntry(key="k", value="v", tier=MemoryTier.STM))
+
+
+# ------------------------------------------------------------------ #
+# Tier assignment
+# ------------------------------------------------------------------ #
+
+
+class TestSTMTierEnforcement:
+    def test_entry_tier_set_to_stm(self) -> None:
+        stm = ShortTermMemory()
+        entry = MemoryEntry(key="k", value="v", tier=MemoryTier.EPISODIC)
+        stm.write(entry)
+        assert entry.tier is MemoryTier.STM


### PR DESCRIPTION
Closes #116

Adds `ShortTermMemory(MemoryStore)`:
- Token-bounded buffer (max_tokens=32768 default)
- TTL-based expiry with eviction on write
- FIFO eviction when over budget
- Optional MQTT publish callback
- Usage stats, flush, query by prefix
- 19 unit tests