### PR TITLE
#117: Episodic LTM store with JSON persistence and time-range queries

### DIFF
--- a/src/openbad/memory/episodic.py
+++ b/src/openbad/memory/episodic.py
@@ -1,0 +1,158 @@
+"""Episodic Long-Term Memory — chronological interaction logs with JSON storage."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from openbad.memory.base import MemoryEntry, MemoryStore, MemoryTier
+
+
+class EpisodicMemory(MemoryStore):
+    """Chronological log of interactions, persisted to JSON.
+
+    Supports time-range queries, task-ID filtering, and append-only logging
+    with optional on-disk persistence.
+    """
+
+    def __init__(
+        self,
+        storage_path: Path | None = None,
+        auto_persist: bool = True,
+    ) -> None:
+        self._storage_path = storage_path
+        self._auto_persist = auto_persist
+        self._entries: dict[str, MemoryEntry] = {}
+        self._timeline: list[str] = []  # keys in chronological order
+
+        if storage_path and storage_path.exists():
+            self._load()
+
+    # ------------------------------------------------------------------ #
+    # MemoryStore interface
+    # ------------------------------------------------------------------ #
+
+    def write(self, entry: MemoryEntry) -> str:
+        """Append an episodic entry to the log."""
+        now = time.time()
+        if entry.created_at == 0.0:
+            entry.created_at = now
+        entry.tier = MemoryTier.EPISODIC
+
+        if entry.key in self._entries:
+            # Replace existing — remove from timeline and re-append
+            self._timeline = [k for k in self._timeline if k != entry.key]
+
+        self._entries[entry.key] = entry
+        self._timeline.append(entry.key)
+
+        if self._auto_persist:
+            self._save()
+
+        return entry.entry_id
+
+    def read(self, key: str) -> MemoryEntry | None:
+        """Read an entry by key, updating access stats."""
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        entry.touch(time.time())
+        return entry
+
+    def delete(self, key: str) -> bool:
+        """Delete an entry from the log."""
+        if key not in self._entries:
+            return False
+        del self._entries[key]
+        self._timeline = [k for k in self._timeline if k != key]
+        if self._auto_persist:
+            self._save()
+        return True
+
+    def query(self, prefix: str) -> list[MemoryEntry]:
+        """Query entries by key prefix, returned chronologically."""
+        return [
+            self._entries[k]
+            for k in self._timeline
+            if k.startswith(prefix)
+        ]
+
+    def list_keys(self) -> list[str]:
+        """Return all keys in chronological order."""
+        return list(self._timeline)
+
+    def size(self) -> int:
+        """Return the number of entries."""
+        return len(self._entries)
+
+    # ------------------------------------------------------------------ #
+    # Episodic-specific methods
+    # ------------------------------------------------------------------ #
+
+    def query_time_range(
+        self,
+        start: float,
+        end: float,
+    ) -> list[MemoryEntry]:
+        """Return entries within the given time range [start, end]."""
+        return [
+            self._entries[k]
+            for k in self._timeline
+            if start <= self._entries[k].created_at <= end
+        ]
+
+    def query_by_task(self, task_id: str) -> list[MemoryEntry]:
+        """Return entries with a matching task_id in metadata."""
+        return [
+            self._entries[k]
+            for k in self._timeline
+            if self._entries[k].metadata.get("task_id") == task_id
+        ]
+
+    def recent(self, n: int = 10) -> list[MemoryEntry]:
+        """Return the N most recent entries."""
+        keys = self._timeline[-n:]
+        return [self._entries[k] for k in keys]
+
+    def save(self) -> None:
+        """Explicitly persist to disk."""
+        self._save()
+
+    # ------------------------------------------------------------------ #
+    # Persistence
+    # ------------------------------------------------------------------ #
+
+    def _save(self) -> None:
+        """Write entries to JSON file."""
+        if self._storage_path is None:
+            return
+        self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "timeline": self._timeline,
+            "entries": {k: e.to_dict() for k, e in self._entries.items()},
+        }
+        self._storage_path.write_text(
+            json.dumps(data, indent=2, default=_json_default),
+            encoding="utf-8",
+        )
+
+    def _load(self) -> None:
+        """Load entries from JSON file."""
+        if self._storage_path is None or not self._storage_path.exists():
+            return
+        raw = self._storage_path.read_text(encoding="utf-8")
+        if not raw.strip():
+            return
+        data = json.loads(raw)
+        self._timeline = data.get("timeline", [])
+        entries_data: dict[str, Any] = data.get("entries", {})
+        self._entries = {
+            k: MemoryEntry.from_dict(v) for k, v in entries_data.items()
+        }
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON serializer fallback for non-serializable types."""
+    return str(obj)

--- a/tests/test_episodic.py
+++ b/tests/test_episodic.py
@@ -1,0 +1,229 @@
+"""Tests for Episodic Long-Term Memory store."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.episodic import EpisodicMemory
+
+# ------------------------------------------------------------------ #
+# Basic CRUD
+# ------------------------------------------------------------------ #
+
+
+class TestEpisodicBasicOps:
+    def test_write_and_read(self) -> None:
+        mem = EpisodicMemory()
+        entry = MemoryEntry(key="e1", value="event one", tier=MemoryTier.EPISODIC)
+        eid = mem.write(entry)
+        assert eid == entry.entry_id
+        result = mem.read("e1")
+        assert result is not None
+        assert result.value == "event one"
+        assert result.access_count == 1
+
+    def test_read_missing(self) -> None:
+        mem = EpisodicMemory()
+        assert mem.read("nope") is None
+
+    def test_delete(self) -> None:
+        mem = EpisodicMemory()
+        mem.write(MemoryEntry(key="k", value="v", tier=MemoryTier.EPISODIC))
+        assert mem.delete("k")
+        assert mem.read("k") is None
+        assert not mem.delete("k")
+
+    def test_overwrite_key(self) -> None:
+        mem = EpisodicMemory()
+        mem.write(MemoryEntry(key="k", value="old", tier=MemoryTier.EPISODIC))
+        mem.write(MemoryEntry(key="k", value="new", tier=MemoryTier.EPISODIC))
+        result = mem.read("k")
+        assert result is not None
+        assert result.value == "new"
+        assert mem.size() == 1
+
+    def test_size(self) -> None:
+        mem = EpisodicMemory()
+        assert mem.size() == 0
+        mem.write(MemoryEntry(key="k", value="v", tier=MemoryTier.EPISODIC))
+        assert mem.size() == 1
+
+
+# ------------------------------------------------------------------ #
+# Query
+# ------------------------------------------------------------------ #
+
+
+class TestEpisodicQuery:
+    def test_query_prefix(self) -> None:
+        mem = EpisodicMemory()
+        mem.write(MemoryEntry(key="task/1", value="a", tier=MemoryTier.EPISODIC))
+        mem.write(MemoryEntry(key="task/2", value="b", tier=MemoryTier.EPISODIC))
+        mem.write(MemoryEntry(key="other/1", value="c", tier=MemoryTier.EPISODIC))
+        results = mem.query("task/")
+        assert len(results) == 2
+
+    def test_list_keys_chronological(self) -> None:
+        mem = EpisodicMemory()
+        for i in range(5):
+            mem.write(MemoryEntry(key=f"k{i}", value=str(i), tier=MemoryTier.EPISODIC))
+        keys = mem.list_keys()
+        assert keys == ["k0", "k1", "k2", "k3", "k4"]
+
+
+# ------------------------------------------------------------------ #
+# Time range queries
+# ------------------------------------------------------------------ #
+
+
+class TestEpisodicTimeRange:
+    def test_query_time_range(self) -> None:
+        mem = EpisodicMemory()
+        base = 1000.0
+        for i in range(5):
+            mem.write(MemoryEntry(
+                key=f"e{i}", value=str(i), tier=MemoryTier.EPISODIC,
+                created_at=base + i * 100,
+            ))
+        results = mem.query_time_range(1100.0, 1300.0)
+        assert len(results) == 3
+        assert [r.key for r in results] == ["e1", "e2", "e3"]
+
+    def test_empty_time_range(self) -> None:
+        mem = EpisodicMemory()
+        mem.write(MemoryEntry(
+            key="e", value="v", tier=MemoryTier.EPISODIC, created_at=1000.0,
+        ))
+        results = mem.query_time_range(2000.0, 3000.0)
+        assert results == []
+
+
+# ------------------------------------------------------------------ #
+# Task-ID filtering
+# ------------------------------------------------------------------ #
+
+
+class TestEpisodicTaskFilter:
+    def test_query_by_task(self) -> None:
+        mem = EpisodicMemory()
+        mem.write(MemoryEntry(
+            key="a", value="v", tier=MemoryTier.EPISODIC,
+            metadata={"task_id": "t1"},
+        ))
+        mem.write(MemoryEntry(
+            key="b", value="v", tier=MemoryTier.EPISODIC,
+            metadata={"task_id": "t2"},
+        ))
+        mem.write(MemoryEntry(
+            key="c", value="v", tier=MemoryTier.EPISODIC,
+            metadata={"task_id": "t1"},
+        ))
+        results = mem.query_by_task("t1")
+        assert len(results) == 2
+        assert [r.key for r in results] == ["a", "c"]
+
+    def test_query_by_task_empty(self) -> None:
+        mem = EpisodicMemory()
+        mem.write(MemoryEntry(key="a", value="v", tier=MemoryTier.EPISODIC))
+        assert mem.query_by_task("t99") == []
+
+
+# ------------------------------------------------------------------ #
+# Recent entries
+# ------------------------------------------------------------------ #
+
+
+class TestEpisodicRecent:
+    def test_recent_default(self) -> None:
+        mem = EpisodicMemory()
+        for i in range(15):
+            mem.write(MemoryEntry(key=f"k{i}", value=str(i), tier=MemoryTier.EPISODIC))
+        recent = mem.recent()
+        assert len(recent) == 10
+        assert recent[0].key == "k5"
+        assert recent[-1].key == "k14"
+
+    def test_recent_fewer_than_n(self) -> None:
+        mem = EpisodicMemory()
+        mem.write(MemoryEntry(key="k", value="v", tier=MemoryTier.EPISODIC))
+        recent = mem.recent(5)
+        assert len(recent) == 1
+
+
+# ------------------------------------------------------------------ #
+# Tier enforcement
+# ------------------------------------------------------------------ #
+
+
+class TestEpisodicTier:
+    def test_entry_tier_set_to_episodic(self) -> None:
+        mem = EpisodicMemory()
+        entry = MemoryEntry(key="k", value="v", tier=MemoryTier.STM)
+        mem.write(entry)
+        assert entry.tier is MemoryTier.EPISODIC
+
+
+# ------------------------------------------------------------------ #
+# JSON persistence
+# ------------------------------------------------------------------ #
+
+
+class TestEpisodicPersistence:
+    def test_save_and_reload(self, tmp_path: Path) -> None:
+        path = tmp_path / "episodic.json"
+        mem = EpisodicMemory(storage_path=path)
+        mem.write(MemoryEntry(
+            key="k1", value="hello", tier=MemoryTier.EPISODIC,
+            created_at=1000.0, metadata={"task_id": "t1"},
+        ))
+        mem.write(MemoryEntry(
+            key="k2", value="world", tier=MemoryTier.EPISODIC,
+            created_at=2000.0,
+        ))
+
+        # Reload from disk
+        mem2 = EpisodicMemory(storage_path=path)
+        assert mem2.size() == 2
+        assert mem2.list_keys() == ["k1", "k2"]
+        r = mem2.read("k1")
+        assert r is not None
+        assert r.value == "hello"
+        assert r.metadata == {"task_id": "t1"}
+
+    def test_no_storage_path(self) -> None:
+        mem = EpisodicMemory()
+        mem.write(MemoryEntry(key="k", value="v", tier=MemoryTier.EPISODIC))
+        # Should not raise when auto_persist is True but no path
+        mem.save()
+
+    def test_load_empty_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.json"
+        path.write_text("", encoding="utf-8")
+        mem = EpisodicMemory(storage_path=path)
+        assert mem.size() == 0
+
+    def test_persist_on_delete(self, tmp_path: Path) -> None:
+        path = tmp_path / "episodic.json"
+        mem = EpisodicMemory(storage_path=path)
+        mem.write(MemoryEntry(key="k", value="v", tier=MemoryTier.EPISODIC))
+        mem.delete("k")
+
+        mem2 = EpisodicMemory(storage_path=path)
+        assert mem2.size() == 0
+
+    def test_auto_persist_off(self, tmp_path: Path) -> None:
+        path = tmp_path / "episodic.json"
+        mem = EpisodicMemory(storage_path=path, auto_persist=False)
+        mem.write(MemoryEntry(key="k", value="v", tier=MemoryTier.EPISODIC))
+        assert not path.exists()
+        mem.save()
+        assert path.exists()
+
+    def test_created_at_auto_set(self) -> None:
+        mem = EpisodicMemory()
+        entry = MemoryEntry(key="k", value="v", tier=MemoryTier.EPISODIC)
+        mem.write(entry)
+        assert entry.created_at > 0.0
+        assert abs(entry.created_at - time.time()) < 2.0


### PR DESCRIPTION
Closes #117

Adds `EpisodicMemory(MemoryStore)`:
- Chronological interaction log with append-only writes
- JSON persistence with auto/manual save modes
- Time-range queries, task-ID filtering, recent(n)
- 20 unit tests