### PR TITLE
#119: Procedural LTM store with skill library and Bayesian confidence

### DIFF
--- a/src/openbad/memory/procedural.py
+++ b/src/openbad/memory/procedural.py
@@ -1,0 +1,225 @@
+"""Procedural Long-Term Memory — skill library for learned strategies.
+
+Stores reusable workflows, executable strategies, and learned patterns.
+Each skill has a capability set for search-by-capability, a confidence
+score (Bayesian), and optional executable code.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from openbad.memory.base import MemoryEntry, MemoryStore, MemoryTier
+
+
+@dataclass
+class Skill:
+    """A reusable procedural skill."""
+
+    name: str
+    description: str
+    capabilities: list[str] = field(default_factory=list)
+    code: str = ""
+    confidence: float = 0.5
+    success_count: int = 0
+    failure_count: int = 0
+
+    def update_confidence(self, success: bool) -> None:
+        """Bayesian confidence update based on outcome."""
+        if success:
+            self.success_count += 1
+        else:
+            self.failure_count += 1
+        total = self.success_count + self.failure_count
+        # Bayesian posterior mean with uniform prior (alpha=1, beta=1)
+        self.confidence = (self.success_count + 1) / (total + 2)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "capabilities": self.capabilities,
+            "code": self.code,
+            "confidence": self.confidence,
+            "success_count": self.success_count,
+            "failure_count": self.failure_count,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Skill:
+        """Deserialize from dictionary."""
+        return cls(
+            name=data["name"],
+            description=data.get("description", ""),
+            capabilities=data.get("capabilities", []),
+            code=data.get("code", ""),
+            confidence=data.get("confidence", 0.5),
+            success_count=data.get("success_count", 0),
+            failure_count=data.get("failure_count", 0),
+        )
+
+
+class ProceduralMemory(MemoryStore):
+    """Skill library backed by JSON persistence.
+
+    Each entry's value is expected to be a Skill (or a dict that describes
+    one). Supports search by capability and confidence-based ranking.
+    """
+
+    def __init__(
+        self,
+        storage_path: Path | None = None,
+        auto_persist: bool = True,
+    ) -> None:
+        self._storage_path = storage_path
+        self._auto_persist = auto_persist
+        self._entries: dict[str, MemoryEntry] = {}
+        self._skills: dict[str, Skill] = {}
+
+        if storage_path and storage_path.exists():
+            self._load()
+
+    # ------------------------------------------------------------------ #
+    # MemoryStore interface
+    # ------------------------------------------------------------------ #
+
+    def write(self, entry: MemoryEntry) -> str:
+        """Write a skill entry to the store."""
+        now = time.time()
+        if entry.created_at == 0.0:
+            entry.created_at = now
+        entry.tier = MemoryTier.PROCEDURAL
+
+        self._entries[entry.key] = entry
+
+        # Accept Skill objects or dicts
+        if isinstance(entry.value, Skill):
+            self._skills[entry.key] = entry.value
+        elif isinstance(entry.value, dict):
+            self._skills[entry.key] = Skill.from_dict(entry.value)
+        else:
+            # Wrap bare values as a skill with the value as description
+            self._skills[entry.key] = Skill(
+                name=entry.key, description=str(entry.value),
+            )
+
+        if self._auto_persist:
+            self._save()
+
+        return entry.entry_id
+
+    def read(self, key: str) -> MemoryEntry | None:
+        """Read a skill entry by key."""
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        entry.touch(time.time())
+        return entry
+
+    def delete(self, key: str) -> bool:
+        """Delete a skill entry."""
+        if key not in self._entries:
+            return False
+        del self._entries[key]
+        self._skills.pop(key, None)
+        if self._auto_persist:
+            self._save()
+        return True
+
+    def query(self, prefix: str) -> list[MemoryEntry]:
+        """Query entries by key prefix."""
+        return [e for k, e in self._entries.items() if k.startswith(prefix)]
+
+    def list_keys(self) -> list[str]:
+        """Return all keys."""
+        return list(self._entries.keys())
+
+    def size(self) -> int:
+        """Return number of skills."""
+        return len(self._entries)
+
+    # ------------------------------------------------------------------ #
+    # Procedural-specific methods
+    # ------------------------------------------------------------------ #
+
+    def get_skill(self, key: str) -> Skill | None:
+        """Return the Skill object for a key."""
+        return self._skills.get(key)
+
+    def search_by_capability(self, capability: str) -> list[tuple[str, Skill]]:
+        """Find skills that have the given capability, ranked by confidence."""
+        matches = [
+            (k, s) for k, s in self._skills.items()
+            if capability in s.capabilities
+        ]
+        matches.sort(key=lambda x: x[1].confidence, reverse=True)
+        return matches
+
+    def record_outcome(self, key: str, success: bool) -> None:
+        """Record a success/failure for a skill, updating confidence."""
+        skill = self._skills.get(key)
+        if skill is None:
+            return
+        skill.update_confidence(success)
+        if self._auto_persist:
+            self._save()
+
+    def top_skills(self, n: int = 5) -> list[tuple[str, Skill]]:
+        """Return top N skills ranked by confidence."""
+        ranked = sorted(
+            self._skills.items(),
+            key=lambda x: x[1].confidence,
+            reverse=True,
+        )
+        return ranked[:n]
+
+    def save(self) -> None:
+        """Explicitly persist to disk."""
+        self._save()
+
+    # ------------------------------------------------------------------ #
+    # Persistence
+    # ------------------------------------------------------------------ #
+
+    def _save(self) -> None:
+        """Write entries and skills to JSON file."""
+        if self._storage_path is None:
+            return
+        self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "entries": {k: e.to_dict() for k, e in self._entries.items()},
+            "skills": {k: s.to_dict() for k, s in self._skills.items()},
+        }
+        self._storage_path.write_text(
+            json.dumps(data, indent=2, default=_json_default),
+            encoding="utf-8",
+        )
+
+    def _load(self) -> None:
+        """Load entries and skills from JSON file."""
+        if self._storage_path is None or not self._storage_path.exists():
+            return
+        raw = self._storage_path.read_text(encoding="utf-8")
+        if not raw.strip():
+            return
+        data = json.loads(raw)
+        entries_data: dict[str, Any] = data.get("entries", {})
+        self._entries = {
+            k: MemoryEntry.from_dict(v) for k, v in entries_data.items()
+        }
+        skills_data: dict[str, Any] = data.get("skills", {})
+        self._skills = {
+            k: Skill.from_dict(v) for k, v in skills_data.items()
+        }
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON serializer fallback."""
+    if isinstance(obj, Skill):
+        return obj.to_dict()
+    return str(obj)

--- a/tests/test_procedural.py
+++ b/tests/test_procedural.py
@@ -1,0 +1,297 @@
+"""Tests for Procedural Long-Term Memory (skill library)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.procedural import ProceduralMemory, Skill
+
+# ------------------------------------------------------------------ #
+# Skill dataclass
+# ------------------------------------------------------------------ #
+
+
+class TestSkill:
+    def test_defaults(self) -> None:
+        s = Skill(name="s1", description="test skill")
+        assert s.confidence == 0.5
+        assert s.capabilities == []
+        assert s.code == ""
+        assert s.success_count == 0
+        assert s.failure_count == 0
+
+    def test_update_confidence_success(self) -> None:
+        s = Skill(name="s", description="d")
+        s.update_confidence(success=True)
+        # Bayesian: (1+1)/(1+2) = 2/3
+        assert abs(s.confidence - 2 / 3) < 1e-6
+        assert s.success_count == 1
+
+    def test_update_confidence_failure(self) -> None:
+        s = Skill(name="s", description="d")
+        s.update_confidence(success=False)
+        # Bayesian: (0+1)/(1+2) = 1/3
+        assert abs(s.confidence - 1 / 3) < 1e-6
+        assert s.failure_count == 1
+
+    def test_update_confidence_multiple(self) -> None:
+        s = Skill(name="s", description="d")
+        for _ in range(3):
+            s.update_confidence(success=True)
+        s.update_confidence(success=False)
+        # (3+1)/(4+2) = 4/6 = 2/3
+        assert abs(s.confidence - 2 / 3) < 1e-6
+
+    def test_serialization(self) -> None:
+        s = Skill(
+            name="s1",
+            description="desc",
+            capabilities=["parse", "run"],
+            code="print('hi')",
+            confidence=0.8,
+        )
+        d = s.to_dict()
+        s2 = Skill.from_dict(d)
+        assert s2.name == "s1"
+        assert s2.capabilities == ["parse", "run"]
+        assert s2.code == "print('hi')"
+        assert s2.confidence == 0.8
+
+
+# ------------------------------------------------------------------ #
+# Basic CRUD
+# ------------------------------------------------------------------ #
+
+
+class TestProceduralBasicOps:
+    def test_write_and_read_skill(self) -> None:
+        mem = ProceduralMemory()
+        skill = Skill(name="greet", description="Greet the user")
+        entry = MemoryEntry(key="greet", value=skill, tier=MemoryTier.PROCEDURAL)
+        eid = mem.write(entry)
+        assert eid == entry.entry_id
+        result = mem.read("greet")
+        assert result is not None
+        assert result.access_count == 1
+
+    def test_write_dict_value(self) -> None:
+        mem = ProceduralMemory()
+        entry = MemoryEntry(
+            key="k", tier=MemoryTier.PROCEDURAL,
+            value={"name": "k", "description": "d", "capabilities": ["x"]},
+        )
+        mem.write(entry)
+        skill = mem.get_skill("k")
+        assert skill is not None
+        assert skill.capabilities == ["x"]
+
+    def test_write_bare_value(self) -> None:
+        mem = ProceduralMemory()
+        entry = MemoryEntry(key="k", value="just a string", tier=MemoryTier.PROCEDURAL)
+        mem.write(entry)
+        skill = mem.get_skill("k")
+        assert skill is not None
+        assert skill.description == "just a string"
+
+    def test_read_missing(self) -> None:
+        mem = ProceduralMemory()
+        assert mem.read("nope") is None
+
+    def test_delete(self) -> None:
+        mem = ProceduralMemory()
+        mem.write(MemoryEntry(
+            key="k", value=Skill(name="k", description="d"),
+            tier=MemoryTier.PROCEDURAL,
+        ))
+        assert mem.delete("k")
+        assert mem.read("k") is None
+        assert mem.get_skill("k") is None
+        assert not mem.delete("k")
+
+    def test_size(self) -> None:
+        mem = ProceduralMemory()
+        assert mem.size() == 0
+        mem.write(MemoryEntry(
+            key="k", value=Skill(name="k", description="d"),
+            tier=MemoryTier.PROCEDURAL,
+        ))
+        assert mem.size() == 1
+
+    def test_list_keys(self) -> None:
+        mem = ProceduralMemory()
+        mem.write(MemoryEntry(
+            key="a", value=Skill(name="a", description="d"),
+            tier=MemoryTier.PROCEDURAL,
+        ))
+        mem.write(MemoryEntry(
+            key="b", value=Skill(name="b", description="d"),
+            tier=MemoryTier.PROCEDURAL,
+        ))
+        assert sorted(mem.list_keys()) == ["a", "b"]
+
+    def test_query_prefix(self) -> None:
+        mem = ProceduralMemory()
+        for key in ["skill/a", "skill/b", "other/c"]:
+            mem.write(MemoryEntry(
+                key=key, value=Skill(name=key, description="d"),
+                tier=MemoryTier.PROCEDURAL,
+            ))
+        assert len(mem.query("skill/")) == 2
+
+
+# ------------------------------------------------------------------ #
+# Capability search
+# ------------------------------------------------------------------ #
+
+
+class TestProceduralCapabilitySearch:
+    def test_search_by_capability(self) -> None:
+        mem = ProceduralMemory()
+        mem.write(MemoryEntry(
+            key="s1", tier=MemoryTier.PROCEDURAL,
+            value=Skill(name="s1", description="d", capabilities=["parse", "run"]),
+        ))
+        mem.write(MemoryEntry(
+            key="s2", tier=MemoryTier.PROCEDURAL,
+            value=Skill(name="s2", description="d", capabilities=["run"]),
+        ))
+        mem.write(MemoryEntry(
+            key="s3", tier=MemoryTier.PROCEDURAL,
+            value=Skill(name="s3", description="d", capabilities=["debug"]),
+        ))
+        results = mem.search_by_capability("run")
+        assert len(results) == 2
+        assert {r[0] for r in results} == {"s1", "s2"}
+
+    def test_search_empty(self) -> None:
+        mem = ProceduralMemory()
+        assert mem.search_by_capability("nonexistent") == []
+
+    def test_search_ranked_by_confidence(self) -> None:
+        mem = ProceduralMemory()
+        low = Skill(name="low", description="d", capabilities=["x"], confidence=0.2)
+        high = Skill(name="high", description="d", capabilities=["x"], confidence=0.9)
+        mem.write(MemoryEntry(key="low", value=low, tier=MemoryTier.PROCEDURAL))
+        mem.write(MemoryEntry(key="high", value=high, tier=MemoryTier.PROCEDURAL))
+        results = mem.search_by_capability("x")
+        assert results[0][0] == "high"
+        assert results[1][0] == "low"
+
+
+# ------------------------------------------------------------------ #
+# Outcome recording
+# ------------------------------------------------------------------ #
+
+
+class TestProceduralOutcome:
+    def test_record_success(self) -> None:
+        mem = ProceduralMemory()
+        mem.write(MemoryEntry(
+            key="k", value=Skill(name="k", description="d"),
+            tier=MemoryTier.PROCEDURAL,
+        ))
+        mem.record_outcome("k", success=True)
+        skill = mem.get_skill("k")
+        assert skill is not None
+        assert skill.success_count == 1
+        assert skill.confidence > 0.5
+
+    def test_record_failure(self) -> None:
+        mem = ProceduralMemory()
+        mem.write(MemoryEntry(
+            key="k", value=Skill(name="k", description="d"),
+            tier=MemoryTier.PROCEDURAL,
+        ))
+        mem.record_outcome("k", success=False)
+        skill = mem.get_skill("k")
+        assert skill is not None
+        assert skill.failure_count == 1
+        assert skill.confidence < 0.5
+
+    def test_record_outcome_missing(self) -> None:
+        mem = ProceduralMemory()
+        mem.record_outcome("missing", success=True)  # Should not raise
+
+
+# ------------------------------------------------------------------ #
+# Top skills
+# ------------------------------------------------------------------ #
+
+
+class TestProceduralTopSkills:
+    def test_top_skills(self) -> None:
+        mem = ProceduralMemory()
+        for i, conf in enumerate([0.3, 0.9, 0.5, 0.1, 0.7]):
+            mem.write(MemoryEntry(
+                key=f"s{i}", tier=MemoryTier.PROCEDURAL,
+                value=Skill(name=f"s{i}", description="d", confidence=conf),
+            ))
+        top = mem.top_skills(3)
+        assert len(top) == 3
+        assert top[0][0] == "s1"  # confidence 0.9
+
+
+# ------------------------------------------------------------------ #
+# Tier enforcement
+# ------------------------------------------------------------------ #
+
+
+class TestProceduralTier:
+    def test_entry_tier_set_to_procedural(self) -> None:
+        mem = ProceduralMemory()
+        entry = MemoryEntry(key="k", value="v", tier=MemoryTier.STM)
+        mem.write(entry)
+        assert entry.tier is MemoryTier.PROCEDURAL
+
+
+# ------------------------------------------------------------------ #
+# JSON persistence
+# ------------------------------------------------------------------ #
+
+
+class TestProceduralPersistence:
+    def test_save_and_reload(self, tmp_path: Path) -> None:
+        path = tmp_path / "procedural.json"
+        mem = ProceduralMemory(storage_path=path)
+        skill = Skill(
+            name="s1", description="test",
+            capabilities=["parse"], code="x=1", confidence=0.7,
+        )
+        mem.write(MemoryEntry(
+            key="s1", value=skill, tier=MemoryTier.PROCEDURAL,
+            created_at=1000.0,
+        ))
+
+        mem2 = ProceduralMemory(storage_path=path)
+        assert mem2.size() == 1
+        s = mem2.get_skill("s1")
+        assert s is not None
+        assert s.capabilities == ["parse"]
+        assert s.code == "x=1"
+        assert s.confidence == 0.7
+
+    def test_no_storage_path(self) -> None:
+        mem = ProceduralMemory()
+        mem.write(MemoryEntry(
+            key="k", value=Skill(name="k", description="d"),
+            tier=MemoryTier.PROCEDURAL,
+        ))
+        mem.save()  # Should not raise
+
+    def test_load_empty_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.json"
+        path.write_text("", encoding="utf-8")
+        mem = ProceduralMemory(storage_path=path)
+        assert mem.size() == 0
+
+    def test_auto_persist_off(self, tmp_path: Path) -> None:
+        path = tmp_path / "procedural.json"
+        mem = ProceduralMemory(storage_path=path, auto_persist=False)
+        mem.write(MemoryEntry(
+            key="k", value=Skill(name="k", description="d"),
+            tier=MemoryTier.PROCEDURAL,
+        ))
+        assert not path.exists()
+        mem.save()
+        assert path.exists()


### PR DESCRIPTION
Closes #119

Adds `ProceduralMemory(MemoryStore)` and `Skill` dataclass:
- Bayesian confidence scoring (posterior mean with uniform prior)
- Capability-based search ranked by confidence
- JSON persistence for skills and entries
- Supports Skill objects, dicts, and bare values
- 25 unit tests