### PR TITLE
#120: Memory Controller — unified orchestrator for STM and LTM tiers

### DIFF
--- a/src/openbad/memory/controller.py
+++ b/src/openbad/memory/controller.py
@@ -1,0 +1,169 @@
+"""Memory Controller — unified orchestrator for STM and LTM tiers.
+
+Routes writes to the appropriate store, handles tier promotion from
+STM to LTM, and exposes a unified query API across all memory tiers.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.config import MemoryConfig
+from openbad.memory.episodic import EpisodicMemory
+from openbad.memory.procedural import ProceduralMemory, Skill
+from openbad.memory.semantic import SemanticMemory
+from openbad.memory.stm import ShortTermMemory
+
+logger = logging.getLogger(__name__)
+
+# Type for an optional MQTT publish callback
+PublishFn = Callable[[str, bytes], None]
+
+
+class MemoryController:
+    """Unified orchestrator for short-term and long-term memory tiers.
+
+    Provides a single API surface for:
+    - STM writes with automatic tier tagging
+    - Promotion of STM entries to specific LTM stores
+    - Unified search across all tiers
+    - Snapshot and stats reporting
+    """
+
+    def __init__(
+        self,
+        config: MemoryConfig | None = None,
+        publish_fn: PublishFn | None = None,
+        embed_fn: Callable[[str], list[float]] | None = None,
+    ) -> None:
+        cfg = config or MemoryConfig()
+        storage_dir = cfg.ltm_storage_dir
+
+        self.stm = ShortTermMemory(
+            max_tokens=cfg.stm_max_tokens,
+            default_ttl=cfg.stm_ttl_seconds,
+            publish_fn=publish_fn,
+        )
+        self.episodic = EpisodicMemory(
+            storage_path=Path(storage_dir) / "episodic.json",
+        )
+        self.semantic = SemanticMemory(
+            embed_fn=embed_fn,
+            storage_path=Path(storage_dir) / "semantic.json",
+        )
+        self.procedural = ProceduralMemory(
+            storage_path=Path(storage_dir) / "procedural.json",
+        )
+        self._publish_fn = publish_fn
+
+    # ------------------------------------------------------------------ #
+    # Unified write
+    # ------------------------------------------------------------------ #
+
+    def write_stm(self, key: str, value: Any, **kwargs: Any) -> str:
+        """Write an entry to short-term memory."""
+        entry = MemoryEntry(key=key, value=value, tier=MemoryTier.STM, **kwargs)
+        return self.stm.write(entry)
+
+    def write_episodic(self, key: str, value: Any, **kwargs: Any) -> str:
+        """Write an entry directly to episodic LTM."""
+        entry = MemoryEntry(key=key, value=value, tier=MemoryTier.EPISODIC, **kwargs)
+        return self.episodic.write(entry)
+
+    def write_semantic(self, key: str, value: Any, **kwargs: Any) -> str:
+        """Write an entry directly to semantic LTM."""
+        entry = MemoryEntry(key=key, value=value, tier=MemoryTier.SEMANTIC, **kwargs)
+        return self.semantic.write(entry)
+
+    def write_procedural(
+        self, key: str, value: Skill | dict[str, Any] | str, **kwargs: Any,
+    ) -> str:
+        """Write a skill to procedural LTM."""
+        entry = MemoryEntry(key=key, value=value, tier=MemoryTier.PROCEDURAL, **kwargs)
+        return self.procedural.write(entry)
+
+    # ------------------------------------------------------------------ #
+    # Tier promotion
+    # ------------------------------------------------------------------ #
+
+    def promote_to_episodic(self, stm_key: str) -> str | None:
+        """Move an STM entry to episodic LTM. Returns new entry_id or None."""
+        entry = self.stm.read(stm_key)
+        if entry is None:
+            logger.warning("Cannot promote — STM key not found: %s", stm_key)
+            return None
+        new_entry = MemoryEntry(
+            key=entry.key,
+            value=entry.value,
+            tier=MemoryTier.EPISODIC,
+            created_at=entry.created_at,
+            context=entry.context,
+            metadata={**entry.metadata, "promoted_from": "stm"},
+        )
+        eid = self.episodic.write(new_entry)
+        self.stm.delete(stm_key)
+        logger.info("Promoted %s from STM to episodic LTM", stm_key)
+        return eid
+
+    def promote_to_semantic(self, stm_key: str) -> str | None:
+        """Move an STM entry to semantic LTM. Returns new entry_id or None."""
+        entry = self.stm.read(stm_key)
+        if entry is None:
+            logger.warning("Cannot promote — STM key not found: %s", stm_key)
+            return None
+        new_entry = MemoryEntry(
+            key=entry.key,
+            value=entry.value,
+            tier=MemoryTier.SEMANTIC,
+            created_at=entry.created_at,
+            context=entry.context,
+            metadata={**entry.metadata, "promoted_from": "stm"},
+        )
+        eid = self.semantic.write(new_entry)
+        self.stm.delete(stm_key)
+        logger.info("Promoted %s from STM to semantic LTM", stm_key)
+        return eid
+
+    # ------------------------------------------------------------------ #
+    # Unified read / search
+    # ------------------------------------------------------------------ #
+
+    def read(self, key: str) -> MemoryEntry | None:
+        """Read from any tier, checking STM first then LTM stores."""
+        for store in [self.stm, self.episodic, self.semantic, self.procedural]:
+            result = store.read(key)
+            if result is not None:
+                return result
+        return None
+
+    def search_all(self, prefix: str) -> dict[str, list[MemoryEntry]]:
+        """Query all tiers by key prefix. Returns {tier_name: entries}."""
+        return {
+            "stm": self.stm.query(prefix),
+            "episodic": self.episodic.query(prefix),
+            "semantic": self.semantic.query(prefix),
+            "procedural": self.procedural.query(prefix),
+        }
+
+    # ------------------------------------------------------------------ #
+    # Stats
+    # ------------------------------------------------------------------ #
+
+    def stats(self) -> dict[str, Any]:
+        """Return memory usage statistics across all tiers."""
+        return {
+            "stm": self.stm.usage(),
+            "episodic": {"entry_count": self.episodic.size()},
+            "semantic": {"entry_count": self.semantic.size()},
+            "procedural": {"entry_count": self.procedural.size()},
+            "timestamp": time.time(),
+        }
+
+    def flush_stm(self) -> list[str]:
+        """Flush all STM entries. Returns list of flushed keys."""
+        return self.stm.flush()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,232 @@
+"""Tests for the Memory Controller."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openbad.memory.config import MemoryConfig
+from openbad.memory.controller import MemoryController
+from openbad.memory.procedural import Skill
+
+
+def _make_controller(tmp_path: Path) -> MemoryController:
+    """Create a MemoryController backed by a temp directory."""
+    cfg = MemoryConfig(ltm_storage_dir=tmp_path)
+    return MemoryController(config=cfg)
+
+
+# ------------------------------------------------------------------ #
+# Unified writes
+# ------------------------------------------------------------------ #
+
+
+class TestControllerWrite:
+    def test_write_stm(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        eid = mc.write_stm("k1", "hello")
+        assert eid is not None
+        r = mc.stm.read("k1")
+        assert r is not None
+        assert r.value == "hello"
+
+    def test_write_episodic(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        eid = mc.write_episodic("e1", "event data")
+        assert eid is not None
+        r = mc.episodic.read("e1")
+        assert r is not None
+        assert r.value == "event data"
+
+    def test_write_semantic(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        eid = mc.write_semantic("s1", "concept data")
+        assert eid is not None
+        r = mc.semantic.read("s1")
+        assert r is not None
+        assert r.value == "concept data"
+
+    def test_write_procedural_skill(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        skill = Skill(name="greet", description="Greet user", capabilities=["interact"])
+        eid = mc.write_procedural("greet", skill)
+        assert eid is not None
+        s = mc.procedural.get_skill("greet")
+        assert s is not None
+        assert s.capabilities == ["interact"]
+
+    def test_write_procedural_dict(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_procedural("k", {"name": "k", "description": "d"})
+        assert mc.procedural.get_skill("k") is not None
+
+
+# ------------------------------------------------------------------ #
+# Tier promotion
+# ------------------------------------------------------------------ #
+
+
+class TestControllerPromotion:
+    def test_promote_to_episodic(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_stm("k", "data")
+        eid = mc.promote_to_episodic("k")
+        assert eid is not None
+        # Gone from STM
+        assert mc.stm.read("k") is None
+        # Present in episodic
+        r = mc.episodic.read("k")
+        assert r is not None
+        assert r.value == "data"
+        assert r.metadata.get("promoted_from") == "stm"
+
+    def test_promote_to_semantic(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_stm("k", "concept")
+        eid = mc.promote_to_semantic("k")
+        assert eid is not None
+        assert mc.stm.read("k") is None
+        r = mc.semantic.read("k")
+        assert r is not None
+        assert r.value == "concept"
+
+    def test_promote_missing_key(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        assert mc.promote_to_episodic("nope") is None
+        assert mc.promote_to_semantic("nope") is None
+
+
+# ------------------------------------------------------------------ #
+# Unified read
+# ------------------------------------------------------------------ #
+
+
+class TestControllerRead:
+    def test_read_from_stm(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_stm("k", "stm_val")
+        r = mc.read("k")
+        assert r is not None
+        assert r.value == "stm_val"
+
+    def test_read_from_episodic(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_episodic("k", "ep_val")
+        r = mc.read("k")
+        assert r is not None
+        assert r.value == "ep_val"
+
+    def test_read_from_semantic(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_semantic("k", "sem_val")
+        r = mc.read("k")
+        assert r is not None
+        assert r.value == "sem_val"
+
+    def test_read_from_procedural(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_procedural("k", "skill_val")
+        r = mc.read("k")
+        assert r is not None
+
+    def test_read_missing(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        assert mc.read("nope") is None
+
+    def test_stm_takes_priority(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_stm("k", "from_stm")
+        mc.write_episodic("k", "from_ep")
+        r = mc.read("k")
+        assert r is not None
+        assert r.value == "from_stm"
+
+
+# ------------------------------------------------------------------ #
+# Search all
+# ------------------------------------------------------------------ #
+
+
+class TestControllerSearchAll:
+    def test_search_across_tiers(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_stm("task/1", "a")
+        mc.write_episodic("task/2", "b")
+        mc.write_semantic("task/3", "c")
+        mc.write_procedural("task/4", "d")
+        results = mc.search_all("task/")
+        assert len(results["stm"]) == 1
+        assert len(results["episodic"]) == 1
+        assert len(results["semantic"]) == 1
+        assert len(results["procedural"]) == 1
+
+    def test_search_no_results(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        results = mc.search_all("nothing/")
+        assert all(len(v) == 0 for v in results.values())
+
+
+# ------------------------------------------------------------------ #
+# Stats
+# ------------------------------------------------------------------ #
+
+
+class TestControllerStats:
+    def test_stats_structure(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_stm("k", "v")
+        mc.write_episodic("e", "v")
+        s = mc.stats()
+        assert "stm" in s
+        assert "episodic" in s
+        assert "semantic" in s
+        assert "procedural" in s
+        assert "timestamp" in s
+        assert s["stm"]["entry_count"] == 1
+        assert s["episodic"]["entry_count"] == 1
+
+
+# ------------------------------------------------------------------ #
+# Flush
+# ------------------------------------------------------------------ #
+
+
+class TestControllerFlush:
+    def test_flush_stm(self, tmp_path: Path) -> None:
+        mc = _make_controller(tmp_path)
+        mc.write_stm("a", "1")
+        mc.write_stm("b", "2")
+        flushed = mc.flush_stm()
+        assert sorted(flushed) == ["a", "b"]
+        assert mc.stm.size() == 0
+
+
+# ------------------------------------------------------------------ #
+# Publish callback
+# ------------------------------------------------------------------ #
+
+
+class TestControllerPublish:
+    def test_publish_fn_wired_to_stm(self, tmp_path: Path) -> None:
+        published: list[tuple[str, bytes]] = []
+        cfg = MemoryConfig(ltm_storage_dir=tmp_path)
+        mc = MemoryController(
+            config=cfg,
+            publish_fn=lambda t, p: published.append((t, p)),
+        )
+        mc.write_stm("k", "v")
+        assert len(published) == 1
+        assert published[0][0] == "agent/memory/stm/write"
+
+
+# ------------------------------------------------------------------ #
+# Default config
+# ------------------------------------------------------------------ #
+
+
+class TestControllerDefaultConfig:
+    def test_default_config(self) -> None:
+        mc = MemoryController()
+        assert mc.stm is not None
+        assert mc.episodic is not None
+        assert mc.semantic is not None
+        assert mc.procedural is not None


### PR DESCRIPTION
Closes #120

Adds `MemoryController`:
- Unified write API for all four tiers
- STM-to-LTM promotion (episodic, semantic)
- Cross-tier read with STM priority
- Search all tiers by prefix
- Stats reporting and STM flush
- MQTT publish callback wired to STM
- 20 unit tests