### PR TITLE
#122: SWS sleep phase — negative constraint extraction

### DIFF
--- a/src/openbad/memory/sleep/__init__.py
+++ b/src/openbad/memory/sleep/__init__.py
@@ -1,0 +1,1 @@
+"""Sleep consolidation — memory package."""

--- a/src/openbad/memory/sleep/sws.py
+++ b/src/openbad/memory/sleep/sws.py
@@ -1,0 +1,187 @@
+"""Slow Wave Sleep (SWS) phase — negative constraint extraction.
+
+Replays failed execution traces from STM, extracts negative constraints
+(what went wrong), and writes restrictive policy entries to episodic LTM.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+
+if TYPE_CHECKING:
+    from openbad.memory.controller import MemoryController
+
+logger = logging.getLogger(__name__)
+
+# Metadata keys that indicate a failure entry
+_FAILURE_TAGS = frozenset({"error", "failure", "exception", "timeout", "rejected"})
+
+
+@dataclass
+class NegativeConstraint:
+    """A structured constraint extracted from a failure trace."""
+
+    constraint_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    source_entry_id: str = ""
+    action: str = ""
+    error_type: str = ""
+    description: str = ""
+    created_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "constraint_id": self.constraint_id,
+            "source_entry_id": self.source_entry_id,
+            "action": self.action,
+            "error_type": self.error_type,
+            "description": self.description,
+            "created_at": self.created_at,
+        }
+
+
+class SlowWaveSleep:
+    """SWS phase: scan STM for failures, extract constraints, consolidate."""
+
+    def __init__(
+        self,
+        memory_controller: MemoryController,
+        classify_fn: Callable[[MemoryEntry], list[NegativeConstraint]] | None = None,
+    ) -> None:
+        self._mc = memory_controller
+        self._classify_fn = classify_fn
+
+    # ------------------------------------------------------------------ #
+    # Extract failures from STM
+    # ------------------------------------------------------------------ #
+
+    def extract_failures(self, context: str | None = None) -> list[MemoryEntry]:
+        """Scan STM for entries tagged with error/failure metadata."""
+        all_entries = self._mc.stm.query("")
+        failures: list[MemoryEntry] = []
+
+        for entry in all_entries:
+            if self._is_failure(entry, context):
+                failures.append(entry)
+
+        logger.debug("SWS extracted %d failures from STM", len(failures))
+        return failures
+
+    # ------------------------------------------------------------------ #
+    # Analyze failures → constraints
+    # ------------------------------------------------------------------ #
+
+    def analyze(self, failures: list[MemoryEntry]) -> list[NegativeConstraint]:
+        """Extract structured constraints from failure entries."""
+        if not failures:
+            return []
+
+        if self._classify_fn is not None:
+            constraints: list[NegativeConstraint] = []
+            for entry in failures:
+                constraints.extend(self._classify_fn(entry))
+            return constraints
+
+        return self._heuristic_analyze(failures)
+
+    # ------------------------------------------------------------------ #
+    # Consolidate — write to episodic LTM
+    # ------------------------------------------------------------------ #
+
+    def consolidate(self, constraints: list[NegativeConstraint]) -> list[str]:
+        """Write constraints to episodic LTM with context='sws_constraint'.
+
+        Returns list of entry IDs written.
+        """
+        ids: list[str] = []
+        for c in constraints:
+            entry = MemoryEntry(
+                key=f"sws/{c.constraint_id}",
+                value=c.description,
+                tier=MemoryTier.EPISODIC,
+                metadata={
+                    "context": "sws_constraint",
+                    "action": c.action,
+                    "error_type": c.error_type,
+                    "source_entry_id": c.source_entry_id,
+                    **c.to_dict(),
+                },
+            )
+            eid = self._mc.episodic.write(entry)
+            ids.append(eid)
+            logger.debug("SWS consolidated constraint %s", c.constraint_id)
+
+        if ids:
+            logger.info("SWS wrote %d constraints to episodic LTM", len(ids))
+        return ids
+
+    # ------------------------------------------------------------------ #
+    # Full pipeline
+    # ------------------------------------------------------------------ #
+
+    def run(self, context: str | None = None) -> int:
+        """Execute full SWS pipeline: extract → analyze → consolidate.
+
+        Returns count of constraints written.
+        """
+        failures = self.extract_failures(context)
+        constraints = self.analyze(failures)
+        ids = self.consolidate(constraints)
+        return len(ids)
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _is_failure(entry: MemoryEntry, context: str | None) -> bool:
+        """Check if an entry represents a failure."""
+        meta = entry.metadata or {}
+
+        # Filter by context if specified
+        if context and meta.get("context") != context:
+            return False
+
+        # Check metadata keys for failure indicators
+        status = str(meta.get("status", "")).lower()
+        if status in _FAILURE_TAGS:
+            return True
+
+        # Check for 'error' or 'failure' keys in metadata
+        for tag in _FAILURE_TAGS:
+            if tag in meta:
+                return True
+
+        # Check value for failure patterns
+        val = str(entry.value).lower()
+        return any(tag in val for tag in ("error:", "failed:", "exception:"))
+
+    @staticmethod
+    def _heuristic_analyze(
+        failures: list[MemoryEntry],
+    ) -> list[NegativeConstraint]:
+        """Extract constraints using heuristic pattern matching."""
+        constraints: list[NegativeConstraint] = []
+
+        for entry in failures:
+            meta = entry.metadata or {}
+            action = str(meta.get("action", entry.key))
+            error_type = str(meta.get("error_type", meta.get("status", "unknown")))
+            description = str(entry.value)
+
+            constraints.append(
+                NegativeConstraint(
+                    source_entry_id=entry.entry_id,
+                    action=action,
+                    error_type=error_type,
+                    description=f"Avoid: {description}",
+                )
+            )
+
+        return constraints

--- a/tests/test_sws.py
+++ b/tests/test_sws.py
@@ -1,0 +1,206 @@
+"""Tests for SWS sleep phase — negative constraint extraction."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.config import MemoryConfig
+from openbad.memory.controller import MemoryController
+from openbad.memory.sleep.sws import NegativeConstraint, SlowWaveSleep
+
+
+def _mc(tmp_path: Path) -> MemoryController:
+    return MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+
+
+def _failure_entry(key: str = "fail/1", **meta: object) -> MemoryEntry:
+    return MemoryEntry(
+        key=key,
+        value="error: something went wrong",
+        tier=MemoryTier.STM,
+        metadata={"status": "error", **meta},
+    )
+
+
+def _ok_entry(key: str = "ok/1") -> MemoryEntry:
+    return MemoryEntry(key=key, value="all good", tier=MemoryTier.STM)
+
+
+# ------------------------------------------------------------------ #
+# extract_failures
+# ------------------------------------------------------------------ #
+
+
+class TestExtractFailures:
+    def test_finds_failures_by_status(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_failure_entry("f1"))
+        mc.stm.write(_ok_entry("ok1"))
+        sws = SlowWaveSleep(mc)
+        failures = sws.extract_failures()
+        assert len(failures) == 1
+        assert failures[0].key == "f1"
+
+    def test_finds_failures_by_metadata_tag(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        entry = MemoryEntry(
+            key="f2", value="data", tier=MemoryTier.STM,
+            metadata={"error": "something broke"},
+        )
+        mc.stm.write(entry)
+        sws = SlowWaveSleep(mc)
+        assert len(sws.extract_failures()) == 1
+
+    def test_finds_failures_by_value_pattern(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        entry = MemoryEntry(
+            key="f3", value="failed: connection timeout", tier=MemoryTier.STM,
+        )
+        mc.stm.write(entry)
+        sws = SlowWaveSleep(mc)
+        assert len(sws.extract_failures()) == 1
+
+    def test_filters_by_context(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_failure_entry("f1", context="taskA"))
+        mc.stm.write(_failure_entry("f2", context="taskB"))
+        sws = SlowWaveSleep(mc)
+        failures = sws.extract_failures(context="taskA")
+        assert len(failures) == 1
+        assert failures[0].key == "f1"
+
+    def test_empty_stm(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        sws = SlowWaveSleep(mc)
+        assert sws.extract_failures() == []
+
+
+# ------------------------------------------------------------------ #
+# analyze
+# ------------------------------------------------------------------ #
+
+
+class TestAnalyze:
+    def test_heuristic_analysis(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        sws = SlowWaveSleep(mc)
+        failures = [_failure_entry("f1", action="network_call", error_type="timeout")]
+        constraints = sws.analyze(failures)
+        assert len(constraints) == 1
+        c = constraints[0]
+        assert c.action == "network_call"
+        assert c.error_type == "timeout"
+        assert "Avoid:" in c.description
+
+    def test_custom_classify_fn(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+
+        def custom_fn(entry: MemoryEntry) -> list[NegativeConstraint]:
+            return [NegativeConstraint(action="custom", error_type="custom", description="no")]
+
+        sws = SlowWaveSleep(mc, classify_fn=custom_fn)
+        constraints = sws.analyze([_failure_entry()])
+        assert len(constraints) == 1
+        assert constraints[0].action == "custom"
+
+    def test_empty_failures(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        sws = SlowWaveSleep(mc)
+        assert sws.analyze([]) == []
+
+    def test_multiple_failures(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        sws = SlowWaveSleep(mc)
+        failures = [_failure_entry(f"f{i}") for i in range(3)]
+        constraints = sws.analyze(failures)
+        assert len(constraints) == 3
+
+
+# ------------------------------------------------------------------ #
+# consolidate
+# ------------------------------------------------------------------ #
+
+
+class TestConsolidate:
+    def test_writes_to_episodic(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        sws = SlowWaveSleep(mc)
+        constraints = [
+            NegativeConstraint(
+                action="act", error_type="err", description="avoid X",
+            ),
+        ]
+        ids = sws.consolidate(constraints)
+        assert len(ids) == 1
+        # Verify in episodic store
+        entries = mc.episodic.query("sws/")
+        assert len(entries) == 1
+        assert entries[0].metadata["context"] == "sws_constraint"
+
+    def test_empty_constraints(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        sws = SlowWaveSleep(mc)
+        assert sws.consolidate([]) == []
+
+
+# ------------------------------------------------------------------ #
+# run (full pipeline)
+# ------------------------------------------------------------------ #
+
+
+class TestRun:
+    def test_full_pipeline(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_failure_entry("f1", action="api_call", error_type="500"))
+        mc.stm.write(_failure_entry("f2", action="db_query", error_type="timeout"))
+        mc.stm.write(_ok_entry("ok1"))
+        sws = SlowWaveSleep(mc)
+        count = sws.run()
+        assert count == 2
+        # Verify episodic has 2 constraint entries
+        entries = mc.episodic.query("sws/")
+        assert len(entries) == 2
+
+    def test_run_with_no_failures(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_ok_entry("ok1"))
+        sws = SlowWaveSleep(mc)
+        assert sws.run() == 0
+
+    def test_run_with_context_filter(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_failure_entry("f1", context="taskA"))
+        mc.stm.write(_failure_entry("f2", context="taskB"))
+        sws = SlowWaveSleep(mc)
+        count = sws.run(context="taskA")
+        assert count == 1
+
+
+# ------------------------------------------------------------------ #
+# NegativeConstraint dataclass
+# ------------------------------------------------------------------ #
+
+
+class TestNegativeConstraint:
+    def test_to_dict(self) -> None:
+        now = time.time()
+        c = NegativeConstraint(
+            constraint_id="abc",
+            source_entry_id="src1",
+            action="act",
+            error_type="err",
+            description="desc",
+            created_at=now,
+        )
+        d = c.to_dict()
+        assert d["constraint_id"] == "abc"
+        assert d["action"] == "act"
+        assert d["created_at"] == now
+
+    def test_defaults(self) -> None:
+        c = NegativeConstraint()
+        assert len(c.constraint_id) == 12
+        assert c.action == ""
+        assert c.created_at > 0


### PR DESCRIPTION
Closes #122

Adds `sleep/` package with `SlowWaveSleep`:
- `extract_failures()` — scans STM for error/failure-tagged entries
- `NegativeConstraint` dataclass
- `analyze()` — heuristic + optional classify_fn
- `consolidate()` — writes to episodic LTM
- `run()` — full pipeline
- 16 unit tests