### PR TITLE
#123: REM sleep phase — skill abstraction from successful traces

### DIFF
--- a/src/openbad/memory/sleep/rem.py
+++ b/src/openbad/memory/sleep/rem.py
@@ -1,0 +1,191 @@
+"""REM sleep phase — skill abstraction from successful traces.
+
+Analyzes successful task sequences from STM, abstracts them into
+reusable procedural skills with Bayesian confidence scoring, and
+stores them in the skill library.  Deduplicates against existing
+skills by name similarity.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from openbad.memory.base import MemoryEntry
+from openbad.memory.procedural import Skill
+
+if TYPE_CHECKING:
+    from openbad.memory.controller import MemoryController
+
+logger = logging.getLogger(__name__)
+
+_SUCCESS_TAGS = frozenset({"success", "completed", "ok", "done"})
+
+
+class RapidEyeMovement:
+    """REM phase: abstract successful STM traces into procedural skills."""
+
+    def __init__(
+        self,
+        memory_controller: MemoryController,
+        abstract_fn: Callable[[list[MemoryEntry]], Skill | None] | None = None,
+    ) -> None:
+        self._mc = memory_controller
+        self._abstract_fn = abstract_fn
+
+    # ------------------------------------------------------------------ #
+    # Extract successes from STM
+    # ------------------------------------------------------------------ #
+
+    def extract_successes(
+        self, context: str | None = None,
+    ) -> list[MemoryEntry]:
+        """Scan STM for entries tagged with success metadata."""
+        all_entries = self._mc.stm.query("")
+        successes: list[MemoryEntry] = []
+
+        for entry in all_entries:
+            if self._is_success(entry, context):
+                successes.append(entry)
+
+        logger.debug("REM extracted %d successes from STM", len(successes))
+        return successes
+
+    # ------------------------------------------------------------------ #
+    # Abstract to skill
+    # ------------------------------------------------------------------ #
+
+    def abstract_to_skill(
+        self, entries: list[MemoryEntry],
+    ) -> Skill | None:
+        """Abstract related success entries into a reusable Skill.
+
+        Uses optional LLM abstract_fn if provided, otherwise heuristic.
+        """
+        if not entries:
+            return None
+
+        if self._abstract_fn is not None:
+            return self._abstract_fn(entries)
+
+        return self._heuristic_abstract(entries)
+
+    # ------------------------------------------------------------------ #
+    # Consolidate — write/update procedural LTM
+    # ------------------------------------------------------------------ #
+
+    def consolidate(self, skills: list[Skill]) -> list[str]:
+        """Write new skills or update existing ones in procedural LTM.
+
+        If a skill with a matching name already exists, update its
+        confidence rather than creating a duplicate.  Returns list of
+        keys written/updated.
+        """
+        keys: list[str] = []
+        for skill in skills:
+            existing_key = self._find_existing(skill.name)
+            if existing_key is not None:
+                # Update confidence on existing skill
+                self._mc.procedural.record_outcome(existing_key, success=True)
+                keys.append(existing_key)
+                logger.debug("REM updated existing skill %s", existing_key)
+            else:
+                key = f"rem/{skill.name}"
+                self._mc.write_procedural(key, skill)
+                keys.append(key)
+                logger.debug("REM created new skill %s", key)
+
+        if keys:
+            logger.info("REM consolidated %d skills", len(keys))
+        return keys
+
+    # ------------------------------------------------------------------ #
+    # Full pipeline
+    # ------------------------------------------------------------------ #
+
+    def run(self, context: str | None = None) -> int:
+        """Execute full REM pipeline: extract → abstract → consolidate.
+
+        Groups successes by action/task context and abstracts each group
+        into a skill.  Returns count of skills created/updated.
+        """
+        successes = self.extract_successes(context)
+        if not successes:
+            return 0
+
+        groups = self._group_by_action(successes)
+        skills: list[Skill] = []
+        for _action, entries in groups.items():
+            skill = self.abstract_to_skill(entries)
+            if skill is not None:
+                skills.append(skill)
+
+        keys = self.consolidate(skills)
+        return len(keys)
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _is_success(entry: MemoryEntry, context: str | None) -> bool:
+        """Check if an entry represents a successful trace."""
+        meta = entry.metadata or {}
+
+        # Context filter
+        if context and meta.get("context") != context:
+            return False
+
+        status = str(meta.get("status", "")).lower()
+        if status in _SUCCESS_TAGS:
+            return True
+
+        return any(tag in meta for tag in _SUCCESS_TAGS)
+
+    def _find_existing(self, name: str) -> str | None:
+        """Find an existing skill key that matches the given name."""
+        name_lower = name.lower()
+        for key in self._mc.procedural.list_keys():
+            skill = self._mc.procedural.get_skill(key)
+            if skill is not None and skill.name.lower() == name_lower:
+                return key
+        return None
+
+    @staticmethod
+    def _group_by_action(
+        entries: list[MemoryEntry],
+    ) -> dict[str, list[MemoryEntry]]:
+        """Group success entries by their action metadata."""
+        groups: dict[str, list[MemoryEntry]] = {}
+        for entry in entries:
+            meta = entry.metadata or {}
+            action = str(meta.get("action", entry.key))
+            groups.setdefault(action, []).append(entry)
+        return groups
+
+    @staticmethod
+    def _heuristic_abstract(entries: list[MemoryEntry]) -> Skill:
+        """Create a Skill from success entries using heuristic extraction."""
+        # Use the first entry's action as the skill name
+        meta = entries[0].metadata or {}
+        action = str(meta.get("action", entries[0].key))
+        descriptions = [str(e.value) for e in entries]
+        summary = "; ".join(descriptions[:5])
+
+        # Collect capabilities from entry metadata
+        capabilities: list[str] = []
+        for entry in entries:
+            m = entry.metadata or {}
+            if "capability" in m:
+                cap = m["capability"]
+                if cap not in capabilities:
+                    capabilities.append(cap)
+
+        return Skill(
+            name=action,
+            description=f"Abstracted from {len(entries)} successes: {summary}",
+            capabilities=capabilities if capabilities else [action],
+            confidence=0.5 + min(len(entries) * 0.05, 0.4),
+            success_count=len(entries),
+        )

--- a/tests/test_rem.py
+++ b/tests/test_rem.py
@@ -1,0 +1,197 @@
+"""Tests for REM sleep phase — skill abstraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.config import MemoryConfig
+from openbad.memory.controller import MemoryController
+from openbad.memory.procedural import Skill
+from openbad.memory.sleep.rem import RapidEyeMovement
+
+
+def _mc(tmp_path: Path) -> MemoryController:
+    return MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+
+
+def _success(key: str = "s/1", action: str = "fetch", **meta: object) -> MemoryEntry:
+    return MemoryEntry(
+        key=key, value=f"success doing {action}", tier=MemoryTier.STM,
+        metadata={"status": "success", "action": action, **meta},
+    )
+
+
+def _neutral(key: str = "n/1") -> MemoryEntry:
+    return MemoryEntry(key=key, value="neutral", tier=MemoryTier.STM)
+
+
+# ------------------------------------------------------------------ #
+# extract_successes
+# ------------------------------------------------------------------ #
+
+
+class TestExtractSuccesses:
+    def test_finds_successes(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_success("s1"))
+        mc.stm.write(_neutral("n1"))
+        rem = RapidEyeMovement(mc)
+        successes = rem.extract_successes()
+        assert len(successes) == 1
+        assert successes[0].key == "s1"
+
+    def test_finds_by_meta_tag(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        entry = MemoryEntry(
+            key="s2", value="data", tier=MemoryTier.STM,
+            metadata={"success": True},
+        )
+        mc.stm.write(entry)
+        rem = RapidEyeMovement(mc)
+        assert len(rem.extract_successes()) == 1
+
+    def test_filters_by_context(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_success("s1", context="taskA"))
+        mc.stm.write(_success("s2", context="taskB"))
+        rem = RapidEyeMovement(mc)
+        results = rem.extract_successes(context="taskA")
+        assert len(results) == 1
+        assert results[0].key == "s1"
+
+    def test_empty_stm(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        rem = RapidEyeMovement(mc)
+        assert rem.extract_successes() == []
+
+
+# ------------------------------------------------------------------ #
+# abstract_to_skill
+# ------------------------------------------------------------------ #
+
+
+class TestAbstractToSkill:
+    def test_heuristic_abstraction(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        rem = RapidEyeMovement(mc)
+        entries = [_success("s1", action="deploy"), _success("s2", action="deploy")]
+        skill = rem.abstract_to_skill(entries)
+        assert skill is not None
+        assert skill.name == "deploy"
+        assert skill.success_count == 2
+        assert skill.confidence > 0.5
+
+    def test_custom_abstract_fn(self, tmp_path: Path) -> None:
+        def custom_fn(entries: list[MemoryEntry]) -> Skill:
+            return Skill(name="custom", description="from LLM")
+
+        mc = _mc(tmp_path)
+        rem = RapidEyeMovement(mc, abstract_fn=custom_fn)
+        skill = rem.abstract_to_skill([_success()])
+        assert skill is not None
+        assert skill.name == "custom"
+
+    def test_empty_entries(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        rem = RapidEyeMovement(mc)
+        assert rem.abstract_to_skill([]) is None
+
+    def test_capabilities_from_metadata(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        rem = RapidEyeMovement(mc)
+        entries = [
+            MemoryEntry(
+                key="s1", value="v", tier=MemoryTier.STM,
+                metadata={"status": "success", "action": "a", "capability": "http"},
+            ),
+        ]
+        skill = rem.abstract_to_skill(entries)
+        assert skill is not None
+        assert "http" in skill.capabilities
+
+
+# ------------------------------------------------------------------ #
+# consolidate
+# ------------------------------------------------------------------ #
+
+
+class TestConsolidate:
+    def test_creates_new_skill(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        rem = RapidEyeMovement(mc)
+        skill = Skill(name="new_skill", description="d", capabilities=["c"])
+        keys = rem.consolidate([skill])
+        assert len(keys) == 1
+        assert keys[0] == "rem/new_skill"
+        assert mc.procedural.get_skill("rem/new_skill") is not None
+
+    def test_updates_existing_skill(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        # Pre-populate a skill
+        existing = Skill(name="fetch", description="d", confidence=0.5)
+        mc.write_procedural("rem/fetch", existing)
+        old_confidence = mc.procedural.get_skill("rem/fetch").confidence
+
+        rem = RapidEyeMovement(mc)
+        # Consolidate should update, not duplicate
+        keys = rem.consolidate([Skill(name="fetch", description="d2")])
+        assert len(keys) == 1
+        assert keys[0] == "rem/fetch"
+        new_confidence = mc.procedural.get_skill("rem/fetch").confidence
+        assert new_confidence != old_confidence  # Updated via record_outcome
+
+    def test_empty_skills(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        rem = RapidEyeMovement(mc)
+        assert rem.consolidate([]) == []
+
+    def test_dedup_case_insensitive(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.write_procedural("rem/Deploy", Skill(name="Deploy", description="d"))
+        rem = RapidEyeMovement(mc)
+        keys = rem.consolidate([Skill(name="deploy", description="d2")])
+        assert keys[0] == "rem/Deploy"  # Found existing
+        assert mc.procedural.size() == 1  # No duplicate
+
+
+# ------------------------------------------------------------------ #
+# run (full pipeline)
+# ------------------------------------------------------------------ #
+
+
+class TestRun:
+    def test_full_pipeline(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_success("s1", action="api_call"))
+        mc.stm.write(_success("s2", action="api_call"))
+        mc.stm.write(_success("s3", action="db_query"))
+        mc.stm.write(_neutral("n1"))
+        rem = RapidEyeMovement(mc)
+        count = rem.run()
+        assert count == 2  # Two distinct actions
+        assert mc.procedural.size() == 2
+
+    def test_run_no_successes(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_neutral("n1"))
+        rem = RapidEyeMovement(mc)
+        assert rem.run() == 0
+
+    def test_run_with_context(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.stm.write(_success("s1", action="build", context="ci"))
+        mc.stm.write(_success("s2", action="deploy", context="prod"))
+        rem = RapidEyeMovement(mc)
+        count = rem.run(context="ci")
+        assert count == 1
+
+    def test_run_merges_existing(self, tmp_path: Path) -> None:
+        mc = _mc(tmp_path)
+        mc.write_procedural("rem/fetch", Skill(name="fetch", description="d"))
+        mc.stm.write(_success("s1", action="fetch"))
+        rem = RapidEyeMovement(mc)
+        count = rem.run()
+        assert count == 1
+        # Should not create a duplicate
+        assert mc.procedural.size() == 1


### PR DESCRIPTION
Closes #123

Adds `RapidEyeMovement` to `sleep/rem.py`:
- `extract_successes()` — scans STM for success-tagged entries
- `abstract_to_skill()` — heuristic + optional LLM abstract_fn
- `consolidate()` — writes/updates procedural LTM with dedup
- `run()` — full pipeline with action-based grouping
- Case-insensitive skill deduplication
- 16 unit tests