### PR TITLE
#124: Sleep cycle orchestrator — idle detection and phase sequencing

### DIFF
--- a/src/openbad/memory/sleep/orchestrator.py
+++ b/src/openbad/memory/sleep/orchestrator.py
@@ -1,0 +1,207 @@
+"""Sleep cycle orchestrator — idle detection and phase sequencing.
+
+Detects agent idle state, triggers SWS → REM → pruning in sequence,
+and publishes consolidation events to the MQTT nervous system.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from openbad.memory.forgetting import prune_store
+
+if TYPE_CHECKING:
+    from openbad.memory.controller import MemoryController
+    from openbad.memory.sleep.rem import RapidEyeMovement
+    from openbad.memory.sleep.sws import SlowWaveSleep
+
+logger = logging.getLogger(__name__)
+
+
+class SleepPhase(enum.Enum):
+    """Phases of the sleep consolidation cycle."""
+
+    AWAKE = "awake"
+    SWS = "sws"
+    REM = "rem"
+    PRUNING = "pruning"
+    COMPLETE = "complete"
+
+
+@dataclass
+class MemoryPruner:
+    """Wrapper around the forgetting module for use in the sleep cycle."""
+
+    memory_controller: MemoryController
+    threshold: float = 0.1
+    half_life_hours: float = 168.0
+
+    def run(self) -> int:
+        """Prune decayed entries from episodic and semantic stores.
+
+        Returns total count of entries pruned.
+        """
+        now = time.time()
+        total = 0
+        total += len(
+            prune_store(
+                self.memory_controller.episodic,
+                threshold=self.threshold,
+                half_life_hours=self.half_life_hours,
+                now=now,
+            )
+        )
+        total += len(
+            prune_store(
+                self.memory_controller.semantic,
+                threshold=self.threshold,
+                half_life_hours=self.half_life_hours,
+                now=now,
+            )
+        )
+        return total
+
+
+@dataclass
+class SleepReport:
+    """Report from a completed sleep cycle."""
+
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    phase_durations: dict[str, float] = field(default_factory=dict)
+    constraints_extracted: int = 0
+    skills_created: int = 0
+    entries_pruned: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "duration_seconds": self.finished_at - self.started_at,
+            "phase_durations": self.phase_durations,
+            "constraints_extracted": self.constraints_extracted,
+            "skills_created": self.skills_created,
+            "entries_pruned": self.entries_pruned,
+        }
+
+
+class SleepOrchestrator:
+    """Orchestrates SWS → REM → pruning sleep consolidation cycles."""
+
+    def __init__(
+        self,
+        sws: SlowWaveSleep,
+        rem: RapidEyeMovement,
+        pruner: MemoryPruner,
+        idle_threshold_seconds: float = 300.0,
+        publish_fn: Callable[[str, bytes], None] | None = None,
+    ) -> None:
+        self._sws = sws
+        self._rem = rem
+        self._pruner = pruner
+        self._idle_threshold = idle_threshold_seconds
+        self._publish_fn = publish_fn
+        self._phase = SleepPhase.AWAKE
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def phase(self) -> SleepPhase:
+        return self._phase
+
+    # ------------------------------------------------------------------ #
+    # Idle detection
+    # ------------------------------------------------------------------ #
+
+    def is_idle(self, last_activity: float) -> bool:
+        """Check if agent has been idle long enough to trigger sleep."""
+        return (time.time() - last_activity) >= self._idle_threshold
+
+    # ------------------------------------------------------------------ #
+    # Run a single sleep cycle
+    # ------------------------------------------------------------------ #
+
+    def run_cycle(self) -> SleepReport:
+        """Execute SWS → REM → pruning in sequence."""
+        report = SleepReport(started_at=time.time())
+
+        # SWS phase
+        self._set_phase(SleepPhase.SWS)
+        t0 = time.time()
+        report.constraints_extracted = self._sws.run()
+        report.phase_durations[SleepPhase.SWS.value] = time.time() - t0
+
+        # REM phase
+        self._set_phase(SleepPhase.REM)
+        t0 = time.time()
+        report.skills_created = self._rem.run()
+        report.phase_durations[SleepPhase.REM.value] = time.time() - t0
+
+        # Pruning phase
+        self._set_phase(SleepPhase.PRUNING)
+        t0 = time.time()
+        report.entries_pruned = self._pruner.run()
+        report.phase_durations[SleepPhase.PRUNING.value] = time.time() - t0
+
+        # Complete
+        report.finished_at = time.time()
+        self._set_phase(SleepPhase.COMPLETE)
+
+        logger.info(
+            "Sleep cycle complete: %d constraints, %d skills, %d pruned",
+            report.constraints_extracted,
+            report.skills_created,
+            report.entries_pruned,
+        )
+
+        # Return to awake
+        self._set_phase(SleepPhase.AWAKE)
+        return report
+
+    # ------------------------------------------------------------------ #
+    # Background monitoring
+    # ------------------------------------------------------------------ #
+
+    async def start_background(
+        self,
+        get_last_activity: Callable[[], float],
+        check_interval: float = 60.0,
+    ) -> None:
+        """Start an asyncio background task that checks idle and triggers cycles."""
+        if self._task is not None:
+            return
+
+        self._task = asyncio.current_task()
+
+        try:
+            while True:
+                await asyncio.sleep(check_interval)
+                last = get_last_activity()
+                if self.is_idle(last):
+                    logger.info("Agent idle — starting sleep cycle")
+                    self.run_cycle()
+        except asyncio.CancelledError:
+            logger.info("Sleep orchestrator background task cancelled")
+
+    def stop(self) -> None:
+        """Cancel the background task."""
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    # ------------------------------------------------------------------ #
+    # Internal
+    # ------------------------------------------------------------------ #
+
+    def _set_phase(self, phase: SleepPhase) -> None:
+        self._phase = phase
+        if self._publish_fn is not None:
+            self._publish_fn(
+                "agent/memory/sleep/phase",
+                phase.value.encode(),
+            )

--- a/tests/test_sleep_orchestrator.py
+++ b/tests/test_sleep_orchestrator.py
@@ -1,0 +1,219 @@
+"""Tests for the sleep cycle orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from pathlib import Path
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.config import MemoryConfig
+from openbad.memory.controller import MemoryController
+from openbad.memory.sleep.orchestrator import (
+    MemoryPruner,
+    SleepOrchestrator,
+    SleepPhase,
+    SleepReport,
+)
+from openbad.memory.sleep.rem import RapidEyeMovement
+from openbad.memory.sleep.sws import SlowWaveSleep
+
+
+def _setup(tmp_path: Path) -> tuple[MemoryController, SleepOrchestrator]:
+    mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+    sws = SlowWaveSleep(mc)
+    rem = RapidEyeMovement(mc)
+    pruner = MemoryPruner(memory_controller=mc)
+    orch = SleepOrchestrator(sws=sws, rem=rem, pruner=pruner)
+    return mc, orch
+
+
+# ------------------------------------------------------------------ #
+# Idle detection
+# ------------------------------------------------------------------ #
+
+
+class TestIdleDetection:
+    def test_not_idle_when_recent(self, tmp_path: Path) -> None:
+        _, orch = _setup(tmp_path)
+        assert not orch.is_idle(time.time())
+
+    def test_idle_after_threshold(self, tmp_path: Path) -> None:
+        _, orch = _setup(tmp_path)
+        assert orch.is_idle(time.time() - 400)
+
+    def test_custom_threshold(self, tmp_path: Path) -> None:
+        mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+        sws = SlowWaveSleep(mc)
+        rem = RapidEyeMovement(mc)
+        pruner = MemoryPruner(memory_controller=mc)
+        orch = SleepOrchestrator(
+            sws=sws, rem=rem, pruner=pruner, idle_threshold_seconds=10.0,
+        )
+        assert not orch.is_idle(time.time() - 5)
+        assert orch.is_idle(time.time() - 15)
+
+
+# ------------------------------------------------------------------ #
+# Phase transitions
+# ------------------------------------------------------------------ #
+
+
+class TestPhaseTransitions:
+    def test_starts_awake(self, tmp_path: Path) -> None:
+        _, orch = _setup(tmp_path)
+        assert orch.phase == SleepPhase.AWAKE
+
+    def test_publishes_phase_transitions(self, tmp_path: Path) -> None:
+        mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+        sws = SlowWaveSleep(mc)
+        rem = RapidEyeMovement(mc)
+        pruner = MemoryPruner(memory_controller=mc)
+        phases: list[str] = []
+        orch = SleepOrchestrator(
+            sws=sws, rem=rem, pruner=pruner,
+            publish_fn=lambda t, p: phases.append(p.decode()),
+        )
+        orch.run_cycle()
+        assert phases == ["sws", "rem", "pruning", "complete", "awake"]
+
+    def test_returns_to_awake(self, tmp_path: Path) -> None:
+        _, orch = _setup(tmp_path)
+        orch.run_cycle()
+        assert orch.phase == SleepPhase.AWAKE
+
+
+# ------------------------------------------------------------------ #
+# Run cycle
+# ------------------------------------------------------------------ #
+
+
+class TestRunCycle:
+    def test_empty_cycle(self, tmp_path: Path) -> None:
+        _, orch = _setup(tmp_path)
+        report = orch.run_cycle()
+        assert report.constraints_extracted == 0
+        assert report.skills_created == 0
+        assert report.entries_pruned == 0
+        assert report.finished_at >= report.started_at
+
+    def test_cycle_with_failures_and_successes(self, tmp_path: Path) -> None:
+        mc, orch = _setup(tmp_path)
+        # Add failures
+        mc.stm.write(MemoryEntry(
+            key="f1", value="error: crash", tier=MemoryTier.STM,
+            metadata={"status": "error", "action": "deploy"},
+        ))
+        # Add successes
+        mc.stm.write(MemoryEntry(
+            key="s1", value="ok", tier=MemoryTier.STM,
+            metadata={"status": "success", "action": "build"},
+        ))
+        report = orch.run_cycle()
+        assert report.constraints_extracted >= 1
+        assert report.skills_created >= 1
+
+    def test_cycle_reports_phase_durations(self, tmp_path: Path) -> None:
+        _, orch = _setup(tmp_path)
+        report = orch.run_cycle()
+        assert "sws" in report.phase_durations
+        assert "rem" in report.phase_durations
+        assert "pruning" in report.phase_durations
+
+
+# ------------------------------------------------------------------ #
+# SleepReport
+# ------------------------------------------------------------------ #
+
+
+class TestSleepReport:
+    def test_to_dict(self) -> None:
+        r = SleepReport(
+            started_at=100.0,
+            finished_at=110.0,
+            constraints_extracted=3,
+            skills_created=1,
+            entries_pruned=5,
+        )
+        d = r.to_dict()
+        assert d["duration_seconds"] == 10.0
+        assert d["constraints_extracted"] == 3
+
+    def test_defaults(self) -> None:
+        r = SleepReport()
+        assert r.started_at == 0.0
+        assert r.phase_durations == {}
+
+
+# ------------------------------------------------------------------ #
+# MemoryPruner
+# ------------------------------------------------------------------ #
+
+
+class TestMemoryPruner:
+    def test_prunes_decayed_entries(self, tmp_path: Path) -> None:
+        mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+        # Write old episodic entry
+        mc.episodic.write(MemoryEntry(
+            key="old", value="data", tier=MemoryTier.EPISODIC,
+            created_at=time.time() - 100000 * 3600,
+        ))
+        # Write fresh episodic entry
+        mc.episodic.write(MemoryEntry(
+            key="fresh", value="data", tier=MemoryTier.EPISODIC,
+        ))
+        pruner = MemoryPruner(memory_controller=mc)
+        count = pruner.run()
+        assert count >= 1
+        assert mc.episodic.read("fresh") is not None
+
+    def test_no_pruning_when_all_fresh(self, tmp_path: Path) -> None:
+        mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+        mc.episodic.write(MemoryEntry(
+            key="a", value="data", tier=MemoryTier.EPISODIC,
+        ))
+        pruner = MemoryPruner(memory_controller=mc)
+        assert pruner.run() == 0
+
+
+# ------------------------------------------------------------------ #
+# Background task
+# ------------------------------------------------------------------ #
+
+
+class TestBackground:
+    async def test_background_cancellation(self, tmp_path: Path) -> None:
+        mc, orch = _setup(tmp_path)
+
+        async def run_bg() -> None:
+            await orch.start_background(
+                get_last_activity=lambda: time.time() - 600,
+                check_interval=0.05,
+            )
+
+        task = asyncio.create_task(run_bg())
+        await asyncio.sleep(0.15)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def test_stop_method(self, tmp_path: Path) -> None:
+        _, orch = _setup(tmp_path)
+        # stop on a non-started orchestrator should be safe
+        orch.stop()
+        assert orch.phase == SleepPhase.AWAKE
+
+
+# ------------------------------------------------------------------ #
+# SleepPhase enum
+# ------------------------------------------------------------------ #
+
+
+class TestSleepPhaseEnum:
+    def test_values(self) -> None:
+        assert SleepPhase.AWAKE.value == "awake"
+        assert SleepPhase.SWS.value == "sws"
+        assert SleepPhase.REM.value == "rem"
+        assert SleepPhase.PRUNING.value == "pruning"
+        assert SleepPhase.COMPLETE.value == "complete"


### PR DESCRIPTION
Closes #124

Adds `orchestrator.py`:
- `SleepPhase` enum (AWAKE, SWS, REM, PRUNING, COMPLETE)
- `MemoryPruner` — wraps forgetting module for episodic+semantic stores
- `SleepReport` dataclass with `to_dict()`  
- `SleepOrchestrator`: idle detection, SWS->REM->pruning sequencing, MQTT publish, async background task
- 16 unit tests