### PR TITLE
#137: Active inference scaffold, plugin interface, and config

### DIFF
--- a/config/active_inference.yaml
+++ b/config/active_inference.yaml
@@ -1,0 +1,11 @@
+active_inference:
+  plugin_dir: "src/openbad/plugins/observations"
+  surprise_threshold: 0.6
+  daily_token_budget: 5000
+  cooldown_seconds: 300
+  max_concurrent: 1
+  suppressed_in_states:
+    - THROTTLED
+    - EMERGENCY
+  world_model_history_size: 20
+  ema_alpha: 0.1

--- a/src/openbad/active_inference/__init__.py
+++ b/src/openbad/active_inference/__init__.py
@@ -1,0 +1,1 @@
+"""Active inference — prediction-driven exploration engine."""

--- a/src/openbad/active_inference/config.py
+++ b/src/openbad/active_inference/config.py
@@ -1,0 +1,41 @@
+"""Active-inference configuration loaded from YAML."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class ActiveInferenceConfig:
+    """Configuration for the prediction-driven exploration system."""
+
+    plugin_dir: Path = Path("src/openbad/plugins/observations")
+    surprise_threshold: float = 0.6
+    daily_token_budget: int = 5000
+    cooldown_seconds: int = 300
+    max_concurrent: int = 1
+    suppressed_in_states: list[str] = field(
+        default_factory=lambda: ["THROTTLED", "EMERGENCY"],
+    )
+    world_model_history_size: int = 20
+    ema_alpha: float = 0.1
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> ActiveInferenceConfig:
+        """Load configuration from a YAML file."""
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        data = raw.get("active_inference", raw)
+        if "plugin_dir" in data:
+            data["plugin_dir"] = Path(data["plugin_dir"])
+        if "suppressed_in_states" in data:
+            data["suppressed_in_states"] = list(data["suppressed_in_states"])
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+    def to_dict(self) -> dict:
+        """Serialise to a plain dict."""
+        d = {k: getattr(self, k) for k in self.__dataclass_fields__}
+        d["plugin_dir"] = str(d["plugin_dir"])
+        return d

--- a/src/openbad/active_inference/plugin_interface.py
+++ b/src/openbad/active_inference/plugin_interface.py
@@ -1,0 +1,46 @@
+"""Observation plugin interface and result dataclass."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+
+@dataclass
+class ObservationResult:
+    """Structured observation returned by an :class:`ObservationPlugin`."""
+
+    metrics: dict[str, float | int | str]
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+    raw_data: Any = None
+
+
+class ObservationPlugin(ABC):
+    """Base class for all data-source observation plugins.
+
+    Subclasses must implement :pymethod:`source_id`, :pymethod:`observe`,
+    and :pymethod:`default_predictions`.
+    """
+
+    @property
+    @abstractmethod
+    def source_id(self) -> str:
+        """Unique identifier for this data source (e.g. ``'system_health'``)."""
+
+    @abstractmethod
+    async def observe(self) -> ObservationResult:
+        """Fetch the current state of this data source."""
+
+    @abstractmethod
+    def default_predictions(self) -> dict[str, dict[str, float]]:
+        """Return initial predictions for this source before any observations.
+
+        Returns a mapping of metric name → ``{"expected": …, "tolerance": …}``.
+        """
+
+    @property
+    def poll_interval_seconds(self) -> int:
+        """How often to poll this source.  Default: 60 s."""
+        return 60

--- a/src/openbad/active_inference/plugin_loader.py
+++ b/src/openbad/active_inference/plugin_loader.py
@@ -1,0 +1,55 @@
+"""Plugin discovery and loading from a configurable directory."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+
+from openbad.active_inference.plugin_interface import ObservationPlugin
+
+
+def _load_module_from_path(path: Path) -> object:
+    """Import a single ``.py`` file as a module and return it."""
+    module_name = f"_openbad_plugin_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def discover_plugins(directory: Path) -> list[type[ObservationPlugin]]:
+    """Discover :class:`ObservationPlugin` subclasses in *directory*.
+
+    Scans all ``*.py`` files (non-recursive) in *directory* for concrete
+    classes that implement :class:`ObservationPlugin`.
+    """
+    if not directory.is_dir():
+        return []
+
+    found: list[type[ObservationPlugin]] = []
+    for py_file in sorted(directory.glob("*.py")):
+        if py_file.name.startswith("_"):
+            continue
+        try:
+            mod = _load_module_from_path(py_file)
+        except Exception:  # noqa: BLE001, S112
+            continue
+        for _name, obj in inspect.getmembers(mod, inspect.isclass):
+            if (
+                issubclass(obj, ObservationPlugin)
+                and obj is not ObservationPlugin
+                and not inspect.isabstract(obj)
+            ):
+                found.append(obj)
+    return found
+
+
+def load_plugins(directory: Path) -> list[ObservationPlugin]:
+    """Discover **and instantiate** all plugins in *directory*."""
+    return [cls() for cls in discover_plugins(directory)]

--- a/tests/test_plugin_interface.py
+++ b/tests/test_plugin_interface.py
@@ -1,0 +1,125 @@
+"""Tests for ObservationPlugin interface and ObservationResult."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from openbad.active_inference.plugin_interface import (
+    ObservationPlugin,
+    ObservationResult,
+)
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+
+class _GoodPlugin(ObservationPlugin):
+    """Concrete plugin for testing."""
+
+    @property
+    def source_id(self) -> str:
+        return "test_source"
+
+    async def observe(self) -> ObservationResult:
+        return ObservationResult(metrics={"cpu": 50.0})
+
+    def default_predictions(self) -> dict[str, dict[str, float]]:
+        return {"cpu": {"expected": 30.0, "tolerance": 20.0}}
+
+
+class _CustomPollPlugin(_GoodPlugin):
+    @property
+    def poll_interval_seconds(self) -> int:
+        return 120
+
+
+# ------------------------------------------------------------------ #
+# ObservationResult
+# ------------------------------------------------------------------ #
+
+
+class TestObservationResult:
+    def test_default_timestamp(self) -> None:
+        r = ObservationResult(metrics={"a": 1})
+        assert isinstance(r.timestamp, datetime)
+        assert r.timestamp.tzinfo == UTC
+
+    def test_explicit_timestamp(self) -> None:
+        ts = datetime(2025, 1, 1, tzinfo=UTC)
+        r = ObservationResult(metrics={"a": 1}, timestamp=ts)
+        assert r.timestamp == ts
+
+    def test_raw_data_default_none(self) -> None:
+        r = ObservationResult(metrics={})
+        assert r.raw_data is None
+
+    def test_raw_data_custom(self) -> None:
+        r = ObservationResult(metrics={}, raw_data={"detail": True})
+        assert r.raw_data == {"detail": True}
+
+    def test_metrics_various_types(self) -> None:
+        r = ObservationResult(metrics={"f": 1.5, "i": 42, "s": "ok"})
+        assert r.metrics["f"] == 1.5
+        assert r.metrics["i"] == 42
+        assert r.metrics["s"] == "ok"
+
+
+# ------------------------------------------------------------------ #
+# ObservationPlugin ABC
+# ------------------------------------------------------------------ #
+
+
+class TestObservationPlugin:
+    def test_concrete_implementation(self) -> None:
+        p = _GoodPlugin()
+        assert p.source_id == "test_source"
+
+    async def test_observe_returns_result(self) -> None:
+        p = _GoodPlugin()
+        r = await p.observe()
+        assert isinstance(r, ObservationResult)
+        assert r.metrics["cpu"] == 50.0
+
+    def test_default_predictions(self) -> None:
+        p = _GoodPlugin()
+        preds = p.default_predictions()
+        assert "cpu" in preds
+        assert preds["cpu"]["expected"] == 30.0
+
+    def test_default_poll_interval(self) -> None:
+        p = _GoodPlugin()
+        assert p.poll_interval_seconds == 60
+
+    def test_custom_poll_interval(self) -> None:
+        p = _CustomPollPlugin()
+        assert p.poll_interval_seconds == 120
+
+    def test_abstract_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            ObservationPlugin()  # type: ignore[abstract]
+
+    def test_missing_source_id_raises(self) -> None:
+        class _Bad(ObservationPlugin):
+            async def observe(self) -> ObservationResult:
+                return ObservationResult(metrics={})
+
+            def default_predictions(self) -> dict:
+                return {}
+
+        with pytest.raises(TypeError):
+            _Bad()  # type: ignore[abstract]
+
+    def test_missing_observe_raises(self) -> None:
+        class _Bad(ObservationPlugin):
+            @property
+            def source_id(self) -> str:
+                return "x"
+
+            def default_predictions(self) -> dict:
+                return {}
+
+        with pytest.raises(TypeError):
+            _Bad()  # type: ignore[abstract]

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,133 @@
+"""Tests for plugin discovery and loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openbad.active_inference.plugin_interface import ObservationPlugin
+from openbad.active_inference.plugin_loader import discover_plugins, load_plugins
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+_GOOD_PLUGIN_SRC = """\
+from openbad.active_inference.plugin_interface import ObservationPlugin, ObservationResult
+
+class DemoPlugin(ObservationPlugin):
+    @property
+    def source_id(self) -> str:
+        return "demo"
+
+    async def observe(self) -> ObservationResult:
+        return ObservationResult(metrics={"x": 1})
+
+    def default_predictions(self) -> dict:
+        return {"x": {"expected": 0.0, "tolerance": 1.0}}
+"""
+
+_ABSTRACT_PLUGIN_SRC = """\
+from openbad.active_inference.plugin_interface import ObservationPlugin
+
+class AbstractOnly(ObservationPlugin):
+    pass
+"""
+
+_BAD_MODULE_SRC = "raise RuntimeError('import boom')\n"
+
+
+# ------------------------------------------------------------------ #
+# Tests
+# ------------------------------------------------------------------ #
+
+
+class TestDiscoverPlugins:
+    def test_finds_concrete_plugin(self, tmp_path: Path) -> None:
+        (tmp_path / "demo.py").write_text(_GOOD_PLUGIN_SRC, encoding="utf-8")
+        found = discover_plugins(tmp_path)
+        assert len(found) == 1
+        assert found[0].__name__ == "DemoPlugin"
+
+    def test_skips_abstract_plugin(self, tmp_path: Path) -> None:
+        (tmp_path / "abstract.py").write_text(
+            _ABSTRACT_PLUGIN_SRC, encoding="utf-8",
+        )
+        found = discover_plugins(tmp_path)
+        assert len(found) == 0
+
+    def test_skips_bad_module(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.py").write_text(_BAD_MODULE_SRC, encoding="utf-8")
+        found = discover_plugins(tmp_path)
+        assert len(found) == 0
+
+    def test_skips_underscore_files(self, tmp_path: Path) -> None:
+        (tmp_path / "__init__.py").write_text(
+            _GOOD_PLUGIN_SRC, encoding="utf-8",
+        )
+        found = discover_plugins(tmp_path)
+        assert len(found) == 0
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        found = discover_plugins(tmp_path)
+        assert found == []
+
+    def test_nonexistent_directory(self, tmp_path: Path) -> None:
+        found = discover_plugins(tmp_path / "nope")
+        assert found == []
+
+    def test_multiple_plugins(self, tmp_path: Path) -> None:
+        for name in ("a", "b"):
+            src = _GOOD_PLUGIN_SRC.replace("DemoPlugin", f"Plugin{name.upper()}")
+            src = src.replace('"demo"', f'"{name}"')
+            (tmp_path / f"{name}.py").write_text(src, encoding="utf-8")
+        found = discover_plugins(tmp_path)
+        assert len(found) == 2
+
+
+class TestLoadPlugins:
+    def test_instantiates_plugins(self, tmp_path: Path) -> None:
+        (tmp_path / "demo.py").write_text(_GOOD_PLUGIN_SRC, encoding="utf-8")
+        plugins = load_plugins(tmp_path)
+        assert len(plugins) == 1
+        assert isinstance(plugins[0], ObservationPlugin)
+        assert plugins[0].source_id == "demo"
+
+    def test_empty_returns_empty(self, tmp_path: Path) -> None:
+        assert load_plugins(tmp_path) == []
+
+
+class TestConfigFromYaml:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        from openbad.active_inference.config import ActiveInferenceConfig
+
+        cfg = ActiveInferenceConfig(surprise_threshold=0.8)
+        path = tmp_path / "ai.yaml"
+        import yaml
+
+        path.write_text(
+            yaml.dump({"active_inference": cfg.to_dict()}),
+            encoding="utf-8",
+        )
+
+        loaded = ActiveInferenceConfig.from_yaml(path)
+        assert loaded.surprise_threshold == 0.8
+        assert loaded.plugin_dir == cfg.plugin_dir
+
+    def test_defaults(self) -> None:
+        from openbad.active_inference.config import ActiveInferenceConfig
+
+        cfg = ActiveInferenceConfig()
+        assert cfg.surprise_threshold == 0.6
+        assert cfg.daily_token_budget == 5000
+        assert cfg.cooldown_seconds == 300
+        assert cfg.max_concurrent == 1
+        assert cfg.world_model_history_size == 20
+        assert cfg.ema_alpha == 0.1
+
+    def test_to_dict(self) -> None:
+        from openbad.active_inference.config import ActiveInferenceConfig
+
+        cfg = ActiveInferenceConfig()
+        d = cfg.to_dict()
+        assert isinstance(d["plugin_dir"], str)
+        assert d["surprise_threshold"] == 0.6


### PR DESCRIPTION
Closes #137

## Summary
Creates the `src/openbad/active_inference/` package with:
- `plugin_interface.py` — `ObservationPlugin` ABC and `ObservationResult` dataclass
- `plugin_loader.py` — discover and load plugins from configurable directory
- `config.py` — `ActiveInferenceConfig` dataclass from YAML
- `config/active_inference.yaml` — declarative defaults

## How to test
```bash
pytest tests/test_plugin_interface.py tests/test_plugin_loader.py -v
```
25 tests pass.