### PR TITLE
#142: Endocrine controller — central hormone state and decay

### DIFF
--- a/config/endocrine.yaml
+++ b/config/endocrine.yaml
@@ -1,0 +1,25 @@
+endocrine:
+  publish_interval_seconds: 10.0
+  significant_change_delta: 0.1
+
+  dopamine:
+    increment: 0.15
+    activation_threshold: 0.50
+    half_life_seconds: 300.0
+
+  adrenaline:
+    increment: 0.25
+    activation_threshold: 0.60
+    escalation_threshold: 0.85
+    half_life_seconds: 60.0
+
+  cortisol:
+    increment: 0.15
+    activation_threshold: 0.50
+    escalation_threshold: 0.80
+    half_life_seconds: 900.0
+
+  endorphin:
+    increment: 0.15
+    activation_threshold: 0.40
+    half_life_seconds: 600.0

--- a/src/openbad/endocrine/__init__.py
+++ b/src/openbad/endocrine/__init__.py
@@ -1,0 +1,1 @@
+"""Digital endocrine system — continuous hormone regulation."""

--- a/src/openbad/endocrine/config.py
+++ b/src/openbad/endocrine/config.py
@@ -1,0 +1,77 @@
+"""Endocrine system configuration loaded from YAML."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class HormoneConfig:
+    """Per-hormone tunables."""
+
+    increment: float = 0.15
+    activation_threshold: float = 0.50
+    escalation_threshold: float | None = None
+    half_life_seconds: float = 300.0
+
+
+@dataclass
+class EndocrineConfig:
+    """Top-level endocrine configuration."""
+
+    dopamine: HormoneConfig = field(
+        default_factory=lambda: HormoneConfig(
+            increment=0.15,
+            activation_threshold=0.50,
+            half_life_seconds=300.0,
+        ),
+    )
+    adrenaline: HormoneConfig = field(
+        default_factory=lambda: HormoneConfig(
+            increment=0.25,
+            activation_threshold=0.60,
+            escalation_threshold=0.85,
+            half_life_seconds=60.0,
+        ),
+    )
+    cortisol: HormoneConfig = field(
+        default_factory=lambda: HormoneConfig(
+            increment=0.15,
+            activation_threshold=0.50,
+            escalation_threshold=0.80,
+            half_life_seconds=900.0,
+        ),
+    )
+    endorphin: HormoneConfig = field(
+        default_factory=lambda: HormoneConfig(
+            increment=0.15,
+            activation_threshold=0.40,
+            half_life_seconds=600.0,
+        ),
+    )
+    publish_interval_seconds: float = 10.0
+    significant_change_delta: float = 0.1
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> EndocrineConfig:
+        """Load configuration from a YAML file."""
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        data = raw.get("endocrine", raw)
+
+        hormones: dict[str, HormoneConfig] = {}
+        for name in ("dopamine", "adrenaline", "cortisol", "endorphin"):
+            if name in data and isinstance(data[name], dict):
+                fields = HormoneConfig.__dataclass_fields__
+                hormones[name] = HormoneConfig(
+                    **{k: v for k, v in data[name].items() if k in fields},
+                )
+
+        kwargs: dict = {}
+        for scalar in ("publish_interval_seconds", "significant_change_delta"):
+            if scalar in data:
+                kwargs[scalar] = float(data[scalar])
+
+        return cls(**hormones, **kwargs)

--- a/src/openbad/endocrine/controller.py
+++ b/src/openbad/endocrine/controller.py
@@ -1,0 +1,120 @@
+"""Central endocrine controller — continuous hormone levels with decay."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+
+from openbad.endocrine.config import EndocrineConfig, HormoneConfig
+
+HORMONES = ("dopamine", "adrenaline", "cortisol", "endorphin")
+
+
+@dataclass
+class HormoneState:
+    """Snapshot of all hormone levels."""
+
+    dopamine: float = 0.0
+    adrenaline: float = 0.0
+    cortisol: float = 0.0
+    endorphin: float = 0.0
+    timestamp: float = field(default_factory=time.monotonic)
+
+    def to_dict(self) -> dict[str, float]:
+        return {h: getattr(self, h) for h in HORMONES}
+
+
+class EndocrineController:
+    """Manages continuous hormone levels with additive triggers and exponential decay."""
+
+    def __init__(self, config: EndocrineConfig | None = None) -> None:
+        self._config = config or EndocrineConfig()
+        self._levels: dict[str, float] = {h: 0.0 for h in HORMONES}
+        self._last_decay: float = time.monotonic()
+        self._last_publish: float = time.monotonic()
+        self._previous_state: dict[str, float] = {h: 0.0 for h in HORMONES}
+
+    # -- Queries ----------------------------------------------------------- #
+
+    def get_state(self) -> HormoneState:
+        """Return the current hormone levels."""
+        return HormoneState(**self._levels)
+
+    def level(self, hormone: str) -> float:
+        """Return current level for a single hormone."""
+        return self._levels[hormone]
+
+    def is_active(self, hormone: str) -> bool:
+        """``True`` when *hormone* exceeds its activation threshold."""
+        cfg = self._hormone_config(hormone)
+        return self._levels[hormone] > cfg.activation_threshold
+
+    def is_escalated(self, hormone: str) -> bool:
+        """``True`` when *hormone* exceeds its escalation threshold (if any)."""
+        cfg = self._hormone_config(hormone)
+        if cfg.escalation_threshold is None:
+            return False
+        return self._levels[hormone] > cfg.escalation_threshold
+
+    # -- Mutations --------------------------------------------------------- #
+
+    def trigger(self, hormone: str, amount: float | None = None) -> float:
+        """Add *amount* (default: configured increment) to *hormone*, clamped to [0, 1]."""
+        cfg = self._hormone_config(hormone)
+        delta = amount if amount is not None else cfg.increment
+        self._levels[hormone] = max(0.0, min(1.0, self._levels[hormone] + delta))
+        return self._levels[hormone]
+
+    def decay(self, dt: float | None = None) -> None:
+        """Apply exponential decay to all hormones.
+
+        If *dt* is ``None``, use the wall-clock delta since the last decay.
+        """
+        now = time.monotonic()
+        if dt is None:
+            dt = now - self._last_decay
+        self._last_decay = now
+
+        if dt <= 0:
+            return
+
+        for hormone in HORMONES:
+            cfg = self._hormone_config(hormone)
+            hl = cfg.half_life_seconds
+            self._levels[hormone] *= math.pow(2, -dt / hl)
+            # Snap to zero when negligible.
+            if self._levels[hormone] < 1e-4:
+                self._levels[hormone] = 0.0
+
+    def reset(self) -> None:
+        """Reset all hormone levels to zero."""
+        for h in HORMONES:
+            self._levels[h] = 0.0
+        self._last_decay = time.monotonic()
+
+    # -- Publishing helpers ------------------------------------------------ #
+
+    def should_publish(self) -> bool:
+        """``True`` when it's time for a periodic or significant-change publish."""
+        now = time.monotonic()
+        if now - self._last_publish >= self._config.publish_interval_seconds:
+            return True
+        delta = self._config.significant_change_delta
+        return any(
+            abs(self._levels[h] - self._previous_state.get(h, 0.0)) >= delta
+            for h in HORMONES
+        )
+
+    def mark_published(self) -> None:
+        """Record that a publish just happened."""
+        self._last_publish = time.monotonic()
+        self._previous_state = dict(self._levels)
+
+    # -- Internal ---------------------------------------------------------- #
+
+    def _hormone_config(self, hormone: str) -> HormoneConfig:
+        cfg = getattr(self._config, hormone, None)
+        if cfg is None:
+            raise ValueError(f"Unknown hormone: {hormone!r}")
+        return cfg

--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -85,7 +85,10 @@ IMMUNE_ALL = "agent/immune/+"
 ENDOCRINE = "agent/endocrine/{hormone}"
 ENDOCRINE_CORTISOL = "agent/endocrine/cortisol"
 ENDOCRINE_ADRENALINE = "agent/endocrine/adrenaline"
+ENDOCRINE_DOPAMINE = "agent/endocrine/dopamine"
 ENDOCRINE_ENDORPHIN = "agent/endocrine/endorphin"
+ENDOCRINE_STATE = "agent/endocrine/state"
+ENDOCRINE_TELEMETRY = "agent/endocrine/telemetry"
 
 # Wildcard: all endocrine events
 ENDOCRINE_ALL = "agent/endocrine/+"
@@ -98,6 +101,16 @@ MEMORY_LTM_CONSOLIDATE = "agent/memory/ltm/consolidate"
 
 # Wildcard: all memory events
 MEMORY_ALL = "agent/memory/#"
+
+# ---------------------------------------------------------------------------
+# Active inference (exploration / surprise)
+# ---------------------------------------------------------------------------
+INFERENCE_SURPRISE = "agent/inference/surprise"
+INFERENCE_EXPLORATION = "agent/inference/exploration"
+INFERENCE_TAKEAWAY = "agent/inference/takeaway"
+
+# Wildcard: all inference events
+INFERENCE_ALL = "agent/inference/+"
 
 # ---------------------------------------------------------------------------
 # Sleep / maintenance cycles

--- a/tests/test_endocrine_controller.py
+++ b/tests/test_endocrine_controller.py
@@ -1,0 +1,277 @@
+"""Tests for the endocrine controller."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from openbad.endocrine.config import EndocrineConfig, HormoneConfig
+from openbad.endocrine.controller import (
+    HORMONES,
+    EndocrineController,
+    HormoneState,
+)
+
+# ------------------------------------------------------------------ #
+# HormoneState
+# ------------------------------------------------------------------ #
+
+
+class TestHormoneState:
+    def test_defaults_zero(self) -> None:
+        s = HormoneState()
+        for h in HORMONES:
+            assert getattr(s, h) == 0.0
+
+    def test_to_dict(self) -> None:
+        s = HormoneState(dopamine=0.3, cortisol=0.7)
+        d = s.to_dict()
+        assert d["dopamine"] == 0.3
+        assert d["cortisol"] == 0.7
+        assert d["adrenaline"] == 0.0
+
+
+# ------------------------------------------------------------------ #
+# Trigger / clamping
+# ------------------------------------------------------------------ #
+
+
+class TestTrigger:
+    def test_default_increment(self) -> None:
+        c = EndocrineController()
+        c.trigger("dopamine")
+        assert c.level("dopamine") == pytest.approx(0.15)
+
+    def test_custom_amount(self) -> None:
+        c = EndocrineController()
+        c.trigger("dopamine", 0.4)
+        assert c.level("dopamine") == pytest.approx(0.4)
+
+    def test_clamp_upper(self) -> None:
+        c = EndocrineController()
+        c.trigger("dopamine", 1.5)
+        assert c.level("dopamine") == 1.0
+
+    def test_clamp_lower(self) -> None:
+        c = EndocrineController()
+        c.trigger("dopamine", -0.5)
+        assert c.level("dopamine") == 0.0
+
+    def test_additive(self) -> None:
+        c = EndocrineController()
+        c.trigger("adrenaline", 0.3)
+        c.trigger("adrenaline", 0.3)
+        assert c.level("adrenaline") == pytest.approx(0.6)
+
+    def test_unknown_hormone_raises(self) -> None:
+        c = EndocrineController()
+        with pytest.raises(ValueError, match="Unknown hormone"):
+            c.trigger("serotonin")
+
+
+# ------------------------------------------------------------------ #
+# Decay
+# ------------------------------------------------------------------ #
+
+
+class TestDecay:
+    def test_exact_half_life(self) -> None:
+        cfg = EndocrineConfig(
+            dopamine=HormoneConfig(half_life_seconds=10.0),
+        )
+        c = EndocrineController(cfg)
+        c.trigger("dopamine", 1.0)
+        c.decay(dt=10.0)
+        assert c.level("dopamine") == pytest.approx(0.5, abs=1e-4)
+
+    def test_two_half_lives(self) -> None:
+        cfg = EndocrineConfig(
+            dopamine=HormoneConfig(half_life_seconds=10.0),
+        )
+        c = EndocrineController(cfg)
+        c.trigger("dopamine", 1.0)
+        c.decay(dt=20.0)
+        assert c.level("dopamine") == pytest.approx(0.25, abs=1e-4)
+
+    def test_snap_to_zero(self) -> None:
+        cfg = EndocrineConfig(
+            dopamine=HormoneConfig(half_life_seconds=1.0),
+        )
+        c = EndocrineController(cfg)
+        c.trigger("dopamine", 0.01)
+        c.decay(dt=100.0)
+        assert c.level("dopamine") == 0.0
+
+    def test_zero_dt_no_change(self) -> None:
+        c = EndocrineController()
+        c.trigger("cortisol", 0.5)
+        c.decay(dt=0.0)
+        assert c.level("cortisol") == pytest.approx(0.5)
+
+    def test_negative_dt_no_change(self) -> None:
+        c = EndocrineController()
+        c.trigger("cortisol", 0.5)
+        c.decay(dt=-1.0)
+        assert c.level("cortisol") == pytest.approx(0.5)
+
+    def test_decay_all_hormones(self) -> None:
+        cfg = EndocrineConfig(
+            dopamine=HormoneConfig(half_life_seconds=10.0),
+            adrenaline=HormoneConfig(half_life_seconds=10.0),
+            cortisol=HormoneConfig(half_life_seconds=10.0),
+            endorphin=HormoneConfig(half_life_seconds=10.0),
+        )
+        c = EndocrineController(cfg)
+        for h in HORMONES:
+            c.trigger(h, 1.0)
+        c.decay(dt=10.0)
+        for h in HORMONES:
+            assert c.level(h) == pytest.approx(0.5, abs=1e-4)
+
+
+# ------------------------------------------------------------------ #
+# Activation / escalation
+# ------------------------------------------------------------------ #
+
+
+class TestThresholds:
+    def test_not_active_below_threshold(self) -> None:
+        c = EndocrineController()
+        c.trigger("dopamine", 0.30)
+        assert not c.is_active("dopamine")
+
+    def test_active_above_threshold(self) -> None:
+        c = EndocrineController()
+        c.trigger("dopamine", 0.55)
+        assert c.is_active("dopamine")
+
+    def test_not_escalated_without_config(self) -> None:
+        c = EndocrineController()
+        c.trigger("dopamine", 1.0)
+        assert not c.is_escalated("dopamine")
+
+    def test_escalated(self) -> None:
+        c = EndocrineController()
+        c.trigger("adrenaline", 0.90)
+        assert c.is_escalated("adrenaline")
+
+    def test_cortisol_two_tiers(self) -> None:
+        c = EndocrineController()
+        c.trigger("cortisol", 0.55)
+        assert c.is_active("cortisol")
+        assert not c.is_escalated("cortisol")
+
+        c.trigger("cortisol", 0.30)
+        assert c.is_escalated("cortisol")
+
+
+# ------------------------------------------------------------------ #
+# Reset
+# ------------------------------------------------------------------ #
+
+
+class TestReset:
+    def test_reset_zeroes(self) -> None:
+        c = EndocrineController()
+        for h in HORMONES:
+            c.trigger(h, 0.8)
+        c.reset()
+        for h in HORMONES:
+            assert c.level(h) == 0.0
+
+
+# ------------------------------------------------------------------ #
+# Publishing helpers
+# ------------------------------------------------------------------ #
+
+
+class TestPublish:
+    def test_should_publish_on_interval(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = EndocrineConfig(publish_interval_seconds=1.0)
+        c = EndocrineController(cfg)
+        c.mark_published()
+
+        # Advance monotonic clock past publish interval.
+        _base = time.monotonic()
+        monkeypatch.setattr(time, "monotonic", lambda: _base + 2.0)
+        assert c.should_publish()
+
+    def test_should_publish_on_significant_change(self) -> None:
+        cfg = EndocrineConfig(
+            publish_interval_seconds=999.0,
+            significant_change_delta=0.1,
+        )
+        c = EndocrineController(cfg)
+        c.mark_published()
+        c.trigger("dopamine", 0.15)
+        assert c.should_publish()
+
+    def test_no_publish_when_quiet(self) -> None:
+        cfg = EndocrineConfig(
+            publish_interval_seconds=999.0,
+            significant_change_delta=0.5,
+        )
+        c = EndocrineController(cfg)
+        c.mark_published()
+        c.trigger("dopamine", 0.05)
+        assert not c.should_publish()
+
+
+# ------------------------------------------------------------------ #
+# get_state
+# ------------------------------------------------------------------ #
+
+
+class TestGetState:
+    def test_returns_snapshot(self) -> None:
+        c = EndocrineController()
+        c.trigger("adrenaline", 0.4)
+        s = c.get_state()
+        assert isinstance(s, HormoneState)
+        assert s.adrenaline == pytest.approx(0.4)
+        assert s.dopamine == 0.0
+
+
+# ------------------------------------------------------------------ #
+# Config from YAML
+# ------------------------------------------------------------------ #
+
+
+class TestEndocrineConfigYaml:
+    def test_round_trip(self, tmp_path) -> None:
+        import yaml
+
+        cfg_data = {
+            "endocrine": {
+                "publish_interval_seconds": 5.0,
+                "significant_change_delta": 0.05,
+                "dopamine": {
+                    "increment": 0.20,
+                    "activation_threshold": 0.55,
+                    "half_life_seconds": 200.0,
+                },
+                "adrenaline": {
+                    "increment": 0.30,
+                    "activation_threshold": 0.65,
+                    "escalation_threshold": 0.90,
+                    "half_life_seconds": 30.0,
+                },
+            },
+        }
+        path = tmp_path / "endo.yaml"
+        path.write_text(yaml.dump(cfg_data), encoding="utf-8")
+
+        loaded = EndocrineConfig.from_yaml(path)
+        assert loaded.dopamine.increment == pytest.approx(0.20)
+        assert loaded.adrenaline.escalation_threshold == pytest.approx(0.90)
+        assert loaded.publish_interval_seconds == pytest.approx(5.0)
+        # Unmentioned hormones keep defaults.
+        assert loaded.cortisol.increment == pytest.approx(0.15)
+
+    def test_defaults(self) -> None:
+        cfg = EndocrineConfig()
+        assert cfg.dopamine.half_life_seconds == 300.0
+        assert cfg.adrenaline.half_life_seconds == 60.0
+        assert cfg.cortisol.escalation_threshold == 0.80
+        assert cfg.endorphin.activation_threshold == 0.40


### PR DESCRIPTION
Closes #142

## Summary
Creates `src/openbad/endocrine/` package with:
- `config.py` — `HormoneConfig` / `EndocrineConfig` dataclasses from YAML
- `controller.py` — `EndocrineController` with trigger, decay, activation/escalation checks, publish helpers
- `config/endocrine.yaml` — conservative defaults
- Adds `ENDOCRINE_DOPAMINE`, `ENDOCRINE_STATE`, `ENDOCRINE_TELEMETRY`, and `INFERENCE_*` topics

## How to test
```bash
pytest tests/test_endocrine_controller.py -v
```
26 tests pass.