### PR TITLE
#138: System health observation plugin (built-in)

### DIFF
--- a/src/openbad/plugins/__init__.py
+++ b/src/openbad/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Observation plugins for the active inference system."""

--- a/src/openbad/plugins/observations/__init__.py
+++ b/src/openbad/plugins/observations/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in observation plugins."""

--- a/src/openbad/plugins/observations/system_health.py
+++ b/src/openbad/plugins/observations/system_health.py
@@ -1,0 +1,98 @@
+"""System-health observation plugin — zero external dependencies.
+
+Monitors CPU percentage, memory percentage, disk I/O latency (ms),
+active process count, and uptime hours.  Reuses the interoception
+monitor where possible so metrics are not double-collected.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import time
+
+from openbad.active_inference.plugin_interface import ObservationPlugin, ObservationResult
+
+
+def _cpu_percent() -> float:
+    """Return overall CPU usage percentage."""
+    try:
+        from openbad.interoception.monitor import collect_cpu
+
+        snap = collect_cpu()
+        return snap.usage_percent
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def _memory_percent() -> float:
+    """Return overall memory usage percentage."""
+    try:
+        from openbad.interoception.monitor import collect_memory
+
+        snap = collect_memory()
+        return snap.usage_percent
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def _disk_io_latency_ms() -> float:
+    """Best-effort disk I/O latency estimate (ms)."""
+    try:
+        from openbad.interoception.disk_network import sample_disk_io
+
+        snap = sample_disk_io()
+        return snap.latency_ms
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def _process_count() -> int:
+    """Number of running processes."""
+    if platform.system() == "Linux":
+        try:
+            return len(os.listdir("/proc")) - 2  # rough count
+        except OSError:
+            pass
+    # Fallback: use os.cpu_count as a proxy (not great but safe).
+    return os.cpu_count() or 1
+
+
+_BOOT = time.monotonic()
+
+
+def _uptime_hours() -> float:
+    """Agent uptime in hours (since module load)."""
+    return (time.monotonic() - _BOOT) / 3600.0
+
+
+class SystemHealthPlugin(ObservationPlugin):
+    """Built-in plugin that monitors core system-health indicators."""
+
+    @property
+    def source_id(self) -> str:
+        return "system_health"
+
+    async def observe(self) -> ObservationResult:
+        return ObservationResult(
+            metrics={
+                "cpu_percent": _cpu_percent(),
+                "memory_percent": _memory_percent(),
+                "disk_io_latency_ms": _disk_io_latency_ms(),
+                "process_count": _process_count(),
+                "uptime_hours": _uptime_hours(),
+            },
+        )
+
+    def default_predictions(self) -> dict[str, dict[str, float]]:
+        return {
+            "cpu_percent": {"expected": 30.0, "tolerance": 20.0},
+            "memory_percent": {"expected": 50.0, "tolerance": 15.0},
+            "disk_io_latency_ms": {"expected": 5.0, "tolerance": 10.0},
+            "process_count": {"expected": 150.0, "tolerance": 50.0},
+            "uptime_hours": {"expected": 1.0, "tolerance": 24.0},
+        }
+
+    @property
+    def poll_interval_seconds(self) -> int:
+        return 30

--- a/tests/test_system_health_plugin.py
+++ b/tests/test_system_health_plugin.py
@@ -1,0 +1,81 @@
+"""Tests for the system health observation plugin."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from openbad.active_inference.plugin_interface import ObservationPlugin, ObservationResult
+from openbad.plugins.observations.system_health import SystemHealthPlugin
+
+
+class TestSystemHealthPlugin:
+    def test_implements_abc(self) -> None:
+        p = SystemHealthPlugin()
+        assert isinstance(p, ObservationPlugin)
+
+    def test_source_id(self) -> None:
+        assert SystemHealthPlugin().source_id == "system_health"
+
+    def test_poll_interval(self) -> None:
+        assert SystemHealthPlugin().poll_interval_seconds == 30
+
+    async def test_observe_returns_result(self) -> None:
+        p = SystemHealthPlugin()
+        with (
+            patch(
+                "openbad.plugins.observations.system_health._cpu_percent",
+                return_value=42.0,
+            ),
+            patch(
+                "openbad.plugins.observations.system_health._memory_percent",
+                return_value=65.0,
+            ),
+            patch(
+                "openbad.plugins.observations.system_health._disk_io_latency_ms",
+                return_value=3.0,
+            ),
+            patch(
+                "openbad.plugins.observations.system_health._process_count",
+                return_value=200,
+            ),
+            patch(
+                "openbad.plugins.observations.system_health._uptime_hours",
+                return_value=1.5,
+            ),
+        ):
+            r = await p.observe()
+
+        assert isinstance(r, ObservationResult)
+        assert r.metrics["cpu_percent"] == 42.0
+        assert r.metrics["memory_percent"] == 65.0
+        assert r.metrics["disk_io_latency_ms"] == 3.0
+        assert r.metrics["process_count"] == 200
+        assert r.metrics["uptime_hours"] == 1.5
+
+    def test_default_predictions_keys(self) -> None:
+        preds = SystemHealthPlugin().default_predictions()
+        expected_keys = {
+            "cpu_percent",
+            "memory_percent",
+            "disk_io_latency_ms",
+            "process_count",
+            "uptime_hours",
+        }
+        assert set(preds.keys()) == expected_keys
+
+    def test_default_predictions_structure(self) -> None:
+        preds = SystemHealthPlugin().default_predictions()
+        for _metric, vals in preds.items():
+            assert "expected" in vals
+            assert "tolerance" in vals
+            assert vals["tolerance"] > 0
+
+    async def test_observe_handles_collector_failure(self) -> None:
+        """_cpu_percent catches exceptions from the underlying collector."""
+        with patch(
+            "openbad.interoception.monitor.collect_cpu",
+            side_effect=RuntimeError("boom"),
+        ):
+            from openbad.plugins.observations.system_health import _cpu_percent
+
+            assert _cpu_percent() == 0.0


### PR DESCRIPTION
Closes #138

## Summary
- `src/openbad/plugins/observations/system_health.py` — `SystemHealthPlugin` implementing `ObservationPlugin` ABC
- Monitors CPU%, memory%, disk I/O latency, process count, uptime
- Reuses interoception `collect_cpu`/`collect_memory` where available, graceful fallback on failure
- Conservative default predictions (cpu 30±20, memory 50±15, etc.)

## How to test
```bash
pytest tests/test_system_health_plugin.py -v
```
7 tests pass.