### PR TITLE
#139: World model with self-calibrating EMA and surprise calculator

### DIFF
--- a/src/openbad/active_inference/surprise.py
+++ b/src/openbad/active_inference/surprise.py
@@ -1,0 +1,22 @@
+"""Surprise calculator — normalized prediction error."""
+
+from __future__ import annotations
+
+
+def compute_surprise(
+    observed: float,
+    expected: float,
+    tolerance: float,
+) -> float:
+    """Return normalised surprise in ``[0.0, 1.0]``.
+
+    ``surprise = min(|observed - expected| / max(tolerance, 1e-6), 1.0)``
+    """
+    return min(abs(observed - expected) / max(tolerance, 1e-6), 1.0)
+
+
+def aggregate_surprise(errors: dict[str, float]) -> float:
+    """Return the maximum surprise across all metrics."""
+    if not errors:
+        return 0.0
+    return max(errors.values())

--- a/src/openbad/active_inference/world_model.py
+++ b/src/openbad/active_inference/world_model.py
@@ -1,0 +1,160 @@
+"""World model — prediction store with self-calibrating EMA."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class PredictionEntry:
+    """A single metric's prediction state."""
+
+    source_id: str
+    metric_name: str
+    expected_value: float
+    tolerance: float
+    prediction_error: float = 0.0
+    last_updated: float = field(default_factory=time.monotonic)
+    _history: deque[float] = field(
+        default_factory=lambda: deque(maxlen=20),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "source_id": self.source_id,
+            "metric_name": self.metric_name,
+            "expected_value": self.expected_value,
+            "tolerance": self.tolerance,
+            "prediction_error": self.prediction_error,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> PredictionEntry:
+        return cls(
+            source_id=d["source_id"],
+            metric_name=d["metric_name"],
+            expected_value=d["expected_value"],
+            tolerance=d["tolerance"],
+            prediction_error=d.get("prediction_error", 0.0),
+        )
+
+
+class WorldModel:
+    """Tracks expected values per source/metric with EMA self-calibration."""
+
+    def __init__(
+        self,
+        history_size: int = 20,
+        ema_alpha: float = 0.1,
+    ) -> None:
+        self._predictions: dict[str, PredictionEntry] = {}
+        self._history_size = history_size
+        self._alpha = ema_alpha
+
+    # -- Key helpers ------------------------------------------------------- #
+
+    @staticmethod
+    def _key(source_id: str, metric_name: str) -> str:
+        return f"{source_id}:{metric_name}"
+
+    # -- Registration ------------------------------------------------------ #
+
+    def register_source(
+        self,
+        source_id: str,
+        defaults: dict[str, dict[str, float]],
+    ) -> None:
+        """Seed predictions from a plugin's ``default_predictions()``."""
+        for metric_name, vals in defaults.items():
+            key = self._key(source_id, metric_name)
+            if key not in self._predictions:
+                self._predictions[key] = PredictionEntry(
+                    source_id=source_id,
+                    metric_name=metric_name,
+                    expected_value=vals["expected"],
+                    tolerance=vals["tolerance"],
+                    _history=deque(maxlen=self._history_size),
+                )
+
+    # -- Update ------------------------------------------------------------ #
+
+    def update(
+        self,
+        source_id: str,
+        metrics: dict[str, float | int | str],
+    ) -> dict[str, float]:
+        """Incorporate new observations and return per-metric prediction errors."""
+        errors: dict[str, float] = {}
+        for metric_name, observed in metrics.items():
+            if not isinstance(observed, (int, float)):
+                continue
+            key = self._key(source_id, metric_name)
+            entry = self._predictions.get(key)
+            if entry is None:
+                # Auto-register with loose tolerance.
+                entry = PredictionEntry(
+                    source_id=source_id,
+                    metric_name=metric_name,
+                    expected_value=float(observed),
+                    tolerance=abs(float(observed)) * 0.5 + 1.0,
+                    _history=deque(maxlen=self._history_size),
+                )
+                self._predictions[key] = entry
+
+            val = float(observed)
+            error = abs(val - entry.expected_value) / max(entry.tolerance, 1e-6)
+            entry.prediction_error = min(error, 1.0)
+            errors[metric_name] = entry.prediction_error
+
+            # EMA update for expected value.
+            entry.expected_value += self._alpha * (val - entry.expected_value)
+
+            # Adjust tolerance from observed variance.
+            entry._history.append(val)
+            if len(entry._history) >= 2:
+                mean = sum(entry._history) / len(entry._history)
+                var = sum((x - mean) ** 2 for x in entry._history) / len(
+                    entry._history,
+                )
+                std = math.sqrt(var)
+                # Tolerance = 2 × std, with a floor of 1.0.
+                entry.tolerance += self._alpha * (max(2.0 * std, 1.0) - entry.tolerance)
+
+            entry.last_updated = time.monotonic()
+
+        return errors
+
+    # -- Queries ----------------------------------------------------------- #
+
+    def get_predictions(self, source_id: str) -> list[PredictionEntry]:
+        """Return all predictions for a source."""
+        return [e for e in self._predictions.values() if e.source_id == source_id]
+
+    def get_entry(self, source_id: str, metric_name: str) -> PredictionEntry | None:
+        return self._predictions.get(self._key(source_id, metric_name))
+
+    def reset_errors(self) -> None:
+        """Reset all prediction errors to zero (post-consolidation)."""
+        for entry in self._predictions.values():
+            entry.prediction_error = 0.0
+
+    # -- Persistence ------------------------------------------------------- #
+
+    def persist(self, path: Path) -> None:
+        """Save world model state to a JSON file."""
+        data = [e.to_dict() for e in self._predictions.values()]
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def load(self, path: Path) -> None:
+        """Load world model state from a JSON file."""
+        if not path.exists():
+            return
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        for d in raw:
+            key = self._key(d["source_id"], d["metric_name"])
+            self._predictions[key] = PredictionEntry.from_dict(d)

--- a/tests/test_surprise.py
+++ b/tests/test_surprise.py
@@ -1,0 +1,41 @@
+"""Tests for the surprise calculator."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.active_inference.surprise import aggregate_surprise, compute_surprise
+
+
+class TestComputeSurprise:
+    def test_zero_surprise(self) -> None:
+        assert compute_surprise(50.0, 50.0, 10.0) == 0.0
+
+    def test_half_surprise(self) -> None:
+        assert compute_surprise(55.0, 50.0, 10.0) == pytest.approx(0.5)
+
+    def test_full_surprise(self) -> None:
+        assert compute_surprise(60.0, 50.0, 10.0) == pytest.approx(1.0)
+
+    def test_capped_at_one(self) -> None:
+        assert compute_surprise(100.0, 0.0, 10.0) == 1.0
+
+    def test_zero_tolerance_safe(self) -> None:
+        # Should not divide by zero; uses 1e-6 floor.
+        result = compute_surprise(1.0, 0.0, 0.0)
+        assert result == 1.0
+
+    def test_negative_direction(self) -> None:
+        assert compute_surprise(40.0, 50.0, 10.0) == pytest.approx(1.0)
+
+
+class TestAggregateSurprise:
+    def test_empty(self) -> None:
+        assert aggregate_surprise({}) == 0.0
+
+    def test_max_value(self) -> None:
+        errors = {"a": 0.2, "b": 0.8, "c": 0.5}
+        assert aggregate_surprise(errors) == pytest.approx(0.8)
+
+    def test_single(self) -> None:
+        assert aggregate_surprise({"x": 0.3}) == pytest.approx(0.3)

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -1,0 +1,128 @@
+"""Tests for the world model prediction store."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.active_inference.world_model import PredictionEntry, WorldModel
+
+
+class TestPredictionEntry:
+    def test_to_dict_round_trip(self) -> None:
+        e = PredictionEntry(
+            source_id="s", metric_name="m",
+            expected_value=10.0, tolerance=5.0,
+            prediction_error=0.3,
+        )
+        d = e.to_dict()
+        restored = PredictionEntry.from_dict(d)
+        assert restored.expected_value == 10.0
+        assert restored.tolerance == 5.0
+        assert restored.prediction_error == pytest.approx(0.3)
+
+
+class TestWorldModelRegistration:
+    def test_register_source(self) -> None:
+        wm = WorldModel()
+        wm.register_source("sys", {"cpu": {"expected": 30.0, "tolerance": 20.0}})
+        entries = wm.get_predictions("sys")
+        assert len(entries) == 1
+        assert entries[0].metric_name == "cpu"
+
+    def test_register_idempotent(self) -> None:
+        wm = WorldModel()
+        wm.register_source("sys", {"cpu": {"expected": 30.0, "tolerance": 20.0}})
+        wm.update("sys", {"cpu": 50.0})
+        # Re-register should NOT overwrite updated entry.
+        wm.register_source("sys", {"cpu": {"expected": 30.0, "tolerance": 20.0}})
+        e = wm.get_entry("sys", "cpu")
+        assert e is not None
+        assert e.expected_value != 30.0  # EMA shifted it
+
+
+class TestWorldModelUpdate:
+    def test_prediction_error(self) -> None:
+        wm = WorldModel()
+        wm.register_source("sys", {"cpu": {"expected": 30.0, "tolerance": 20.0}})
+        errors = wm.update("sys", {"cpu": 50.0})
+        # |50 - 30| / 20 = 1.0
+        assert errors["cpu"] == pytest.approx(1.0)
+
+    def test_prediction_error_capped_at_1(self) -> None:
+        wm = WorldModel()
+        wm.register_source("sys", {"cpu": {"expected": 30.0, "tolerance": 5.0}})
+        errors = wm.update("sys", {"cpu": 100.0})
+        assert errors["cpu"] == 1.0
+
+    def test_ema_convergence(self) -> None:
+        wm = WorldModel(ema_alpha=0.3)
+        wm.register_source("sys", {"cpu": {"expected": 0.0, "tolerance": 50.0}})
+        # Feed constant value — expected should converge toward it.
+        for _ in range(30):
+            wm.update("sys", {"cpu": 50.0})
+        e = wm.get_entry("sys", "cpu")
+        assert e is not None
+        assert e.expected_value == pytest.approx(50.0, abs=1.0)
+
+    def test_tolerance_adjusts_from_variance(self) -> None:
+        wm = WorldModel(ema_alpha=0.3, history_size=10)
+        wm.register_source("sys", {"cpu": {"expected": 50.0, "tolerance": 1.0}})
+        # Feed highly variable data.
+        for v in [10, 90, 20, 80, 30, 70, 40, 60, 50, 50]:
+            wm.update("sys", {"cpu": float(v)})
+        e = wm.get_entry("sys", "cpu")
+        assert e is not None
+        assert e.tolerance > 1.0  # Tolerance grew from variance
+
+    def test_auto_register_unknown_metric(self) -> None:
+        wm = WorldModel()
+        errors = wm.update("sys", {"new_metric": 42.0})
+        assert "new_metric" in errors
+        e = wm.get_entry("sys", "new_metric")
+        assert e is not None
+
+    def test_skips_non_numeric(self) -> None:
+        wm = WorldModel()
+        errors = wm.update("sys", {"label": "ok"})
+        assert errors == {}
+
+    def test_ring_buffer_size(self) -> None:
+        wm = WorldModel(history_size=5)
+        wm.register_source("sys", {"cpu": {"expected": 0.0, "tolerance": 50.0}})
+        for i in range(10):
+            wm.update("sys", {"cpu": float(i)})
+        e = wm.get_entry("sys", "cpu")
+        assert e is not None
+        assert len(e._history) == 5
+
+
+class TestWorldModelResetErrors:
+    def test_reset(self) -> None:
+        wm = WorldModel()
+        wm.register_source("sys", {"cpu": {"expected": 30.0, "tolerance": 20.0}})
+        wm.update("sys", {"cpu": 80.0})
+        wm.reset_errors()
+        e = wm.get_entry("sys", "cpu")
+        assert e is not None
+        assert e.prediction_error == 0.0
+
+
+class TestWorldModelPersistence:
+    def test_persist_and_load(self, tmp_path) -> None:
+        wm = WorldModel()
+        wm.register_source("sys", {"cpu": {"expected": 30.0, "tolerance": 20.0}})
+        wm.update("sys", {"cpu": 45.0})
+
+        path = tmp_path / "world.json"
+        wm.persist(path)
+
+        wm2 = WorldModel()
+        wm2.load(path)
+        e = wm2.get_entry("sys", "cpu")
+        assert e is not None
+        assert e.expected_value == pytest.approx(31.5, abs=0.1)
+
+    def test_load_nonexistent(self, tmp_path) -> None:
+        wm = WorldModel()
+        wm.load(tmp_path / "missing.json")
+        assert wm.get_predictions("any") == []


### PR DESCRIPTION
Closes #139

## Summary
- `world_model.py` — `PredictionEntry` dataclass, `WorldModel` with EMA self-calibration (alpha=0.1), ring buffer history, auto-registration, JSON persistence
- `surprise.py` — `compute_surprise()` normalized prediction error, `aggregate_surprise()` max across metrics

## How to test
```bash
pytest tests/test_world_model.py tests/test_surprise.py -v
```
22 tests pass.