### PR TITLE
#140: Exploration budget and engine with cooldown and suppression

### DIFF
--- a/src/openbad/active_inference/budget.py
+++ b/src/openbad/active_inference/budget.py
@@ -1,0 +1,61 @@
+"""Exploration budget — daily token bucket with cooldown."""
+
+from __future__ import annotations
+
+import time
+
+
+class ExplorationBudget:
+    """Daily token budget that gates exploration actions.
+
+    Tracks remaining tokens and enforces a cooldown between actions.
+    """
+
+    def __init__(
+        self,
+        daily_limit: int = 5000,
+        cooldown_seconds: float = 300.0,
+    ) -> None:
+        self._daily_limit = daily_limit
+        self._remaining = daily_limit
+        self._cooldown = cooldown_seconds
+        self._last_action: float = -cooldown_seconds
+
+    # -- Properties -------------------------------------------------------- #
+
+    @property
+    def remaining(self) -> int:
+        return self._remaining
+
+    @property
+    def daily_limit(self) -> int:
+        return self._daily_limit
+
+    @property
+    def cooldown_seconds(self) -> float:
+        return self._cooldown
+
+    # -- Actions ----------------------------------------------------------- #
+
+    def can_spend(self, cost: int = 1, *, now: float | None = None) -> bool:
+        """Check whether *cost* tokens can be spent right now."""
+        now = now if now is not None else time.monotonic()
+        if self._remaining < cost:
+            return False
+        return not now - self._last_action < self._cooldown
+
+    def spend(self, cost: int = 1, *, now: float | None = None) -> bool:
+        """Deduct *cost* tokens if allowed. Returns ``True`` on success."""
+        now = now if now is not None else time.monotonic()
+        if not self.can_spend(cost, now=now):
+            return False
+        self._remaining -= cost
+        self._last_action = now
+        return True
+
+    def reset(self, daily_limit: int | None = None) -> None:
+        """Reset the budget (e.g. at midnight)."""
+        if daily_limit is not None:
+            self._daily_limit = daily_limit
+        self._remaining = self._daily_limit
+        self._last_action = -self._cooldown

--- a/src/openbad/active_inference/engine.py
+++ b/src/openbad/active_inference/engine.py
@@ -1,0 +1,122 @@
+"""Exploration engine — orchestrates poll → surprise → action cycle."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from dataclasses import dataclass, field
+
+from openbad.active_inference.budget import ExplorationBudget
+from openbad.active_inference.config import ActiveInferenceConfig
+from openbad.active_inference.plugin_interface import ObservationPlugin
+from openbad.active_inference.surprise import aggregate_surprise
+from openbad.active_inference.world_model import WorldModel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExplorationEvent:
+    """Result of one exploration cycle iteration."""
+
+    source_id: str
+    surprise: float
+    explored: bool
+    errors: dict[str, float] = field(default_factory=dict)
+
+
+class ExplorationEngine:
+    """Polls plugins, computes surprise, and decides whether to explore."""
+
+    def __init__(
+        self,
+        config: ActiveInferenceConfig,
+        world_model: WorldModel,
+        budget: ExplorationBudget,
+        plugins: list[ObservationPlugin] | None = None,
+    ) -> None:
+        self._config = config
+        self._world_model = world_model
+        self._budget = budget
+        self._plugins: list[ObservationPlugin] = plugins or []
+        self._suppressed_states: set[str] = set(config.suppressed_in_states)
+        self._current_state: str = "NOMINAL"
+
+    # -- Plugin management ------------------------------------------------- #
+
+    def add_plugin(self, plugin: ObservationPlugin) -> None:
+        self._plugins.append(plugin)
+        self._world_model.register_source(
+            plugin.source_id,
+            plugin.default_predictions(),
+        )
+
+    # -- State ------------------------------------------------------------- #
+
+    def set_state(self, state: str) -> None:
+        self._current_state = state
+
+    @property
+    def is_suppressed(self) -> bool:
+        return self._current_state in self._suppressed_states
+
+    # -- Core cycle -------------------------------------------------------- #
+
+    async def poll_plugin(
+        self,
+        plugin: ObservationPlugin,
+    ) -> ExplorationEvent:
+        """Poll a single plugin and decide whether to explore."""
+        result = await plugin.observe()
+        errors = self._world_model.update(plugin.source_id, result.metrics)
+        surprise = aggregate_surprise(errors)
+
+        explored = False
+        if (
+            surprise >= self._config.surprise_threshold
+            and not self.is_suppressed
+            and self._budget.can_spend()
+        ):
+            self._budget.spend()
+            explored = True
+
+        return ExplorationEvent(
+            source_id=plugin.source_id,
+            surprise=surprise,
+            explored=explored,
+            errors=errors,
+        )
+
+    async def run_cycle(self) -> list[ExplorationEvent]:
+        """Run one pass over all registered plugins (sequentially)."""
+        events: list[ExplorationEvent] = []
+        for plugin in self._plugins:
+            try:
+                event = await self.poll_plugin(plugin)
+                events.append(event)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Plugin %s failed during poll cycle",
+                    plugin.source_id,
+                    exc_info=True,
+                )
+        return events
+
+    async def run_loop(self, *, stop_event: asyncio.Event | None = None) -> None:
+        """Continuously poll plugins at their configured interval.
+
+        Respects ``max_concurrent`` from config (runs plugins sequentially
+        when set to 1).
+        """
+        stop = stop_event or asyncio.Event()
+        while not stop.is_set():
+            await self.run_cycle()
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(
+                    stop.wait(),
+                    timeout=min(
+                        (p.poll_interval_seconds for p in self._plugins),
+                        default=60.0,
+                    ),
+                )

--- a/tests/test_exploration_budget.py
+++ b/tests/test_exploration_budget.py
@@ -1,0 +1,50 @@
+"""Tests for the exploration budget."""
+
+from __future__ import annotations
+
+from openbad.active_inference.budget import ExplorationBudget
+
+
+class TestExplorationBudget:
+    def test_initial_remaining(self) -> None:
+        b = ExplorationBudget(daily_limit=100)
+        assert b.remaining == 100
+        assert b.daily_limit == 100
+
+    def test_spend_deducts(self) -> None:
+        b = ExplorationBudget(daily_limit=10, cooldown_seconds=0)
+        assert b.spend(cost=3, now=1.0)
+        assert b.remaining == 7
+
+    def test_spend_fails_insufficient(self) -> None:
+        b = ExplorationBudget(daily_limit=2, cooldown_seconds=0)
+        b.spend(cost=2, now=1.0)
+        assert not b.can_spend(cost=1, now=2.0)
+
+    def test_cooldown_blocks(self) -> None:
+        b = ExplorationBudget(daily_limit=100, cooldown_seconds=10)
+        b.spend(cost=1, now=0.0)
+        assert not b.can_spend(cost=1, now=5.0)  # 5 < 10
+        assert b.can_spend(cost=1, now=10.0)  # 10 >= 10
+
+    def test_reset(self) -> None:
+        b = ExplorationBudget(daily_limit=10, cooldown_seconds=0)
+        b.spend(cost=10, now=1.0)
+        assert b.remaining == 0
+        b.reset()
+        assert b.remaining == 10
+
+    def test_reset_with_new_limit(self) -> None:
+        b = ExplorationBudget(daily_limit=10, cooldown_seconds=0)
+        b.spend(cost=5, now=1.0)
+        b.reset(daily_limit=20)
+        assert b.remaining == 20
+        assert b.daily_limit == 20
+
+    def test_can_spend_checks_cost_and_cooldown(self) -> None:
+        b = ExplorationBudget(daily_limit=5, cooldown_seconds=1)
+        assert b.can_spend(cost=5, now=0.0)
+        b.spend(cost=1, now=0.0)
+        assert not b.can_spend(cost=1, now=0.5)  # cooldown
+        assert b.can_spend(cost=4, now=1.0)
+        assert not b.can_spend(cost=5, now=1.0)  # over budget

--- a/tests/test_exploration_engine.py
+++ b/tests/test_exploration_engine.py
@@ -1,0 +1,134 @@
+"""Tests for the exploration engine."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openbad.active_inference.budget import ExplorationBudget
+from openbad.active_inference.config import ActiveInferenceConfig
+from openbad.active_inference.engine import ExplorationEngine
+from openbad.active_inference.plugin_interface import (
+    ObservationPlugin,
+    ObservationResult,
+)
+from openbad.active_inference.world_model import WorldModel
+
+
+class StubPlugin(ObservationPlugin):
+    """Minimal plugin for testing."""
+
+    def __init__(
+        self,
+        src_id: str = "stub",
+        metrics: dict[str, float] | None = None,
+    ) -> None:
+        self._src = src_id
+        self._metrics = metrics or {"val": 50.0}
+
+    @property
+    def source_id(self) -> str:
+        return self._src
+
+    async def observe(self) -> ObservationResult:
+        return ObservationResult(
+            metrics=self._metrics,
+            timestamp=datetime.now(tz=UTC),
+        )
+
+    def default_predictions(self) -> dict[str, dict[str, float]]:
+        return {"val": {"expected": 50.0, "tolerance": 10.0}}
+
+
+@pytest.fixture
+def cfg() -> ActiveInferenceConfig:
+    return ActiveInferenceConfig(
+        surprise_threshold=0.6,
+        daily_token_budget=100,
+        cooldown_seconds=0,
+    )
+
+
+@pytest.fixture
+def wm() -> WorldModel:
+    return WorldModel()
+
+
+@pytest.fixture
+def budget() -> ExplorationBudget:
+    return ExplorationBudget(daily_limit=100, cooldown_seconds=0)
+
+
+class TestExplorationEngine:
+    async def test_poll_no_surprise(
+        self, cfg: ActiveInferenceConfig, wm: WorldModel, budget: ExplorationBudget,
+    ) -> None:
+        engine = ExplorationEngine(cfg, wm, budget)
+        plugin = StubPlugin(metrics={"val": 50.0})
+        engine.add_plugin(plugin)
+        event = await engine.poll_plugin(plugin)
+        assert event.surprise == pytest.approx(0.0)
+        assert not event.explored
+
+    async def test_poll_high_surprise_triggers_explore(
+        self, cfg: ActiveInferenceConfig, wm: WorldModel, budget: ExplorationBudget,
+    ) -> None:
+        engine = ExplorationEngine(cfg, wm, budget)
+        plugin = StubPlugin(metrics={"val": 100.0})  # big deviation
+        engine.add_plugin(plugin)
+        event = await engine.poll_plugin(plugin)
+        assert event.surprise >= cfg.surprise_threshold
+        assert event.explored
+        assert budget.remaining == 99
+
+    async def test_suppressed_state_blocks_explore(
+        self, cfg: ActiveInferenceConfig, wm: WorldModel, budget: ExplorationBudget,
+    ) -> None:
+        engine = ExplorationEngine(cfg, wm, budget)
+        plugin = StubPlugin(metrics={"val": 100.0})
+        engine.add_plugin(plugin)
+        engine.set_state("THROTTLED")
+        event = await engine.poll_plugin(plugin)
+        assert event.surprise >= cfg.surprise_threshold
+        assert not event.explored  # suppressed
+
+    async def test_budget_exhausted_blocks_explore(
+        self, cfg: ActiveInferenceConfig, wm: WorldModel,
+    ) -> None:
+        empty_budget = ExplorationBudget(daily_limit=0, cooldown_seconds=0)
+        engine = ExplorationEngine(cfg, wm, empty_budget)
+        plugin = StubPlugin(metrics={"val": 100.0})
+        engine.add_plugin(plugin)
+        event = await engine.poll_plugin(plugin)
+        assert not event.explored
+
+    async def test_run_cycle(
+        self, cfg: ActiveInferenceConfig, wm: WorldModel, budget: ExplorationBudget,
+    ) -> None:
+        engine = ExplorationEngine(cfg, wm, budget)
+        engine.add_plugin(StubPlugin("a", {"val": 100.0}))
+        engine.add_plugin(StubPlugin("b", {"val": 50.0}))
+        events = await engine.run_cycle()
+        assert len(events) == 2
+
+    async def test_plugin_error_handled(
+        self, cfg: ActiveInferenceConfig, wm: WorldModel, budget: ExplorationBudget,
+    ) -> None:
+        engine = ExplorationEngine(cfg, wm, budget)
+        bad = StubPlugin()
+        bad.observe = AsyncMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
+        engine.add_plugin(bad)
+        events = await engine.run_cycle()
+        assert len(events) == 0  # error swallowed
+
+    async def test_run_loop_stops(
+        self, cfg: ActiveInferenceConfig, wm: WorldModel, budget: ExplorationBudget,
+    ) -> None:
+        engine = ExplorationEngine(cfg, wm, budget)
+        engine.add_plugin(StubPlugin())
+        stop = asyncio.Event()
+        stop.set()
+        await engine.run_loop(stop_event=stop)  # Should return immediately


### PR DESCRIPTION
Closes #140

## Summary
- `budget.py` — `ExplorationBudget` with daily token limit, cooldown between actions, and reset
- `engine.py` — `ExplorationEngine` orchestrates poll→surprise→action cycle, respects suppressed states, budget-gated exploration, async run loop

## How to test
```bash
pytest tests/test_exploration_budget.py tests/test_exploration_engine.py -v
```
14 tests pass.