### PR TITLE
#143: Dopamine hooks for positive-outcome triggers

### DIFF
--- a/src/openbad/endocrine/hooks/__init__.py
+++ b/src/openbad/endocrine/hooks/__init__.py
@@ -1,0 +1,1 @@
+"""Endocrine hooks sub-package."""

--- a/src/openbad/endocrine/hooks/dopamine.py
+++ b/src/openbad/endocrine/hooks/dopamine.py
@@ -1,0 +1,60 @@
+"""Dopamine hooks — map positive outcomes to dopamine triggers.
+
+Dopamine fires when the system achieves something positive:
+- Task completion
+- Successful exploration (surprise resolved)
+- Positive user feedback
+- Learning (world model improvement)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from openbad.endocrine.controller import EndocrineController
+
+
+@dataclass
+class DopamineEvent:
+    """Describes a dopamine-triggering event."""
+
+    source: str
+    reason: str
+    intensity: float = 1.0  # multiplier on configured increment
+
+
+class DopamineHooks:
+    """Translates positive-outcome events into dopamine triggers."""
+
+    def __init__(self, controller: EndocrineController) -> None:
+        self._controller = controller
+
+    def on_task_complete(self, task_id: str = "") -> float:
+        """Fire dopamine for a completed task."""
+        return self._controller.trigger("dopamine")
+
+    def on_exploration_success(self, surprise_delta: float = 0.0) -> float:
+        """Fire dopamine when exploration resolves surprise."""
+        amount = self._controller._config.dopamine.increment  # noqa: SLF001
+        if surprise_delta > 0:
+            amount *= min(1.0 + surprise_delta, 2.0)
+        return self._controller.trigger("dopamine", amount)
+
+    def on_positive_feedback(self) -> float:
+        """Fire dopamine from positive user feedback."""
+        amount = self._controller._config.dopamine.increment * 1.5  # noqa: SLF001
+        return self._controller.trigger("dopamine", amount)
+
+    def on_learning(self, improvement: float = 0.0) -> float:
+        """Fire dopamine when the world model improves."""
+        amount = self._controller._config.dopamine.increment  # noqa: SLF001
+        if improvement > 0:
+            amount *= min(1.0 + improvement, 1.5)
+        return self._controller.trigger("dopamine", amount)
+
+    def fire(self, event: DopamineEvent) -> float:
+        """Generic dopamine trigger from a ``DopamineEvent``."""
+        amount = (
+            self._controller._config.dopamine.increment * event.intensity  # noqa: SLF001
+        )
+        return self._controller.trigger("dopamine", amount)

--- a/tests/test_dopamine_hooks.py
+++ b/tests/test_dopamine_hooks.py
@@ -1,0 +1,80 @@
+"""Tests for dopamine hooks."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.endocrine.controller import EndocrineController
+from openbad.endocrine.hooks.dopamine import DopamineEvent, DopamineHooks
+
+
+@pytest.fixture
+def controller() -> EndocrineController:
+    return EndocrineController()
+
+
+@pytest.fixture
+def hooks(controller: EndocrineController) -> DopamineHooks:
+    return DopamineHooks(controller)
+
+
+class TestDopamineHooks:
+    def test_on_task_complete(
+        self, hooks: DopamineHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_task_complete("task-1")
+        assert level > 0.0
+        assert controller.level("dopamine") == level
+
+    def test_on_exploration_success_base(
+        self, hooks: DopamineHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_exploration_success(surprise_delta=0.0)
+        assert level == pytest.approx(
+            controller._config.dopamine.increment,  # noqa: SLF001
+        )
+
+    def test_on_exploration_success_scaled(
+        self, hooks: DopamineHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_exploration_success(surprise_delta=0.5)
+        base = controller._config.dopamine.increment  # noqa: SLF001
+        # 0.15 * 1.5 = 0.225
+        assert level == pytest.approx(base * 1.5)
+
+    def test_on_positive_feedback(
+        self, hooks: DopamineHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_positive_feedback()
+        base = controller._config.dopamine.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 1.5)
+
+    def test_on_learning(
+        self, hooks: DopamineHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_learning(improvement=0.3)
+        base = controller._config.dopamine.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 1.3)
+
+    def test_fire_generic(
+        self, hooks: DopamineHooks, controller: EndocrineController,
+    ) -> None:
+        event = DopamineEvent(source="test", reason="manual", intensity=2.0)
+        level = hooks.fire(event)
+        base = controller._config.dopamine.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 2.0)
+
+    def test_multiple_triggers_additive(
+        self, hooks: DopamineHooks, controller: EndocrineController,
+    ) -> None:
+        hooks.on_task_complete()
+        hooks.on_task_complete()
+        base = controller._config.dopamine.increment  # noqa: SLF001
+        assert controller.level("dopamine") == pytest.approx(base * 2)
+
+    def test_level_clamped_at_one(
+        self, hooks: DopamineHooks, controller: EndocrineController,
+    ) -> None:
+        for _ in range(20):
+            hooks.on_task_complete()
+        assert controller.level("dopamine") <= 1.0


### PR DESCRIPTION
Closes #143

## Summary
- `hooks/dopamine.py` — `DopamineHooks` with `on_task_complete()`, `on_exploration_success()`, `on_positive_feedback()`, `on_learning()`, `fire()` generic
- `DopamineEvent` dataclass for custom triggers with intensity multiplier
- All hooks map to `EndocrineController.trigger("dopamine", ...)`

## How to test
```bash
pytest tests/test_dopamine_hooks.py -v
```
8 tests pass.