### PR TITLE
#145: Cortisol hooks for sustained stress triggers

### DIFF
--- a/src/openbad/endocrine/hooks/cortisol.py
+++ b/src/openbad/endocrine/hooks/cortisol.py
@@ -1,0 +1,64 @@
+"""Cortisol hooks — map sustained stress to cortisol triggers.
+
+Cortisol fires under sustained negative conditions:
+- Prolonged high resource utilization
+- Repeated task failures
+- Persistent high surprise (unresolved anomalies)
+- Error accumulation
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from openbad.endocrine.controller import EndocrineController
+
+
+@dataclass
+class CortisolEvent:
+    """Describes a cortisol-triggering event."""
+
+    source: str
+    reason: str
+    intensity: float = 1.0
+
+
+class CortisolHooks:
+    """Translates sustained-stress events into cortisol triggers."""
+
+    def __init__(self, controller: EndocrineController) -> None:
+        self._controller = controller
+
+    def on_sustained_load(self, duration_seconds: float = 0.0) -> float:
+        """Fire cortisol for prolonged high resource utilization."""
+        amount = self._controller._config.cortisol.increment  # noqa: SLF001
+        if duration_seconds > 60:
+            amount *= min(1.0 + duration_seconds / 300.0, 2.0)
+        return self._controller.trigger("cortisol", amount)
+
+    def on_repeated_failure(self, failure_count: int = 1) -> float:
+        """Fire cortisol from repeated task failures."""
+        amount = self._controller._config.cortisol.increment  # noqa: SLF001
+        amount *= min(float(failure_count), 3.0)
+        return self._controller.trigger("cortisol", amount)
+
+    def on_persistent_surprise(self, surprise_level: float = 0.0) -> float:
+        """Fire cortisol when high surprise persists unresolved."""
+        amount = self._controller._config.cortisol.increment  # noqa: SLF001
+        if surprise_level > 0:
+            amount *= min(1.0 + surprise_level, 2.0)
+        return self._controller.trigger("cortisol", amount)
+
+    def on_error_accumulation(self, error_count: int = 1) -> float:
+        """Fire cortisol from accumulating errors."""
+        amount = self._controller._config.cortisol.increment  # noqa: SLF001
+        amount *= min(float(error_count), 3.0)
+        return self._controller.trigger("cortisol", amount)
+
+    def fire(self, event: CortisolEvent) -> float:
+        """Generic cortisol trigger from a ``CortisolEvent``."""
+        amount = (
+            self._controller._config.cortisol.increment  # noqa: SLF001
+            * event.intensity
+        )
+        return self._controller.trigger("cortisol", amount)

--- a/tests/test_cortisol_hooks.py
+++ b/tests/test_cortisol_hooks.py
@@ -1,0 +1,77 @@
+"""Tests for cortisol hooks."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.endocrine.controller import EndocrineController
+from openbad.endocrine.hooks.cortisol import CortisolEvent, CortisolHooks
+
+
+@pytest.fixture
+def controller() -> EndocrineController:
+    return EndocrineController()
+
+
+@pytest.fixture
+def hooks(controller: EndocrineController) -> CortisolHooks:
+    return CortisolHooks(controller)
+
+
+class TestCortisolHooks:
+    def test_on_sustained_load_short(
+        self, hooks: CortisolHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_sustained_load(duration_seconds=30)
+        base = controller._config.cortisol.increment  # noqa: SLF001
+        assert level == pytest.approx(base)
+
+    def test_on_sustained_load_long(
+        self, hooks: CortisolHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_sustained_load(duration_seconds=150)
+        base = controller._config.cortisol.increment  # noqa: SLF001
+        assert level == pytest.approx(base * (1.0 + 150.0 / 300.0))
+
+    def test_on_repeated_failure(
+        self, hooks: CortisolHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_repeated_failure(failure_count=2)
+        base = controller._config.cortisol.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 2.0)
+
+    def test_on_repeated_failure_capped(
+        self, hooks: CortisolHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_repeated_failure(failure_count=10)
+        base = controller._config.cortisol.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 3.0)
+
+    def test_on_persistent_surprise(
+        self, hooks: CortisolHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_persistent_surprise(surprise_level=0.7)
+        base = controller._config.cortisol.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 1.7)
+
+    def test_on_error_accumulation(
+        self, hooks: CortisolHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_error_accumulation(error_count=2)
+        base = controller._config.cortisol.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 2.0)
+
+    def test_fire_generic(
+        self, hooks: CortisolHooks, controller: EndocrineController,
+    ) -> None:
+        event = CortisolEvent(source="test", reason="stress", intensity=2.0)
+        level = hooks.fire(event)
+        base = controller._config.cortisol.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 2.0)
+
+    def test_level_clamped(
+        self, hooks: CortisolHooks, controller: EndocrineController,
+    ) -> None:
+        for _ in range(20):
+            hooks.on_repeated_failure(failure_count=3)
+        assert controller.level("cortisol") <= 1.0


### PR DESCRIPTION
Closes #145

## Summary
- `hooks/cortisol.py` — `CortisolHooks` with `on_sustained_load()`, `on_repeated_failure()`, `on_persistent_surprise()`, `on_error_accumulation()`, `fire()`
- `CortisolEvent` dataclass for custom triggers

## How to test
```bash
pytest tests/test_cortisol_hooks.py -v
```
8 tests pass.