### PR TITLE
#141: Takeaway generator for exploration insights

### DIFF
--- a/src/openbad/active_inference/takeaway.py
+++ b/src/openbad/active_inference/takeaway.py
@@ -1,0 +1,94 @@
+"""Takeaway generator — distills exploration events into actionable insights.
+
+After an exploration cycle, the takeaway generator produces a structured
+summary (a "takeaway") that can be published on MQTT for downstream consumers
+(e.g. memory consolidation, dashboard, endocrine hooks).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+from openbad.active_inference.engine import ExplorationEvent
+
+
+@dataclass
+class Takeaway:
+    """A single actionable insight from exploration."""
+
+    source_id: str
+    summary: str
+    surprise_level: float
+    metrics: dict[str, float] = field(default_factory=dict)
+    explored: bool = False
+    timestamp: float = field(default_factory=time.monotonic)
+
+    def to_dict(self) -> dict:
+        return {
+            "source_id": self.source_id,
+            "summary": self.summary,
+            "surprise_level": self.surprise_level,
+            "metrics": self.metrics,
+            "explored": self.explored,
+            "timestamp": self.timestamp,
+        }
+
+
+class TakeawayGenerator:
+    """Generates takeaways from exploration events.
+
+    A takeaway is produced when surprise exceeds *threshold* or exploration
+    was triggered.
+    """
+
+    def __init__(self, surprise_threshold: float = 0.3) -> None:
+        self._threshold = surprise_threshold
+        self._history: list[Takeaway] = []
+        self._max_history: int = 100
+
+    @property
+    def history(self) -> list[Takeaway]:
+        return list(self._history)
+
+    def process(self, events: list[ExplorationEvent]) -> list[Takeaway]:
+        """Process a batch of exploration events, return takeaways for notable ones."""
+        takeaways: list[Takeaway] = []
+        for event in events:
+            if event.surprise < self._threshold and not event.explored:
+                continue
+
+            summary = self._build_summary(event)
+            t = Takeaway(
+                source_id=event.source_id,
+                summary=summary,
+                surprise_level=event.surprise,
+                metrics=dict(event.errors),
+                explored=event.explored,
+            )
+            takeaways.append(t)
+            self._history.append(t)
+
+        # Trim history.
+        if len(self._history) > self._max_history:
+            self._history = self._history[-self._max_history :]
+
+        return takeaways
+
+    def clear_history(self) -> None:
+        self._history.clear()
+
+    @staticmethod
+    def _build_summary(event: ExplorationEvent) -> str:
+        parts: list[str] = []
+        parts.append(f"[{event.source_id}]")
+        parts.append(f"surprise={event.surprise:.2f}")
+
+        if event.explored:
+            parts.append("(explored)")
+
+        top_errors = sorted(event.errors.items(), key=lambda kv: kv[1], reverse=True)
+        for metric, error in top_errors[:3]:
+            parts.append(f"{metric}={error:.2f}")
+
+        return " ".join(parts)

--- a/tests/test_takeaway.py
+++ b/tests/test_takeaway.py
@@ -1,0 +1,129 @@
+"""Tests for the takeaway generator."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.active_inference.engine import ExplorationEvent
+from openbad.active_inference.takeaway import Takeaway, TakeawayGenerator
+
+
+class TestTakeaway:
+    def test_to_dict(self) -> None:
+        t = Takeaway(
+            source_id="sys", summary="test",
+            surprise_level=0.5, metrics={"cpu": 0.5},
+            explored=True, timestamp=1.0,
+        )
+        d = t.to_dict()
+        assert d["source_id"] == "sys"
+        assert d["explored"] is True
+        assert d["surprise_level"] == 0.5
+
+
+class TestTakeawayGenerator:
+    def test_no_takeaway_below_threshold(self) -> None:
+        gen = TakeawayGenerator(surprise_threshold=0.5)
+        events = [
+            ExplorationEvent(
+                source_id="sys", surprise=0.2,
+                explored=False, errors={"cpu": 0.2},
+            ),
+        ]
+        takeaways = gen.process(events)
+        assert takeaways == []
+
+    def test_takeaway_above_threshold(self) -> None:
+        gen = TakeawayGenerator(surprise_threshold=0.3)
+        events = [
+            ExplorationEvent(
+                source_id="sys", surprise=0.8,
+                explored=False, errors={"cpu": 0.8},
+            ),
+        ]
+        takeaways = gen.process(events)
+        assert len(takeaways) == 1
+        assert takeaways[0].source_id == "sys"
+        assert takeaways[0].surprise_level == pytest.approx(0.8)
+
+    def test_takeaway_when_explored(self) -> None:
+        gen = TakeawayGenerator(surprise_threshold=0.9)
+        events = [
+            ExplorationEvent(
+                source_id="sys", surprise=0.1,
+                explored=True, errors={"cpu": 0.1},
+            ),
+        ]
+        takeaways = gen.process(events)
+        assert len(takeaways) == 1
+        assert takeaways[0].explored is True
+
+    def test_summary_format(self) -> None:
+        gen = TakeawayGenerator(surprise_threshold=0.0)
+        events = [
+            ExplorationEvent(
+                source_id="net", surprise=0.6,
+                explored=True, errors={"latency": 0.6, "drops": 0.2},
+            ),
+        ]
+        takeaways = gen.process(events)
+        summary = takeaways[0].summary
+        assert "[net]" in summary
+        assert "surprise=0.60" in summary
+        assert "(explored)" in summary
+        assert "latency=0.60" in summary
+
+    def test_history_grows(self) -> None:
+        gen = TakeawayGenerator(surprise_threshold=0.0)
+        for i in range(5):
+            gen.process([
+                ExplorationEvent(
+                    source_id=f"s{i}", surprise=0.5,
+                    explored=False, errors={},
+                ),
+            ])
+        assert len(gen.history) == 5
+
+    def test_history_trimmed(self) -> None:
+        gen = TakeawayGenerator(surprise_threshold=0.0)
+        gen._max_history = 3
+        for i in range(5):
+            gen.process([
+                ExplorationEvent(
+                    source_id=f"s{i}", surprise=0.5,
+                    explored=False, errors={},
+                ),
+            ])
+        assert len(gen.history) == 3
+        assert gen.history[0].source_id == "s2"
+
+    def test_clear_history(self) -> None:
+        gen = TakeawayGenerator(surprise_threshold=0.0)
+        gen.process([
+            ExplorationEvent(
+                source_id="sys", surprise=0.5,
+                explored=False, errors={},
+            ),
+        ])
+        gen.clear_history()
+        assert gen.history == []
+
+    def test_multiple_events_mixed(self) -> None:
+        gen = TakeawayGenerator(surprise_threshold=0.5)
+        events = [
+            ExplorationEvent(
+                source_id="a", surprise=0.1,
+                explored=False, errors={},
+            ),
+            ExplorationEvent(
+                source_id="b", surprise=0.8,
+                explored=True, errors={"val": 0.8},
+            ),
+            ExplorationEvent(
+                source_id="c", surprise=0.3,
+                explored=False, errors={},
+            ),
+        ]
+        takeaways = gen.process(events)
+        assert len(takeaways) == 1
+        assert takeaways[0].source_id == "b"


### PR DESCRIPTION
Closes #141

## Summary
- `takeaway.py` — `Takeaway` dataclass + `TakeawayGenerator` that distills `ExplorationEvent`s into actionable insights when surprise exceeds threshold or exploration was triggered
- History management with max cap, summaries include top metric errors

## How to test
```bash
pytest tests/test_takeaway.py -v
```
9 tests pass.