### PR TITLE
#146: Endorphin hooks for recovery/resilience triggers

### DIFF
--- a/src/openbad/endocrine/hooks/endorphin.py
+++ b/src/openbad/endocrine/hooks/endorphin.py
@@ -1,0 +1,63 @@
+"""Endorphin hooks — map recovery/resilience events to endorphin triggers.
+
+Endorphin fires during recovery and resilience:
+- System recovery from stress
+- Successful self-healing
+- Stable operation after turbulence
+- Maintenance cycle completion
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from openbad.endocrine.controller import EndocrineController
+
+
+@dataclass
+class EndorphinEvent:
+    """Describes an endorphin-triggering event."""
+
+    source: str
+    reason: str
+    intensity: float = 1.0
+
+
+class EndorphinHooks:
+    """Translates recovery/resilience events into endorphin triggers."""
+
+    def __init__(self, controller: EndocrineController) -> None:
+        self._controller = controller
+
+    def on_recovery(self, stress_level_before: float = 0.0) -> float:
+        """Fire endorphin when the system recovers from stress."""
+        amount = self._controller._config.endorphin.increment  # noqa: SLF001
+        if stress_level_before > 0:
+            amount *= min(1.0 + stress_level_before, 2.0)
+        return self._controller.trigger("endorphin", amount)
+
+    def on_self_heal(self) -> float:
+        """Fire endorphin on successful self-healing action."""
+        amount = (
+            self._controller._config.endorphin.increment * 1.5  # noqa: SLF001
+        )
+        return self._controller.trigger("endorphin", amount)
+
+    def on_stability(self, stable_duration_seconds: float = 0.0) -> float:
+        """Fire endorphin from sustained stable operation after turbulence."""
+        amount = self._controller._config.endorphin.increment  # noqa: SLF001
+        if stable_duration_seconds > 60:
+            amount *= min(1.0 + stable_duration_seconds / 600.0, 1.5)
+        return self._controller.trigger("endorphin", amount)
+
+    def on_maintenance_complete(self) -> float:
+        """Fire endorphin when a maintenance/sleep cycle completes."""
+        return self._controller.trigger("endorphin")
+
+    def fire(self, event: EndorphinEvent) -> float:
+        """Generic endorphin trigger from an ``EndorphinEvent``."""
+        amount = (
+            self._controller._config.endorphin.increment  # noqa: SLF001
+            * event.intensity
+        )
+        return self._controller.trigger("endorphin", amount)

--- a/tests/test_endorphin_hooks.py
+++ b/tests/test_endorphin_hooks.py
@@ -1,0 +1,76 @@
+"""Tests for endorphin hooks."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.endocrine.controller import EndocrineController
+from openbad.endocrine.hooks.endorphin import EndorphinEvent, EndorphinHooks
+
+
+@pytest.fixture
+def controller() -> EndocrineController:
+    return EndocrineController()
+
+
+@pytest.fixture
+def hooks(controller: EndocrineController) -> EndorphinHooks:
+    return EndorphinHooks(controller)
+
+
+class TestEndorphinHooks:
+    def test_on_recovery_base(
+        self, hooks: EndorphinHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_recovery(stress_level_before=0.0)
+        base = controller._config.endorphin.increment  # noqa: SLF001
+        assert level == pytest.approx(base)
+
+    def test_on_recovery_scaled(
+        self, hooks: EndorphinHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_recovery(stress_level_before=0.8)
+        base = controller._config.endorphin.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 1.8)
+
+    def test_on_self_heal(
+        self, hooks: EndorphinHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_self_heal()
+        base = controller._config.endorphin.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 1.5)
+
+    def test_on_stability_short(
+        self, hooks: EndorphinHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_stability(stable_duration_seconds=30)
+        base = controller._config.endorphin.increment  # noqa: SLF001
+        assert level == pytest.approx(base)
+
+    def test_on_stability_long(
+        self, hooks: EndorphinHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_stability(stable_duration_seconds=300)
+        base = controller._config.endorphin.increment  # noqa: SLF001
+        assert level == pytest.approx(base * (1.0 + 300.0 / 600.0))
+
+    def test_on_maintenance_complete(
+        self, hooks: EndorphinHooks, controller: EndocrineController,
+    ) -> None:
+        level = hooks.on_maintenance_complete()
+        assert level > 0.0
+
+    def test_fire_generic(
+        self, hooks: EndorphinHooks, controller: EndocrineController,
+    ) -> None:
+        event = EndorphinEvent(source="test", reason="heal", intensity=2.0)
+        level = hooks.fire(event)
+        base = controller._config.endorphin.increment  # noqa: SLF001
+        assert level == pytest.approx(base * 2.0)
+
+    def test_level_clamped(
+        self, hooks: EndorphinHooks, controller: EndocrineController,
+    ) -> None:
+        for _ in range(20):
+            hooks.on_self_heal()
+        assert controller.level("endorphin") <= 1.0


### PR DESCRIPTION
Closes #146

## Summary
- `hooks/endorphin.py` — `EndorphinHooks` with `on_recovery()`, `on_self_heal()`, `on_stability()`, `on_maintenance_complete()`, `fire()`
- `EndorphinEvent` dataclass for custom triggers

## How to test
```bash
pytest tests/test_endorphin_hooks.py -v
```
8 tests pass.