### PR TITLE
#147: Endocrine telemetry and observability

### DIFF
--- a/src/openbad/endocrine/telemetry.py
+++ b/src/openbad/endocrine/telemetry.py
@@ -1,0 +1,174 @@
+"""Endocrine telemetry — observability for the hormone subsystem."""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass, field
+
+from openbad.endocrine.controller import HORMONES, EndocrineController
+
+
+@dataclass
+class HormoneChangeEvent:
+    """A logged change to a hormone level."""
+
+    hormone: str
+    old_level: float
+    new_level: float
+    trigger_event: str
+    timestamp: float = field(default_factory=time.monotonic)
+
+
+@dataclass
+class HormoneStats:
+    """Aggregate statistics for a single hormone over a tracking window."""
+
+    activation_count: int = 0
+    escalation_count: int = 0
+    total_time_above_threshold: float = 0.0
+    last_trigger_time: float | None = None
+
+
+class EndocrineTelemetry:
+    """Collects, logs, and reports on endocrine system activity.
+
+    Wraps an :class:`EndocrineController` and observes every ``trigger``
+    call that produces a level change above *min_change_delta*.
+    """
+
+    def __init__(
+        self,
+        controller: EndocrineController,
+        *,
+        min_change_delta: float = 0.05,
+        max_history: int = 200,
+    ) -> None:
+        self._controller = controller
+        self._min_delta = min_change_delta
+        self._max_history = max_history
+        self._change_log: deque[HormoneChangeEvent] = deque(maxlen=max_history)
+        self._stats: dict[str, HormoneStats] = {h: HormoneStats() for h in HORMONES}
+        self._last_snapshot: dict[str, float] = {h: 0.0 for h in HORMONES}
+        self._last_snapshot_time: float = time.monotonic()
+
+    # -- Recording --------------------------------------------------------- #
+
+    def record_trigger(
+        self,
+        hormone: str,
+        old_level: float,
+        new_level: float,
+        trigger_event: str = "",
+    ) -> None:
+        """Log a hormone change if it exceeds the minimum delta."""
+        delta = abs(new_level - old_level)
+        if delta < self._min_delta:
+            return
+
+        evt = HormoneChangeEvent(
+            hormone=hormone,
+            old_level=old_level,
+            new_level=new_level,
+            trigger_event=trigger_event,
+        )
+        self._change_log.append(evt)
+        self._stats[hormone].last_trigger_time = evt.timestamp
+
+    def update_activation_stats(self) -> None:
+        """Update activation/escalation counters based on current controller state.
+
+        Should be called periodically (e.g. after each decay tick).
+        """
+        now = time.monotonic()
+        dt = now - self._last_snapshot_time
+
+        for hormone in HORMONES:
+            stats = self._stats[hormone]
+            if self._controller.is_active(hormone):
+                stats.total_time_above_threshold += dt
+                # Count transitions from below to above threshold.
+                cfg = self._controller._hormone_config(hormone)  # noqa: SLF001
+                prev = self._last_snapshot[hormone]
+                curr = self._controller.level(hormone)
+                if prev <= cfg.activation_threshold < curr:
+                    stats.activation_count += 1
+            if self._controller.is_escalated(hormone):
+                cfg = self._controller._hormone_config(hormone)  # noqa: SLF001
+                if (
+                    cfg.escalation_threshold is not None
+                    and self._last_snapshot[hormone]
+                    <= cfg.escalation_threshold
+                    < self._controller.level(hormone)
+                ):
+                    stats.escalation_count += 1
+
+            self._last_snapshot[hormone] = self._controller.level(hormone)
+
+        self._last_snapshot_time = now
+
+    # -- Status ------------------------------------------------------------ #
+
+    def status(self) -> dict:
+        """Build a status report of the full endocrine system."""
+        now = time.monotonic()
+        state = self._controller.get_state()
+        report: dict = {
+            "levels": state.to_dict(),
+            "hormones": {},
+        }
+        for hormone in HORMONES:
+            stats = self._stats[hormone]
+            entry: dict = {
+                "level": getattr(state, hormone),
+                "active": self._controller.is_active(hormone),
+                "escalated": self._controller.is_escalated(hormone),
+                "time_above_threshold": round(stats.total_time_above_threshold, 2),
+                "activation_count": stats.activation_count,
+                "escalation_count": stats.escalation_count,
+            }
+            if stats.last_trigger_time is not None:
+                entry["seconds_since_last_trigger"] = round(now - stats.last_trigger_time, 2)
+            else:
+                entry["seconds_since_last_trigger"] = None
+
+            # Recent changes for this hormone.
+            entry["recent_changes"] = [
+                {
+                    "old": round(e.old_level, 4),
+                    "new": round(e.new_level, 4),
+                    "trigger": e.trigger_event,
+                }
+                for e in self._change_log
+                if e.hormone == hormone
+            ][-5:]  # Last 5 changes.
+
+            report["hormones"][hormone] = entry
+
+        return report
+
+    def summary(self) -> dict:
+        """Compact summary suitable for MQTT publishing."""
+        state = self._controller.get_state()
+        return {
+            "levels": state.to_dict(),
+            "stats": {
+                h: {
+                    "activations": self._stats[h].activation_count,
+                    "escalations": self._stats[h].escalation_count,
+                    "time_above": round(self._stats[h].total_time_above_threshold, 2),
+                }
+                for h in HORMONES
+            },
+        }
+
+    @property
+    def change_log(self) -> list[HormoneChangeEvent]:
+        return list(self._change_log)
+
+    def reset(self) -> None:
+        """Clear all telemetry data."""
+        self._change_log.clear()
+        self._stats = {h: HormoneStats() for h in HORMONES}
+        self._last_snapshot = {h: 0.0 for h in HORMONES}
+        self._last_snapshot_time = time.monotonic()

--- a/tests/test_endocrine_telemetry.py
+++ b/tests/test_endocrine_telemetry.py
@@ -1,0 +1,153 @@
+"""Tests for endocrine telemetry."""
+
+from __future__ import annotations
+
+import time
+
+from openbad.endocrine.config import EndocrineConfig, HormoneConfig
+from openbad.endocrine.controller import HORMONES, EndocrineController
+from openbad.endocrine.telemetry import EndocrineTelemetry
+
+
+def _make_controller(**overrides: HormoneConfig) -> EndocrineController:
+    cfg = EndocrineConfig(**overrides)
+    return EndocrineController(config=cfg)
+
+
+class TestRecordTrigger:
+    def test_logs_above_delta(self) -> None:
+        ctrl = _make_controller()
+        telemetry = EndocrineTelemetry(ctrl, min_change_delta=0.05)
+        telemetry.record_trigger("dopamine", 0.0, 0.15, "task_complete")
+        assert len(telemetry.change_log) == 1
+        assert telemetry.change_log[0].hormone == "dopamine"
+        assert telemetry.change_log[0].trigger_event == "task_complete"
+
+    def test_ignores_below_delta(self) -> None:
+        ctrl = _make_controller()
+        telemetry = EndocrineTelemetry(ctrl, min_change_delta=0.05)
+        telemetry.record_trigger("dopamine", 0.0, 0.02, "tiny")
+        assert len(telemetry.change_log) == 0
+
+    def test_history_capped(self) -> None:
+        ctrl = _make_controller()
+        telemetry = EndocrineTelemetry(ctrl, max_history=3)
+        for i in range(5):
+            telemetry.record_trigger("dopamine", 0.0, 0.2 + i * 0.01, f"evt-{i}")
+        assert len(telemetry.change_log) == 3
+        assert telemetry.change_log[0].trigger_event == "evt-2"
+
+    def test_updates_last_trigger_time(self) -> None:
+        ctrl = _make_controller()
+        telemetry = EndocrineTelemetry(ctrl)
+        telemetry.record_trigger("cortisol", 0.0, 0.15, "load")
+        assert telemetry._stats["cortisol"].last_trigger_time is not None
+
+
+class TestActivationStats:
+    def test_counts_activation_crossing(self) -> None:
+        ctrl = _make_controller(
+            dopamine=HormoneConfig(
+                activation_threshold=0.40,
+                half_life_seconds=300.0,
+            ),
+        )
+        telemetry = EndocrineTelemetry(ctrl)
+        # Snapshot starts at 0. Trigger pushes dopamine above 0.40.
+        ctrl.trigger("dopamine", 0.50)
+        telemetry.update_activation_stats()
+        assert telemetry._stats["dopamine"].activation_count == 1
+
+    def test_no_double_count_when_still_active(self) -> None:
+        ctrl = _make_controller(
+            dopamine=HormoneConfig(
+                activation_threshold=0.40,
+                half_life_seconds=300.0,
+            ),
+        )
+        telemetry = EndocrineTelemetry(ctrl)
+        ctrl.trigger("dopamine", 0.50)
+        telemetry.update_activation_stats()
+        # Still above threshold — should not increment again.
+        ctrl.trigger("dopamine", 0.10)
+        telemetry.update_activation_stats()
+        assert telemetry._stats["dopamine"].activation_count == 1
+
+    def test_tracks_time_above_threshold(self) -> None:
+        ctrl = _make_controller(
+            dopamine=HormoneConfig(
+                activation_threshold=0.30,
+                half_life_seconds=600.0,
+            ),
+        )
+        telemetry = EndocrineTelemetry(ctrl)
+        ctrl.trigger("dopamine", 0.50)
+        # Fake time advance by manipulating snapshot time.
+        telemetry._last_snapshot_time = time.monotonic() - 2.0
+        telemetry.update_activation_stats()
+        assert telemetry._stats["dopamine"].total_time_above_threshold >= 1.5
+
+    def test_counts_escalation_crossing(self) -> None:
+        ctrl = _make_controller(
+            adrenaline=HormoneConfig(
+                activation_threshold=0.30,
+                escalation_threshold=0.70,
+                half_life_seconds=60.0,
+            ),
+        )
+        telemetry = EndocrineTelemetry(ctrl)
+        ctrl.trigger("adrenaline", 0.80)
+        telemetry.update_activation_stats()
+        assert telemetry._stats["adrenaline"].escalation_count == 1
+
+
+class TestStatus:
+    def test_status_contains_all_hormones(self) -> None:
+        ctrl = _make_controller()
+        telemetry = EndocrineTelemetry(ctrl)
+        status = telemetry.status()
+        assert "levels" in status
+        for h in HORMONES:
+            assert h in status["hormones"]
+            assert "level" in status["hormones"][h]
+            assert "active" in status["hormones"][h]
+            assert "recent_changes" in status["hormones"][h]
+
+    def test_status_shows_recent_changes(self) -> None:
+        ctrl = _make_controller()
+        telemetry = EndocrineTelemetry(ctrl)
+        telemetry.record_trigger("dopamine", 0.0, 0.20, "test1")
+        telemetry.record_trigger("dopamine", 0.20, 0.40, "test2")
+        status = telemetry.status()
+        changes = status["hormones"]["dopamine"]["recent_changes"]
+        assert len(changes) == 2
+        assert changes[0]["trigger"] == "test1"
+
+    def test_seconds_since_last_trigger_none_when_never(self) -> None:
+        ctrl = _make_controller()
+        telemetry = EndocrineTelemetry(ctrl)
+        status = telemetry.status()
+        assert status["hormones"]["dopamine"]["seconds_since_last_trigger"] is None
+
+
+class TestSummary:
+    def test_summary_structure(self) -> None:
+        ctrl = _make_controller()
+        telemetry = EndocrineTelemetry(ctrl)
+        s = telemetry.summary()
+        assert "levels" in s
+        assert "stats" in s
+        for h in HORMONES:
+            assert h in s["stats"]
+            assert "activations" in s["stats"][h]
+            assert "escalations" in s["stats"][h]
+
+
+class TestReset:
+    def test_reset_clears_all(self) -> None:
+        ctrl = _make_controller()
+        telemetry = EndocrineTelemetry(ctrl)
+        telemetry.record_trigger("dopamine", 0.0, 0.20, "test")
+        telemetry.reset()
+        assert len(telemetry.change_log) == 0
+        assert telemetry._stats["dopamine"].activation_count == 0


### PR DESCRIPTION
Closes #147

## Summary
- `telemetry.py` — `EndocrineTelemetry` wrapping `EndocrineController`
- `HormoneChangeEvent` log with configurable min delta
- `update_activation_stats()` — tracks activation/escalation crossings, time above threshold
- `status()` — full report with levels, counters, recent changes, time since trigger
- `summary()` — compact dict for MQTT publishing to `agent/endocrine/telemetry`

## How to test
```bash
pytest tests/test_endocrine_telemetry.py -v
```
13 tests pass.