### PR TITLE
#148: L2HR mapper — language to hierarchical rewards

### DIFF
--- a/src/openbad/endocrine/l2hr.py
+++ b/src/openbad/endocrine/l2hr.py
@@ -1,0 +1,186 @@
+"""L2HR mapper — language to hierarchical rewards.
+
+Translates natural-language task outcomes into hormone adjustments
+using a keyword-based heuristic classifier, with optional SLM override.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class HormoneAdjustment:
+    """A set of hormone deltas to apply."""
+
+    dopamine: float = 0.0
+    adrenaline: float = 0.0
+    cortisol: float = 0.0
+    endorphin: float = 0.0
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "dopamine": self.dopamine,
+            "adrenaline": self.adrenaline,
+            "cortisol": self.cortisol,
+            "endorphin": self.endorphin,
+        }
+
+    def is_zero(self) -> bool:
+        return all(
+            v == 0.0
+            for v in (self.dopamine, self.adrenaline, self.cortisol, self.endorphin)
+        )
+
+
+# Default keyword → category mapping.
+_DEFAULT_KEYWORDS: dict[str, list[str]] = {
+    "success": [
+        "success", "resolved", "completed", "fixed", "solved",
+        "correct", "accomplished", "achieved", "passed",
+    ],
+    "failure": [
+        "failed", "error", "timeout", "retry", "retries",
+        "crash", "exception", "broken", "unable",
+    ],
+    "threat": [
+        "injection", "attack", "threat", "malicious", "exploit",
+        "quarantine", "vulnerability", "breach", "suspicious",
+    ],
+    "urgency": [
+        "urgent", "escalat", "critical", "emergency", "immediate",
+        "deadline", "priority", "asap",
+    ],
+    "recovery": [
+        "recover", "heal", "restored", "stabiliz", "resilient",
+        "bounced back", "normalized",
+    ],
+}
+
+# Default adjustments per category — deliberately smaller than direct hooks.
+_DEFAULT_ADJUSTMENTS: dict[str, HormoneAdjustment] = {
+    "success": HormoneAdjustment(dopamine=0.10),
+    "failure": HormoneAdjustment(dopamine=-0.05, cortisol=0.10),
+    "threat": HormoneAdjustment(dopamine=0.10, endorphin=0.10, adrenaline=0.10),
+    "urgency": HormoneAdjustment(adrenaline=0.20),
+    "recovery": HormoneAdjustment(endorphin=0.10, dopamine=0.05),
+}
+
+
+@dataclass
+class L2HRConfig:
+    """Configuration for the L2HR mapper."""
+
+    keywords: dict[str, list[str]] = field(
+        default_factory=lambda: {k: list(v) for k, v in _DEFAULT_KEYWORDS.items()},
+    )
+    adjustments: dict[str, HormoneAdjustment] = field(
+        default_factory=lambda: dict(_DEFAULT_ADJUSTMENTS),
+    )
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> L2HRConfig:
+        """Load L2HR config from YAML."""
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        data = raw.get("l2hr", raw)
+
+        keywords = dict(_DEFAULT_KEYWORDS)
+        if "keywords" in data and isinstance(data["keywords"], dict):
+            for cat, words in data["keywords"].items():
+                if isinstance(words, list):
+                    keywords[cat] = [str(w) for w in words]
+
+        adjustments = dict(_DEFAULT_ADJUSTMENTS)
+        if "adjustments" in data and isinstance(data["adjustments"], dict):
+            for cat, vals in data["adjustments"].items():
+                if isinstance(vals, dict):
+                    adjustments[cat] = HormoneAdjustment(**{
+                        k: float(v)
+                        for k, v in vals.items()
+                        if k in HormoneAdjustment.__dataclass_fields__
+                    })
+
+        return cls(keywords=keywords, adjustments=adjustments)
+
+
+ClassifyFn = Callable[[str], str | None]
+
+
+class L2HRMapper:
+    """Maps natural-language outcomes to hormone adjustments.
+
+    Parameters
+    ----------
+    config
+        Keyword/adjustment configuration. Uses defaults if not provided.
+    classify_fn
+        Optional SLM-based classifier callback. Takes a text string,
+        returns a category name (matching a key in adjustments) or ``None``.
+        When provided, takes priority over keyword matching.
+    """
+
+    def __init__(
+        self,
+        config: L2HRConfig | None = None,
+        classify_fn: ClassifyFn | None = None,
+    ) -> None:
+        self._config = config or L2HRConfig()
+        self._classify_fn = classify_fn
+        self._compiled: dict[str, re.Pattern[str]] = {}
+        self._compile_patterns()
+
+    def _compile_patterns(self) -> None:
+        """Pre-compile keyword regexes for each category."""
+        for category, words in self._config.keywords.items():
+            pattern = "|".join(re.escape(w) for w in words)
+            self._compiled[category] = re.compile(pattern, re.IGNORECASE)
+
+    def classify(self, text: str) -> str | None:
+        """Classify *text* into a category.
+
+        Uses *classify_fn* if provided, otherwise falls back to keyword matching.
+        Returns ``None`` if no category matches.
+        """
+        if self._classify_fn is not None:
+            result = self._classify_fn(text)
+            if result is not None:
+                return result
+
+        for category, pattern in self._compiled.items():
+            if pattern.search(text):
+                return category
+        return None
+
+    def map(self, text: str) -> HormoneAdjustment:
+        """Map a natural-language outcome to hormone adjustments.
+
+        Returns a zero adjustment if the text doesn't match any category.
+        """
+        category = self.classify(text)
+        if category is None:
+            return HormoneAdjustment()
+        return self._config.adjustments.get(category, HormoneAdjustment())
+
+    def map_all(self, text: str) -> list[tuple[str, HormoneAdjustment]]:
+        """Return adjustments for *all* matching categories.
+
+        Useful when an outcome spans multiple categories (e.g. threat + success).
+        """
+        results: list[tuple[str, HormoneAdjustment]] = []
+        if self._classify_fn is not None:
+            cat = self._classify_fn(text)
+            if cat is not None and cat in self._config.adjustments:
+                results.append((cat, self._config.adjustments[cat]))
+
+        for category, pattern in self._compiled.items():
+            if pattern.search(text) and category not in {r[0] for r in results}:
+                adj = self._config.adjustments.get(category)
+                if adj is not None:
+                    results.append((category, adj))
+
+        return results

--- a/tests/test_l2hr.py
+++ b/tests/test_l2hr.py
@@ -1,0 +1,169 @@
+"""Tests for the L2HR mapper."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from openbad.endocrine.l2hr import (
+    HormoneAdjustment,
+    L2HRConfig,
+    L2HRMapper,
+)
+
+
+class TestHormoneAdjustment:
+    def test_to_dict(self) -> None:
+        adj = HormoneAdjustment(dopamine=0.1, cortisol=0.05)
+        d = adj.to_dict()
+        assert d["dopamine"] == pytest.approx(0.1)
+        assert d["adrenaline"] == pytest.approx(0.0)
+
+    def test_is_zero(self) -> None:
+        assert HormoneAdjustment().is_zero()
+        assert not HormoneAdjustment(dopamine=0.01).is_zero()
+
+
+class TestKeywordClassification:
+    def test_success_keywords(self) -> None:
+        mapper = L2HRMapper()
+        assert mapper.classify("Successfully resolved the user's question") == "success"
+        assert mapper.classify("Task completed without errors") == "success"
+
+    def test_failure_keywords(self) -> None:
+        mapper = L2HRMapper()
+        assert mapper.classify("Failed after 3 retries") == "failure"
+        assert mapper.classify("Operation timed out with error") == "failure"
+
+    def test_threat_keywords(self) -> None:
+        mapper = L2HRMapper()
+        assert mapper.classify("Detected and quarantined a prompt injection") == "threat"
+
+    def test_urgency_keywords(self) -> None:
+        mapper = L2HRMapper()
+        assert mapper.classify("User escalated urgency") == "urgency"
+
+    def test_recovery_keywords(self) -> None:
+        mapper = L2HRMapper()
+        assert mapper.classify("System recovered from overload") == "recovery"
+
+    def test_no_match_returns_none(self) -> None:
+        mapper = L2HRMapper()
+        assert mapper.classify("The weather is nice today") is None
+
+
+class TestAdjustmentMapping:
+    def test_success_adjustment(self) -> None:
+        mapper = L2HRMapper()
+        adj = mapper.map("Successfully resolved the user's question")
+        assert adj.dopamine == pytest.approx(0.10)
+        assert adj.adrenaline == pytest.approx(0.0)
+
+    def test_failure_adjustment(self) -> None:
+        mapper = L2HRMapper()
+        adj = mapper.map("Failed after 3 retries")
+        assert adj.dopamine == pytest.approx(-0.05)
+        assert adj.cortisol == pytest.approx(0.10)
+
+    def test_threat_adjustment(self) -> None:
+        mapper = L2HRMapper()
+        adj = mapper.map("Detected and quarantined a prompt injection")
+        assert adj.dopamine == pytest.approx(0.10)
+        assert adj.endorphin == pytest.approx(0.10)
+
+    def test_urgency_adjustment(self) -> None:
+        mapper = L2HRMapper()
+        adj = mapper.map("User escalated urgency")
+        assert adj.adrenaline == pytest.approx(0.20)
+
+    def test_no_match_returns_zero(self) -> None:
+        mapper = L2HRMapper()
+        adj = mapper.map("Nothing special here")
+        assert adj.is_zero()
+
+    def test_adjustments_smaller_than_direct_hooks(self) -> None:
+        """L2HR adjustments should be smaller than direct hook increments (0.15+)."""
+        mapper = L2HRMapper()
+        for _cat, adj in mapper._config.adjustments.items():
+            for h in ("dopamine", "adrenaline", "cortisol", "endorphin"):
+                val = getattr(adj, h)
+                # All values should be < 0.25 (max direct hook increment).
+                assert abs(val) <= 0.20
+
+
+class TestMapAll:
+    def test_single_category(self) -> None:
+        mapper = L2HRMapper()
+        results = mapper.map_all("Task completed successfully")
+        assert len(results) == 1
+        assert results[0][0] == "success"
+
+    def test_multi_category(self) -> None:
+        mapper = L2HRMapper()
+        text = "Detected injection attack and quarantined it successfully"
+        results = mapper.map_all(text)
+        categories = {r[0] for r in results}
+        assert "threat" in categories
+        assert "success" in categories
+
+
+class TestCustomClassifyFn:
+    def test_custom_fn_overrides_keywords(self) -> None:
+        def custom_fn(text: str) -> str | None:
+            if "special" in text.lower():
+                return "success"
+            return None
+
+        mapper = L2HRMapper(classify_fn=custom_fn)
+        assert mapper.classify("This is special") == "success"
+
+    def test_custom_fn_fallback_to_keywords(self) -> None:
+        def custom_fn(_text: str) -> str | None:
+            return None
+
+        mapper = L2HRMapper(classify_fn=custom_fn)
+        assert mapper.classify("Failed after 3 retries") == "failure"
+
+
+class TestYAMLConfig:
+    def test_override_keywords(self, tmp_path: Path) -> None:
+        yaml_content = textwrap.dedent("""\
+            l2hr:
+              keywords:
+                success:
+                  - nailed
+                  - crushed
+              adjustments:
+                success:
+                  dopamine: 0.20
+        """)
+        yml = tmp_path / "l2hr.yaml"
+        yml.write_text(yaml_content, encoding="utf-8")
+
+        config = L2HRConfig.from_yaml(yml)
+        mapper = L2HRMapper(config=config)
+        assert mapper.classify("We crushed it") == "success"
+        adj = mapper.map("We nailed it")
+        assert adj.dopamine == pytest.approx(0.20)
+
+    def test_default_categories_preserved(self, tmp_path: Path) -> None:
+        yaml_content = textwrap.dedent("""\
+            l2hr:
+              keywords:
+                custom_category:
+                  - wow
+              adjustments:
+                custom_category:
+                  dopamine: 0.05
+        """)
+        yml = tmp_path / "l2hr.yaml"
+        yml.write_text(yaml_content, encoding="utf-8")
+
+        config = L2HRConfig.from_yaml(yml)
+        mapper = L2HRMapper(config=config)
+        # Default categories should still work.
+        assert mapper.classify("Failed retries") == "failure"
+        # Custom category should work too.
+        assert mapper.classify("wow this is great") == "custom_category"


### PR DESCRIPTION
Closes #148

## Summary
- `l2hr.py` — `L2HRMapper` with keyword-based heuristic classifier
- `HormoneAdjustment` dataclass for structured deltas
- 5 default categories: success, failure, threat, urgency, recovery
- Optional `classify_fn` callback for SLM-based classification
- `map_all()` for multi-category outcomes
- YAML-configurable keywords and adjustments
- All adjustments deliberately smaller than direct hook increments

## How to test
```bash
pytest tests/test_l2hr.py -v
```
20 tests pass.