### PR TITLE
#150: Example observation plugin templates

### DIFF
--- a/src/openbad/plugins/observations/examples/__init__.py
+++ b/src/openbad/plugins/observations/examples/__init__.py
@@ -1,0 +1,6 @@
+"""Example observation plugin templates.
+
+These plugins demonstrate how to implement the ``ObservationPlugin``
+ABC for common data sources.  They are importable but NOT registered
+by default — copy and adapt for your own integrations.
+"""

--- a/src/openbad/plugins/observations/examples/browser_history.py
+++ b/src/openbad/plugins/observations/examples/browser_history.py
@@ -1,0 +1,66 @@
+"""Browser history observation plugin template.
+
+Setup Instructions
+==================
+1. Close the browser (or copy the history database) to avoid SQLite locks.
+2. Set ``BROWSER_HISTORY_PATH`` to the history database location:
+   - **Chrome** (Linux): ``~/.config/google-chrome/Default/History``
+   - **Chrome** (macOS): ``~/Library/Application Support/Google/Chrome/Default/History``
+   - **Firefox**: ``~/.mozilla/firefox/<profile>/places.sqlite``
+
+Required Permissions
+====================
+- Read access to the browser history SQLite database.
+
+Expected Metrics
+================
+- ``visits_last_hour``: Number of page visits in the last hour.
+- ``unique_domains_last_hour``: Distinct domains visited in the last hour.
+- ``total_visits_today``: Total visits since midnight.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from openbad.active_inference.plugin_interface import ObservationPlugin, ObservationResult
+
+
+class BrowserHistoryPlugin(ObservationPlugin):
+    """Observe browsing activity via SQLite history database.
+
+    This is a **template** — real SQLite queries are stubbed.  Replace the
+    body of :pymethod:`observe` with actual ``sqlite3`` queries against the
+    browser's history database.
+    """
+
+    @property
+    def source_id(self) -> str:
+        return "browser_history"
+
+    @property
+    def poll_interval_seconds(self) -> int:
+        return 300  # 5 minutes
+
+    async def observe(self) -> ObservationResult:
+        # TODO: Replace with real SQLite query.
+        # Example (Chrome):
+        #   conn = sqlite3.connect(history_path)
+        #   cursor = conn.execute(
+        #       "SELECT COUNT(*) FROM urls WHERE last_visit_time > ?", (cutoff,)
+        #   )
+        return ObservationResult(
+            metrics={
+                "visits_last_hour": 0,
+                "unique_domains_last_hour": 0,
+                "total_visits_today": 0,
+            },
+            timestamp=datetime.now(UTC),
+        )
+
+    def default_predictions(self) -> dict[str, dict[str, float]]:
+        return {
+            "visits_last_hour": {"expected": 20.0, "tolerance": 30.0},
+            "unique_domains_last_hour": {"expected": 5.0, "tolerance": 10.0},
+            "total_visits_today": {"expected": 100.0, "tolerance": 100.0},
+        }

--- a/src/openbad/plugins/observations/examples/calendar_google.py
+++ b/src/openbad/plugins/observations/examples/calendar_google.py
@@ -1,0 +1,62 @@
+"""Google Calendar observation plugin template.
+
+Setup Instructions
+==================
+1. Create a Google Cloud project and enable the Calendar API.
+2. Create OAuth 2.0 credentials (Desktop app type).
+3. Download ``credentials.json`` and place it in a secure location.
+4. Set the ``GCAL_CREDENTIALS_PATH`` environment variable.
+
+Required Permissions
+====================
+- ``https://www.googleapis.com/auth/calendar.readonly``
+
+Expected Metrics
+================
+- ``upcoming_events_1h``: Number of events starting in the next hour.
+- ``upcoming_events_24h``: Number of events starting in the next 24 hours.
+- ``free_blocks_today``: Number of free 30-min blocks remaining today.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from openbad.active_inference.plugin_interface import ObservationPlugin, ObservationResult
+
+
+class GoogleCalendarPlugin(ObservationPlugin):
+    """Observe Google Calendar schedule density.
+
+    This is a **template** — real API calls are stubbed.  Replace the body
+    of :pymethod:`observe` with actual ``google-api-python-client`` calls.
+    """
+
+    @property
+    def source_id(self) -> str:
+        return "calendar_google"
+
+    @property
+    def poll_interval_seconds(self) -> int:
+        return 600  # 10 minutes
+
+    async def observe(self) -> ObservationResult:
+        # TODO: Replace with real Calendar API call.
+        # Example:
+        #   service = build("calendar", "v3", credentials=creds)
+        #   events = service.events().list(calendarId="primary", ...).execute()
+        return ObservationResult(
+            metrics={
+                "upcoming_events_1h": 0,
+                "upcoming_events_24h": 0,
+                "free_blocks_today": 16,
+            },
+            timestamp=datetime.now(UTC),
+        )
+
+    def default_predictions(self) -> dict[str, dict[str, float]]:
+        return {
+            "upcoming_events_1h": {"expected": 0.5, "tolerance": 2.0},
+            "upcoming_events_24h": {"expected": 4.0, "tolerance": 5.0},
+            "free_blocks_today": {"expected": 10.0, "tolerance": 6.0},
+        }

--- a/src/openbad/plugins/observations/examples/email_gmail.py
+++ b/src/openbad/plugins/observations/examples/email_gmail.py
@@ -1,0 +1,63 @@
+"""Gmail observation plugin template.
+
+Setup Instructions
+==================
+1. Create a Google Cloud project and enable the Gmail API.
+2. Create OAuth 2.0 credentials (Desktop app type).
+3. Download ``credentials.json`` and place it in a secure location.
+4. Set the ``GMAIL_CREDENTIALS_PATH`` environment variable.
+5. On first run the plugin will open a browser for OAuth consent.
+
+Required Permissions
+====================
+- ``https://www.googleapis.com/auth/gmail.readonly``
+
+Expected Metrics
+================
+- ``unread_count``: Number of unread messages in the inbox.
+- ``inbox_total``: Total number of messages in the inbox.
+- ``latest_timestamp_hours``: Hours since the most recent message.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from openbad.active_inference.plugin_interface import ObservationPlugin, ObservationResult
+
+
+class GmailObservationPlugin(ObservationPlugin):
+    """Observe Gmail inbox state via the Gmail API.
+
+    This is a **template** — real API calls are stubbed.  Replace the body
+    of :pymethod:`observe` with actual ``google-api-python-client`` calls.
+    """
+
+    @property
+    def source_id(self) -> str:
+        return "email_gmail"
+
+    @property
+    def poll_interval_seconds(self) -> int:
+        return 300  # 5 minutes
+
+    async def observe(self) -> ObservationResult:
+        # TODO: Replace with real Gmail API call.
+        # Example:
+        #   service = build("gmail", "v1", credentials=creds)
+        #   results = service.users().messages().list(userId="me", q="is:unread").execute()
+        return ObservationResult(
+            metrics={
+                "unread_count": 0,
+                "inbox_total": 0,
+                "latest_timestamp_hours": 0.0,
+            },
+            timestamp=datetime.now(UTC),
+        )
+
+    def default_predictions(self) -> dict[str, dict[str, float]]:
+        return {
+            "unread_count": {"expected": 5.0, "tolerance": 10.0},
+            "inbox_total": {"expected": 100.0, "tolerance": 50.0},
+            "latest_timestamp_hours": {"expected": 1.0, "tolerance": 4.0},
+        }

--- a/src/openbad/plugins/observations/examples/journal_filesystem.py
+++ b/src/openbad/plugins/observations/examples/journal_filesystem.py
@@ -1,0 +1,63 @@
+"""File system journal observation plugin template.
+
+Setup Instructions
+==================
+1. Set ``JOURNAL_WATCH_DIR`` to the directory to monitor.
+2. The plugin counts new/modified files and total directory size.
+
+Required Permissions
+====================
+- Read access to the watched directory.
+
+Expected Metrics
+================
+- ``files_modified_last_hour``: Files created or modified in the last hour.
+- ``total_files``: Total number of files in the directory.
+- ``total_size_mb``: Total directory size in megabytes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from openbad.active_inference.plugin_interface import ObservationPlugin, ObservationResult
+
+
+class JournalFilesystemPlugin(ObservationPlugin):
+    """Observe file system changes in a watched directory.
+
+    This is a **template** — real filesystem scanning is stubbed.
+    Replace the body of :pymethod:`observe` with actual ``os.scandir``
+    or ``pathlib`` directory walks.
+    """
+
+    @property
+    def source_id(self) -> str:
+        return "journal_filesystem"
+
+    @property
+    def poll_interval_seconds(self) -> int:
+        return 120  # 2 minutes
+
+    async def observe(self) -> ObservationResult:
+        # TODO: Replace with real directory scanning.
+        # Example:
+        #   from pathlib import Path
+        #   watch_dir = Path(os.environ["JOURNAL_WATCH_DIR"])
+        #   files = list(watch_dir.rglob("*"))
+        #   total_size = sum(f.stat().st_size for f in files if f.is_file())
+        return ObservationResult(
+            metrics={
+                "files_modified_last_hour": 0,
+                "total_files": 0,
+                "total_size_mb": 0.0,
+            },
+            timestamp=datetime.now(UTC),
+        )
+
+    def default_predictions(self) -> dict[str, dict[str, float]]:
+        return {
+            "files_modified_last_hour": {"expected": 2.0, "tolerance": 5.0},
+            "total_files": {"expected": 50.0, "tolerance": 50.0},
+            "total_size_mb": {"expected": 100.0, "tolerance": 100.0},
+        }

--- a/tests/test_example_plugins.py
+++ b/tests/test_example_plugins.py
@@ -1,0 +1,62 @@
+"""Tests for example observation plugin templates."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.active_inference.plugin_interface import ObservationPlugin, ObservationResult
+from openbad.plugins.observations.examples.browser_history import BrowserHistoryPlugin
+from openbad.plugins.observations.examples.calendar_google import GoogleCalendarPlugin
+from openbad.plugins.observations.examples.email_gmail import GmailObservationPlugin
+from openbad.plugins.observations.examples.journal_filesystem import (
+    JournalFilesystemPlugin,
+)
+
+ALL_PLUGINS = [
+    GmailObservationPlugin,
+    GoogleCalendarPlugin,
+    BrowserHistoryPlugin,
+    JournalFilesystemPlugin,
+]
+
+
+class TestABCCompliance:
+    @pytest.mark.parametrize("cls", ALL_PLUGINS, ids=lambda c: c.__name__)
+    def test_is_observation_plugin(self, cls: type) -> None:
+        assert issubclass(cls, ObservationPlugin)
+
+    @pytest.mark.parametrize("cls", ALL_PLUGINS, ids=lambda c: c.__name__)
+    def test_has_source_id(self, cls: type) -> None:
+        plugin = cls()
+        assert isinstance(plugin.source_id, str)
+        assert len(plugin.source_id) > 0
+
+    @pytest.mark.parametrize("cls", ALL_PLUGINS, ids=lambda c: c.__name__)
+    def test_has_poll_interval(self, cls: type) -> None:
+        plugin = cls()
+        assert isinstance(plugin.poll_interval_seconds, int)
+        assert plugin.poll_interval_seconds > 0
+
+    @pytest.mark.parametrize("cls", ALL_PLUGINS, ids=lambda c: c.__name__)
+    async def test_observe_returns_result(self, cls: type) -> None:
+        plugin = cls()
+        result = await plugin.observe()
+        assert isinstance(result, ObservationResult)
+        assert isinstance(result.metrics, dict)
+        assert len(result.metrics) > 0
+
+    @pytest.mark.parametrize("cls", ALL_PLUGINS, ids=lambda c: c.__name__)
+    def test_default_predictions_valid(self, cls: type) -> None:
+        plugin = cls()
+        preds = plugin.default_predictions()
+        assert isinstance(preds, dict)
+        for metric_name, vals in preds.items():
+            assert isinstance(metric_name, str)
+            assert "expected" in vals
+            assert "tolerance" in vals
+
+
+class TestSourceIdUniqueness:
+    def test_unique_source_ids(self) -> None:
+        ids = [cls().source_id for cls in ALL_PLUGINS]
+        assert len(ids) == len(set(ids)), f"Duplicate source_ids: {ids}"


### PR DESCRIPTION
Closes #150

## Summary
- 4 example observation plugins conforming to `ObservationPlugin` ABC:
  - `email_gmail.py` — Gmail API (OAuth, readonly)
  - `calendar_google.py` — Google Calendar density monitor
  - `browser_history.py` — SQLite-based Chrome/Firefox history reader
  - `journal_filesystem.py` — Directory change monitor
- Each has setup instructions, required permissions, and metrics in docstrings
- All are importable but NOT registered by default

## How to test
```bash
pytest tests/test_example_plugins.py -v
```
21 tests pass.