### PR TITLE
#177: CLI entrypoint and daemon bootstrap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ dependencies = [
     "aiohttp>=3.9",
     "cryptography>=42.0",
     "bcrypt>=4.0",
+    "click>=8.1",
 ]
+
+[project.scripts]
+openbad = "openbad.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/openbad/cli.py
+++ b/src/openbad/cli.py
@@ -1,0 +1,87 @@
+"""OpenBaD command-line interface.
+
+Entrypoint: ``openbad`` (see ``[project.scripts]`` in ``pyproject.toml``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+
+import click
+
+import openbad
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def main(ctx: click.Context) -> None:
+    """OpenBaD — Biological as Digital agent daemon."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@main.command()
+@click.option("--host", default="localhost", help="MQTT broker host.")
+@click.option("--port", default=1883, type=int, help="MQTT broker port.")
+@click.option("--dry-run", is_flag=True, help="Validate config and exit.")
+@click.option("-v", "--verbose", is_flag=True, help="Enable debug logging.")
+def run(host: str, port: int, dry_run: bool, verbose: bool) -> None:
+    """Start the OpenBaD daemon."""
+    _configure_logging(verbose)
+
+    from openbad.daemon import Daemon
+
+    daemon = Daemon(mqtt_host=host, mqtt_port=port, dry_run=dry_run)
+    try:
+        asyncio.run(daemon.start())
+    except KeyboardInterrupt:
+        asyncio.run(daemon.stop())
+
+
+@main.command()
+@click.option("--host", default="localhost", help="MQTT broker host.")
+@click.option("--port", default=1883, type=int, help="MQTT broker port.")
+def status(host: str, port: int) -> None:
+    """Check daemon status (MQTT reachability and FSM state)."""
+    from openbad.nervous_system.client import NervousSystemClient
+
+    result: dict[str, object] = {"mqtt_reachable": False, "fsm_state": "UNKNOWN"}
+    try:
+        client = NervousSystemClient(host=host, port=port)
+        client.connect(timeout=3.0)
+        result["mqtt_reachable"] = True
+        client.disconnect()
+    except ConnectionError:
+        pass
+    click.echo(json.dumps(result, indent=2))
+    sys.exit(0 if result["mqtt_reachable"] else 1)
+
+
+@main.command()
+def version() -> None:
+    """Print version and exit."""
+    click.echo(f"openbad {openbad.__version__}")
+
+
+@main.command()
+def setup() -> None:
+    """Interactive first-run setup wizard."""
+    click.echo("Setup wizard not yet implemented. See issue #178.")
+
+
+@main.command()
+def tui() -> None:
+    """Launch the terminal UI."""
+    click.echo("TUI not yet implemented. See issue #180.")
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )

--- a/src/openbad/daemon.py
+++ b/src/openbad/daemon.py
@@ -1,0 +1,122 @@
+"""Daemon bootstrap — starts subsystems and runs the main event loop."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+
+from openbad.endocrine.controller import EndocrineController
+from openbad.nervous_system.client import NervousSystemClient
+from openbad.reflex_arc.fsm import AgentFSM
+
+logger = logging.getLogger(__name__)
+
+
+class Daemon:
+    """Core daemon lifecycle: connect MQTT, init subsystems, run loop."""
+
+    def __init__(
+        self,
+        mqtt_host: str = "localhost",
+        mqtt_port: int = 1883,
+        *,
+        dry_run: bool = False,
+    ) -> None:
+        self._mqtt_host = mqtt_host
+        self._mqtt_port = mqtt_port
+        self._dry_run = dry_run
+        self._running = False
+        self._client: NervousSystemClient | None = None
+        self._fsm: AgentFSM | None = None
+        self._endocrine: EndocrineController | None = None
+        self._stop_event: asyncio.Event | None = None
+
+    # -- public --------------------------------------------------------- #
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    @property
+    def fsm(self) -> AgentFSM | None:
+        return self._fsm
+
+    @property
+    def endocrine(self) -> EndocrineController | None:
+        return self._endocrine
+
+    @property
+    def client(self) -> NervousSystemClient | None:
+        return self._client
+
+    async def start(self) -> None:
+        """Connect to MQTT, initialise subsystems, enter the main loop."""
+        logger.info("Daemon starting (dry_run=%s)", self._dry_run)
+        self._stop_event = asyncio.Event()
+
+        # 1. MQTT nervous system
+        self._client = NervousSystemClient.get_instance(
+            host=self._mqtt_host, port=self._mqtt_port
+        )
+        self._client.connect(timeout=5.0)
+
+        # 2. Finite state machine
+        self._fsm = AgentFSM(client=self._client)
+
+        # 3. Endocrine controller
+        self._endocrine = EndocrineController()
+
+        logger.info("All subsystems initialised")
+
+        if self._dry_run:
+            logger.info("Dry-run complete — shutting down")
+            await self.stop()
+            return
+
+        # 4. Signal handlers (Unix only; no-op on Windows)
+        self._install_signal_handlers()
+
+        self._running = True
+        logger.info("Daemon running")
+
+        # Block until stop requested
+        await self._stop_event.wait()
+        await self.stop()
+
+    async def stop(self) -> None:
+        """Gracefully tear down subsystems in reverse order."""
+        if not self._running and not self._dry_run:
+            return
+        logger.info("Daemon stopping")
+        self._running = False
+
+        # Reverse-order teardown
+        self._endocrine = None
+        self._fsm = None
+
+        if self._client is not None:
+            self._client.disconnect()
+            NervousSystemClient.reset_instance()
+            self._client = None
+
+        if self._stop_event is not None:
+            self._stop_event.set()
+
+        logger.info("Daemon stopped")
+
+    def request_stop(self) -> None:
+        """Thread-safe signal to stop the daemon."""
+        if self._stop_event is not None:
+            self._stop_event.set()
+
+    # -- internals ------------------------------------------------------ #
+
+    def _install_signal_handlers(self) -> None:
+        """Register SIGTERM/SIGINT handlers on the running event loop."""
+        if sys.platform == "win32":
+            return
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, self.request_stop)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,75 @@
+"""Tests for CLI entrypoint and subcommand dispatch."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from openbad.cli import main
+
+
+class TestMainGroup:
+    """Top-level CLI group behaviour."""
+
+    def test_no_subcommand_shows_help(self):
+        result = CliRunner().invoke(main)
+        assert result.exit_code == 0
+        assert "OpenBaD" in result.output
+
+    def test_help_flag(self):
+        result = CliRunner().invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "run" in result.output
+        assert "status" in result.output
+        assert "version" in result.output
+        assert "setup" in result.output
+        assert "tui" in result.output
+
+
+class TestVersionCommand:
+    """``openbad version``."""
+
+    def test_prints_version(self):
+        result = CliRunner().invoke(main, ["version"])
+        assert result.exit_code == 0
+        assert "openbad" in result.output
+        assert "0.1.0" in result.output
+
+
+class TestSetupPlaceholder:
+    """``openbad setup`` placeholder."""
+
+    def test_setup_placeholder(self):
+        result = CliRunner().invoke(main, ["setup"])
+        assert result.exit_code == 0
+        assert "Setup wizard" in result.output
+
+
+class TestTuiPlaceholder:
+    """``openbad tui`` placeholder."""
+
+    def test_tui_placeholder(self):
+        result = CliRunner().invoke(main, ["tui"])
+        assert result.exit_code == 0
+        assert "TUI" in result.output
+
+
+class TestStatusCommand:
+    """``openbad status`` — MQTT reachability check."""
+
+    def test_status_no_broker(self):
+        """Without a running broker, exit code should be 1."""
+        result = CliRunner().invoke(main, ["status", "--port", "19999"])
+        assert result.exit_code == 1
+        assert '"mqtt_reachable": false' in result.output
+
+
+class TestRunCommand:
+    """``openbad run`` — daemon lifecycle."""
+
+    def test_run_help(self):
+        result = CliRunner().invoke(main, ["run", "--help"])
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output
+        assert "--host" in result.output
+        assert "--port" in result.output
+        assert "--verbose" in result.output

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,123 @@
+"""Tests for daemon lifecycle (start / stop / dry-run)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openbad.daemon import Daemon
+
+
+class TestDaemonInit:
+    """Construction and default state."""
+
+    def test_defaults(self):
+        d = Daemon()
+        assert d._mqtt_host == "localhost"
+        assert d._mqtt_port == 1883
+        assert not d._dry_run
+        assert not d.is_running
+
+    def test_custom_params(self):
+        d = Daemon(mqtt_host="10.0.0.1", mqtt_port=8883, dry_run=True)
+        assert d._mqtt_host == "10.0.0.1"
+        assert d._mqtt_port == 8883
+        assert d._dry_run
+
+
+class TestDaemonDryRun:
+    """Dry-run validates config without blocking."""
+
+    @pytest.fixture
+    def _mock_mqtt(self):
+        with patch("openbad.daemon.NervousSystemClient") as cls:
+            instance = MagicMock()
+            cls.get_instance.return_value = instance
+            yield instance
+
+    async def test_dry_run_starts_and_stops(self, _mock_mqtt):
+        d = Daemon(dry_run=True)
+        await d.start()
+        # After dry-run, daemon should have stopped itself
+        assert not d.is_running
+        assert d._client is None
+
+    async def test_dry_run_connects_mqtt(self, _mock_mqtt):
+        d = Daemon(dry_run=True)
+        await d.start()
+        _mock_mqtt.connect.assert_called_once()
+
+
+class TestDaemonStartStop:
+    """Normal start/stop lifecycle."""
+
+    @pytest.fixture
+    def mock_client(self):
+        with patch("openbad.daemon.NervousSystemClient") as cls:
+            instance = MagicMock()
+            cls.get_instance.return_value = instance
+            yield instance
+
+    async def test_start_then_stop(self, mock_client):
+        d = Daemon()
+        # Start in background, let it initialise, then stop
+        task = asyncio.create_task(d.start())
+        await asyncio.sleep(0.05)  # let startup complete
+        assert d.is_running
+        assert d.fsm is not None
+        assert d.endocrine is not None
+        assert d.client is mock_client
+
+        await d.stop()
+        await task
+        assert not d.is_running
+        assert d._client is None
+        mock_client.disconnect.assert_called_once()
+
+    async def test_request_stop_unblocks_loop(self, mock_client):
+        d = Daemon()
+        task = asyncio.create_task(d.start())
+        await asyncio.sleep(0.05)
+        d.request_stop()
+        await asyncio.wait_for(task, timeout=2.0)
+        assert not d.is_running
+
+    async def test_stop_idempotent(self, mock_client):
+        d = Daemon()
+        task = asyncio.create_task(d.start())
+        await asyncio.sleep(0.05)
+        await d.stop()
+        await d.stop()  # second stop should not raise
+        await task
+
+
+class TestDaemonSubsystems:
+    """Subsystem wiring."""
+
+    @pytest.fixture
+    def mock_client(self):
+        with patch("openbad.daemon.NervousSystemClient") as cls:
+            instance = MagicMock()
+            cls.get_instance.return_value = instance
+            yield instance
+
+    async def test_fsm_initialised_with_client(self, mock_client):
+        d = Daemon()
+        task = asyncio.create_task(d.start())
+        await asyncio.sleep(0.05)
+        assert d.fsm is not None
+        assert d.fsm._client is mock_client  # noqa: SLF001
+        await d.stop()
+        await task
+
+    async def test_endocrine_controller_created(self, mock_client):
+        d = Daemon()
+        task = asyncio.create_task(d.start())
+        await asyncio.sleep(0.05)
+        assert d.endocrine is not None
+        state = d.endocrine.get_state()
+        assert state.dopamine == 0.0
+        await d.stop()
+        await task


### PR DESCRIPTION
Closes #177

## Summary
- Add `click>=8.1` dependency and `[project.scripts]` entrypoint (`openbad = openbad.cli:main`)
- Create `src/openbad/cli.py` with Click group and subcommands: `run`, `status`, `version`, `setup` (placeholder), `tui` (placeholder)
- Create `src/openbad/daemon.py` with `Daemon` class: async start/stop lifecycle, MQTT connection, FSM + endocrine controller init, SIGTERM/SIGINT handling, `--dry-run` mode
- 16 tests: CLI dispatch, version, status (no-broker), daemon init, dry-run, start/stop, request_stop, subsystem wiring

## How to Test
```bash
pytest tests/test_cli.py tests/test_daemon.py -v
```