### PR TITLE
#178: Interactive setup wizard

### DIFF
--- a/src/openbad/cli.py
+++ b/src/openbad/cli.py
@@ -67,9 +67,37 @@ def version() -> None:
 
 
 @main.command()
-def setup() -> None:
+@click.option(
+    "--config-dir",
+    default=None,
+    type=click.Path(),
+    help="Configuration directory (default: ~/.config/openbad/).",
+)
+@click.option("--host", default="localhost", help="MQTT broker host.")
+@click.option("--port", default=1883, type=int, help="MQTT broker port.")
+@click.option("--non-interactive", is_flag=True, help="Accept all defaults.")
+@click.option("--check", "check_only", is_flag=True, help="Validate existing setup.")
+def setup(
+    config_dir: str | None,
+    host: str,
+    port: int,
+    non_interactive: bool,
+    check_only: bool,
+) -> None:
     """Interactive first-run setup wizard."""
-    click.echo("Setup wizard not yet implemented. See issue #178.")
+    from pathlib import Path
+
+    from openbad.setup import DEFAULT_CONFIG_DIR, run_wizard
+
+    path = Path(config_dir) if config_dir else DEFAULT_CONFIG_DIR
+    ok = run_wizard(
+        config_dir=path,
+        mqtt_host=host,
+        mqtt_port=port,
+        non_interactive=non_interactive,
+        check_only=check_only,
+    )
+    sys.exit(0 if ok else 1)
 
 
 @main.command()

--- a/src/openbad/setup.py
+++ b/src/openbad/setup.py
@@ -1,0 +1,267 @@
+"""Interactive setup wizard for OpenBaD first-run configuration."""
+
+from __future__ import annotations
+
+import os
+import platform
+import secrets
+import shutil
+import sys
+from pathlib import Path
+
+import click
+import yaml
+
+# Template configs shipped with the package
+_PACKAGE_CONFIG_DIR = Path(__file__).resolve().parent.parent.parent / "config"
+
+# Config filenames that the wizard copies
+CONFIG_FILES = [
+    "active_inference.yaml",
+    "broker.conf",
+    "cognitive.yaml",
+    "endocrine.yaml",
+    "identity.yaml",
+    "immune.yaml",
+    "immune_rules.yaml",
+    "memory.yaml",
+    "model_routing.yaml",
+    "permissions.yaml",
+    "sensory_audio.yaml",
+    "sensory_vision.yaml",
+    "threshold_policies.yaml",
+]
+
+SYSTEMD_UNITS = ["openbad-broker.service"]
+
+DEFAULT_CONFIG_DIR = Path.home() / ".config" / "openbad"
+
+
+# ------------------------------------------------------------------
+# Environment checks
+# ------------------------------------------------------------------
+
+
+def check_python_version() -> tuple[bool, str]:
+    """Verify Python >= 3.11."""
+    version = sys.version_info
+    ok = version >= (3, 11)
+    msg = f"Python {version.major}.{version.minor}.{version.micro}"
+    return ok, msg
+
+
+def check_platform() -> tuple[bool, str]:
+    """Check if running on Linux."""
+    is_linux = platform.system() == "Linux"
+    return is_linux, platform.system()
+
+
+def check_cgroup_v2() -> tuple[bool, str]:
+    """Detect cgroup v2 availability."""
+    cgroup_path = Path("/sys/fs/cgroup/cgroup.controllers")
+    if cgroup_path.exists():
+        return True, "cgroup v2 available"
+    return False, "cgroup v2 not detected"
+
+
+def check_systemd() -> tuple[bool, str]:
+    """Check if systemd is the init system."""
+    if Path("/run/systemd/system").is_dir():
+        return True, "systemd detected"
+    return False, "systemd not detected"
+
+
+def check_mqtt_broker(host: str = "localhost", port: int = 1883) -> tuple[bool, str]:
+    """Attempt MQTT connection to detect running broker."""
+    try:
+        from openbad.nervous_system.client import NervousSystemClient
+
+        client = NervousSystemClient(host=host, port=port)
+        client.connect(timeout=3.0)
+        client.disconnect()
+        return True, f"Broker reachable at {host}:{port}"
+    except Exception:  # noqa: BLE001
+        return False, f"Broker not reachable at {host}:{port}"
+
+
+# ------------------------------------------------------------------
+# Config management
+# ------------------------------------------------------------------
+
+
+def copy_configs(dest_dir: Path, *, overwrite: bool = False) -> list[str]:
+    """Copy template config files to *dest_dir*.
+
+    Returns list of files copied.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    copied: list[str] = []
+    for name in CONFIG_FILES:
+        src = _PACKAGE_CONFIG_DIR / name
+        dst = dest_dir / name
+        if not src.exists():
+            continue
+        if dst.exists() and not overwrite:
+            continue
+        shutil.copy2(src, dst)
+        copied.append(name)
+    return copied
+
+
+def generate_secret_key() -> str:
+    """Generate a cryptographic hex secret for identity module."""
+    return secrets.token_hex(32)
+
+
+def patch_identity_config(config_dir: Path, secret_hex: str) -> None:
+    """Update identity.yaml with the given secret key."""
+    identity_path = config_dir / "identity.yaml"
+    if not identity_path.exists():
+        return
+    data = yaml.safe_load(identity_path.read_text()) or {}
+    identity_block = data.get("identity", {})
+    identity_block["secret_hex"] = secret_hex
+    data["identity"] = identity_block
+    identity_path.write_text(yaml.dump(data, default_flow_style=False))
+
+
+def install_systemd_units(config_dir: Path) -> list[str]:
+    """Copy systemd unit files to /etc/systemd/system/.
+
+    Returns list of installed units. Requires root.
+    """
+    systemd_dir = Path("/etc/systemd/system")
+    installed: list[str] = []
+    for name in SYSTEMD_UNITS:
+        src = _PACKAGE_CONFIG_DIR / name
+        if not src.exists():
+            continue
+        dst = systemd_dir / name
+        try:
+            shutil.copy2(src, dst)
+            installed.append(name)
+        except PermissionError:
+            click.echo(f"  Permission denied: {dst} (run as root)")
+    return installed
+
+
+# ------------------------------------------------------------------
+# Validation
+# ------------------------------------------------------------------
+
+
+def validate_config(config_dir: Path) -> list[str]:
+    """Check that all expected config files exist. Return missing names."""
+    missing = []
+    for name in CONFIG_FILES:
+        if not (config_dir / name).exists():
+            missing.append(name)
+    return missing
+
+
+# ------------------------------------------------------------------
+# Wizard steps
+# ------------------------------------------------------------------
+
+
+def run_wizard(
+    config_dir: Path = DEFAULT_CONFIG_DIR,
+    mqtt_host: str = "localhost",
+    mqtt_port: int = 1883,
+    *,
+    non_interactive: bool = False,
+    check_only: bool = False,
+) -> bool:
+    """Run the full setup wizard. Returns True on success."""
+    click.echo("=" * 50)
+    click.echo("  OpenBaD Setup Wizard")
+    click.echo("=" * 50)
+    click.echo()
+
+    # Step 1: Environment checks
+    click.echo("[1/6] Environment check")
+    checks = [
+        ("Python version", check_python_version()),
+        ("Platform", check_platform()),
+        ("cgroup v2", check_cgroup_v2()),
+        ("systemd", check_systemd()),
+    ]
+    all_ok = True
+    for label, (ok, detail) in checks:
+        icon = "OK" if ok else "WARN"
+        click.echo(f"  [{icon}] {label}: {detail}")
+        if not ok and label == "Python version":
+            all_ok = False
+
+    if not all_ok:
+        click.echo("\nCritical requirement not met. Aborting.")
+        return False
+
+    # Step 2: MQTT broker
+    click.echo(f"\n[2/6] MQTT broker ({mqtt_host}:{mqtt_port})")
+    broker_ok, broker_msg = check_mqtt_broker(mqtt_host, mqtt_port)
+    icon = "OK" if broker_ok else "WARN"
+    click.echo(f"  [{icon}] {broker_msg}")
+    if not broker_ok and not check_only:
+        click.echo("  Hint: Install NanoMQ or start the broker first.")
+
+    # Step 3: Config directory
+    click.echo(f"\n[3/6] Config directory: {config_dir}")
+    if check_only:
+        missing = validate_config(config_dir)
+        if missing:
+            click.echo(f"  [WARN] Missing: {', '.join(missing)}")
+        else:
+            click.echo("  [OK] All config files present")
+        click.echo()
+        return len(missing) == 0 and all_ok
+
+    if not non_interactive:
+        response = click.prompt(
+            "  Config directory", default=str(config_dir), type=str
+        )
+        config_dir = Path(response)
+
+    copied = copy_configs(config_dir)
+    if copied:
+        click.echo(f"  Copied {len(copied)} config files")
+    else:
+        click.echo("  Config files already exist (no overwrite)")
+
+    # Step 4: Identity setup
+    click.echo("\n[4/6] Identity setup")
+    identity_path = config_dir / "identity.yaml"
+    if identity_path.exists():
+        data = yaml.safe_load(identity_path.read_text()) or {}
+        current_secret = (data.get("identity") or {}).get("secret_hex", "")
+    else:
+        current_secret = ""
+
+    if not current_secret:
+        secret = generate_secret_key()
+        patch_identity_config(config_dir, secret)
+        click.echo("  Generated new secret key")
+    else:
+        click.echo("  Secret key already configured")
+
+    # Step 5: Systemd integration
+    click.echo("\n[5/6] Systemd integration")
+    if os.geteuid() == 0 if hasattr(os, "geteuid") else False:
+        installed = install_systemd_units(config_dir)
+        if installed:
+            click.echo(f"  Installed: {', '.join(installed)}")
+        else:
+            click.echo("  Units already installed")
+    else:
+        click.echo("  [SKIP] Not running as root (run with sudo to install units)")
+
+    # Step 6: Validation
+    click.echo("\n[6/6] Validation")
+    missing = validate_config(config_dir)
+    if missing:
+        click.echo(f"  [WARN] Missing configs: {', '.join(missing)}")
+        return False
+
+    click.echo("  [OK] All config files present")
+    click.echo("\nSetup complete!")
+    return True

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,185 @@
+"""Tests for the setup wizard."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import yaml
+
+from openbad.setup import (
+    CONFIG_FILES,
+    check_cgroup_v2,
+    check_mqtt_broker,
+    check_platform,
+    check_python_version,
+    check_systemd,
+    copy_configs,
+    generate_secret_key,
+    patch_identity_config,
+    run_wizard,
+    validate_config,
+)
+
+
+class TestEnvironmentChecks:
+    """Environment detection helpers."""
+
+    def test_python_version_passes(self):
+        ok, msg = check_python_version()
+        assert ok
+        assert "Python" in msg
+
+    def test_platform_returns_string(self):
+        _ok, msg = check_platform()
+        assert len(msg) > 0
+
+    @patch("openbad.setup.Path.exists", return_value=True)
+    def test_cgroup_v2_detected(self, _mock):
+        ok, msg = check_cgroup_v2()
+        assert ok
+        assert "v2" in msg
+
+    @patch("openbad.setup.Path.exists", return_value=False)
+    def test_cgroup_v2_not_detected(self, _mock):
+        ok, _msg = check_cgroup_v2()
+        assert not ok
+
+    @patch("openbad.setup.Path.is_dir", return_value=True)
+    def test_systemd_detected(self, _mock):
+        ok, _msg = check_systemd()
+        assert ok
+
+    @patch("openbad.setup.Path.is_dir", return_value=False)
+    def test_systemd_not_detected(self, _mock):
+        ok, _msg = check_systemd()
+        assert not ok
+
+    def test_mqtt_broker_unreachable(self):
+        ok, msg = check_mqtt_broker("localhost", 19999)
+        assert not ok
+        assert "not reachable" in msg
+
+
+class TestCopyConfigs:
+    """Config file copying."""
+
+    def test_copies_to_empty_dir(self, tmp_path):
+        copied = copy_configs(tmp_path)
+        assert len(copied) > 0
+        for name in copied:
+            assert (tmp_path / name).exists()
+
+    def test_no_overwrite_by_default(self, tmp_path):
+        copy_configs(tmp_path)
+        copied2 = copy_configs(tmp_path)
+        assert len(copied2) == 0  # nothing overwritten
+
+    def test_overwrite_flag(self, tmp_path):
+        copy_configs(tmp_path)
+        copied2 = copy_configs(tmp_path, overwrite=True)
+        assert len(copied2) > 0
+
+
+class TestSecretKey:
+    """Secret key generation and patching."""
+
+    def test_generate_secret_key_length(self):
+        key = generate_secret_key()
+        assert len(key) == 64  # 32 bytes hex
+
+    def test_generate_secret_key_unique(self):
+        k1 = generate_secret_key()
+        k2 = generate_secret_key()
+        assert k1 != k2
+
+    def test_patch_identity_config(self, tmp_path):
+        identity_path = tmp_path / "identity.yaml"
+        identity_path.write_text(yaml.dump({"identity": {"secret_hex": ""}}))
+        patch_identity_config(tmp_path, "abc123")
+        data = yaml.safe_load(identity_path.read_text())
+        assert data["identity"]["secret_hex"] == "abc123"  # noqa: S105
+
+    def test_patch_identity_missing_file(self, tmp_path):
+        # Should not raise
+        patch_identity_config(tmp_path, "abc123")
+
+
+class TestValidateConfig:
+    """Config validation."""
+
+    def test_all_present(self, tmp_path):
+        copy_configs(tmp_path)
+        missing = validate_config(tmp_path)
+        assert len(missing) == 0
+
+    def test_missing_files(self, tmp_path):
+        missing = validate_config(tmp_path)
+        assert len(missing) == len(CONFIG_FILES)
+
+    def test_partial(self, tmp_path):
+        copy_configs(tmp_path)
+        (tmp_path / CONFIG_FILES[0]).unlink()
+        missing = validate_config(tmp_path)
+        assert len(missing) == 1
+        assert missing[0] == CONFIG_FILES[0]
+
+
+class TestRunWizard:
+    """Full wizard flow."""
+
+    def test_non_interactive_creates_configs(self, tmp_path):
+        ok = run_wizard(
+            config_dir=tmp_path,
+            mqtt_host="localhost",
+            mqtt_port=19999,
+            non_interactive=True,
+            check_only=False,
+        )
+        assert ok
+        missing = validate_config(tmp_path)
+        assert len(missing) == 0
+
+    def test_check_only_no_configs(self, tmp_path):
+        ok = run_wizard(
+            config_dir=tmp_path,
+            mqtt_host="localhost",
+            mqtt_port=19999,
+            non_interactive=True,
+            check_only=True,
+        )
+        assert not ok  # configs missing
+
+    def test_check_only_with_configs(self, tmp_path):
+        copy_configs(tmp_path)
+        ok = run_wizard(
+            config_dir=tmp_path,
+            mqtt_host="localhost",
+            mqtt_port=19999,
+            non_interactive=True,
+            check_only=True,
+        )
+        assert ok
+
+    def test_idempotent(self, tmp_path):
+        run_wizard(
+            config_dir=tmp_path,
+            non_interactive=True,
+            check_only=False,
+        )
+        # Second run should not break
+        ok = run_wizard(
+            config_dir=tmp_path,
+            non_interactive=True,
+            check_only=False,
+        )
+        assert ok
+
+    def test_generates_secret_key(self, tmp_path):
+        run_wizard(
+            config_dir=tmp_path,
+            non_interactive=True,
+            check_only=False,
+        )
+        data = yaml.safe_load((tmp_path / "identity.yaml").read_text())
+        secret = data["identity"]["secret_hex"]
+        assert len(secret) == 64


### PR DESCRIPTION
Closes #178

## Summary
- Create `src/openbad/setup.py` with 6-step setup wizard:
  1. Environment checks (Python version, platform, cgroup v2, systemd)
  2. MQTT broker connectivity test
  3. Config directory creation + template file copying
  4. Identity secret key generation
  5. Systemd unit installation (when root)
  6. Validation of all config files
- Wire `openbad setup` subcommand with `--config-dir`, `--non-interactive`, `--check` options
- Wizard is idempotent (safe to re-run)
- `--check` mode validates without modifying anything
- 22 tests covering all wizard steps, env checks, config management, key generation

## How to Test
```bash
pytest tests/test_setup.py -v
```