### PR TITLE
#179: Systemd service and install script

### DIFF
--- a/config/openbad.service
+++ b/config/openbad.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=OpenBaD Agent Daemon
+Documentation=https://github.com/bruceamoser/OpenBaD
+After=openbad-broker.service network-online.target
+Wants=network-online.target
+Requires=openbad-broker.service
+
+[Service]
+Type=simple
+User=openbad
+Group=openbad
+ExecStart=/usr/local/bin/openbad run --host localhost --port 1883
+ExecStop=/bin/kill -TERM $MAINPID
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=30s
+
+# Environment
+Environment=OPENBAD_CONFIG_DIR=/etc/openbad
+WorkingDirectory=/var/lib/openbad
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/openbad /var/log/openbad
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+# Resource limits
+LimitNOFILE=65536
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# OpenBaD installation script
+# Usage: sudo ./install.sh [--uninstall]
+set -euo pipefail
+
+OPENBAD_USER="openbad"
+OPENBAD_GROUP="openbad"
+CONFIG_DIR="/etc/openbad"
+DATA_DIR="/var/lib/openbad"
+LOG_DIR="/var/log/openbad"
+SYSTEMD_DIR="/etc/systemd/system"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+CONFIG_SRC="$PROJECT_ROOT/config"
+
+# Colours (if terminal supports them)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Colour
+
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+require_root() {
+    if [[ $EUID -ne 0 ]]; then
+        error "This script must be run as root (sudo)."
+        exit 1
+    fi
+}
+
+# ------------------------------------------------------------------
+# Create system user
+# ------------------------------------------------------------------
+create_user() {
+    if id "$OPENBAD_USER" &>/dev/null; then
+        info "User '$OPENBAD_USER' already exists."
+    else
+        info "Creating system user '$OPENBAD_USER'..."
+        useradd --system --no-create-home --home-dir "$DATA_DIR" \
+                --shell /usr/sbin/nologin "$OPENBAD_USER"
+    fi
+}
+
+# ------------------------------------------------------------------
+# Install Python package
+# ------------------------------------------------------------------
+install_package() {
+    info "Installing openbad Python package..."
+    if command -v pip3 &>/dev/null; then
+        pip3 install --upgrade "$PROJECT_ROOT"
+    elif command -v pip &>/dev/null; then
+        pip install --upgrade "$PROJECT_ROOT"
+    else
+        error "pip not found. Install Python >= 3.11 and pip first."
+        exit 1
+    fi
+}
+
+# ------------------------------------------------------------------
+# Copy configuration files
+# ------------------------------------------------------------------
+install_configs() {
+    info "Installing configuration to $CONFIG_DIR..."
+    mkdir -p "$CONFIG_DIR"
+
+    for f in "$CONFIG_SRC"/*.yaml "$CONFIG_SRC"/*.conf; do
+        [ -f "$f" ] || continue
+        name="$(basename "$f")"
+        dst="$CONFIG_DIR/$name"
+        if [ -f "$dst" ]; then
+            warn "  $name already exists, skipping (remove to reinstall)."
+        else
+            cp "$f" "$dst"
+            info "  Copied $name"
+        fi
+    done
+
+    chown -R "$OPENBAD_USER:$OPENBAD_GROUP" "$CONFIG_DIR"
+    chmod 750 "$CONFIG_DIR"
+    chmod 640 "$CONFIG_DIR"/*
+}
+
+# ------------------------------------------------------------------
+# Create data and log directories
+# ------------------------------------------------------------------
+create_dirs() {
+    info "Creating directories..."
+    mkdir -p "$DATA_DIR" "$LOG_DIR"
+    chown "$OPENBAD_USER:$OPENBAD_GROUP" "$DATA_DIR" "$LOG_DIR"
+    chmod 750 "$DATA_DIR" "$LOG_DIR"
+}
+
+# ------------------------------------------------------------------
+# Install systemd units
+# ------------------------------------------------------------------
+install_units() {
+    info "Installing systemd units..."
+    for unit in openbad-broker.service openbad.service; do
+        src="$CONFIG_SRC/$unit"
+        if [ -f "$src" ]; then
+            cp "$src" "$SYSTEMD_DIR/$unit"
+            info "  Installed $unit"
+        else
+            warn "  $unit not found in $CONFIG_SRC"
+        fi
+    done
+
+    systemctl daemon-reload
+    info "Enabling services..."
+    systemctl enable openbad-broker.service
+    systemctl enable openbad.service
+}
+
+# ------------------------------------------------------------------
+# Start services
+# ------------------------------------------------------------------
+start_services() {
+    info "Starting services..."
+    systemctl start openbad-broker.service
+    systemctl start openbad.service
+    info "Services started. Check status with: systemctl status openbad"
+}
+
+# ------------------------------------------------------------------
+# Uninstall
+# ------------------------------------------------------------------
+uninstall() {
+    info "Stopping services..."
+    systemctl stop openbad.service 2>/dev/null || true
+    systemctl stop openbad-broker.service 2>/dev/null || true
+    systemctl disable openbad.service 2>/dev/null || true
+    systemctl disable openbad-broker.service 2>/dev/null || true
+
+    info "Removing systemd units..."
+    rm -f "$SYSTEMD_DIR/openbad.service"
+    rm -f "$SYSTEMD_DIR/openbad-broker.service"
+    systemctl daemon-reload
+
+    info "Removing Python package..."
+    pip3 uninstall -y openbad 2>/dev/null || true
+
+    warn "Config ($CONFIG_DIR) and data ($DATA_DIR) directories preserved."
+    warn "To fully remove: rm -rf $CONFIG_DIR $DATA_DIR $LOG_DIR"
+    warn "To remove user: userdel $OPENBAD_USER"
+    info "Uninstall complete."
+}
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+main() {
+    require_root
+
+    if [[ "${1:-}" == "--uninstall" ]]; then
+        uninstall
+        exit 0
+    fi
+
+    info "=== OpenBaD Installation ==="
+    create_user
+    install_package
+    install_configs
+    create_dirs
+    install_units
+    start_services
+    info "=== Installation complete ==="
+    info "Run 'openbad status' to verify."
+}
+
+main "$@"

--- a/src/openbad/setup.py
+++ b/src/openbad/setup.py
@@ -32,7 +32,7 @@ CONFIG_FILES = [
     "threshold_policies.yaml",
 ]
 
-SYSTEMD_UNITS = ["openbad-broker.service"]
+SYSTEMD_UNITS = ["openbad-broker.service", "openbad.service"]
 
 DEFAULT_CONFIG_DIR = Path.home() / ".config" / "openbad"
 

--- a/tests/test_service_install.py
+++ b/tests/test_service_install.py
@@ -1,0 +1,116 @@
+"""Tests for systemd service file syntax and install script validation."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+class TestOpenbadServiceFile:
+    """Validate config/openbad.service syntax."""
+
+    def setup_method(self):
+        self.path = CONFIG_DIR / "openbad.service"
+        self.content = self.path.read_text()
+
+    def test_file_exists(self):
+        assert self.path.exists()
+
+    def test_has_unit_section(self):
+        assert "[Unit]" in self.content
+
+    def test_has_service_section(self):
+        assert "[Service]" in self.content
+
+    def test_has_install_section(self):
+        assert "[Install]" in self.content
+
+    def test_after_broker(self):
+        assert "openbad-broker.service" in self.content
+
+    def test_exec_start(self):
+        match = re.search(r"ExecStart=.*openbad run", self.content)
+        assert match is not None
+
+    def test_restart_on_failure(self):
+        assert "Restart=on-failure" in self.content
+
+    def test_security_hardening(self):
+        assert "NoNewPrivileges=true" in self.content
+        assert "ProtectSystem=strict" in self.content
+        assert "PrivateTmp=true" in self.content
+
+    def test_user_set(self):
+        assert "User=openbad" in self.content
+
+    def test_wanted_by(self):
+        assert "WantedBy=multi-user.target" in self.content
+
+
+class TestBrokerServiceFile:
+    """Validate config/openbad-broker.service (pre-existing)."""
+
+    def setup_method(self):
+        self.path = CONFIG_DIR / "openbad-broker.service"
+        self.content = self.path.read_text()
+
+    def test_file_exists(self):
+        assert self.path.exists()
+
+    def test_has_all_sections(self):
+        for section in ("[Unit]", "[Service]", "[Install]"):
+            assert section in self.content
+
+    def test_exec_start_nanomq(self):
+        assert "nanomq" in self.content
+
+
+class TestInstallScript:
+    """Validate scripts/install.sh structure."""
+
+    def setup_method(self):
+        self.path = SCRIPTS_DIR / "install.sh"
+        self.content = self.path.read_text()
+
+    def test_file_exists(self):
+        assert self.path.exists()
+
+    def test_shebang(self):
+        assert self.content.startswith("#!/usr/bin/env bash")
+
+    def test_set_euo_pipefail(self):
+        assert "set -euo pipefail" in self.content
+
+    def test_requires_root(self):
+        assert "require_root" in self.content
+        assert "EUID" in self.content
+
+    def test_creates_user(self):
+        assert "useradd" in self.content
+        assert "openbad" in self.content
+
+    def test_installs_package(self):
+        assert "pip" in self.content
+
+    def test_copies_configs(self):
+        assert "CONFIG_DIR" in self.content
+
+    def test_installs_systemd_units(self):
+        assert "systemctl daemon-reload" in self.content
+        assert "systemctl enable" in self.content
+
+    def test_has_uninstall(self):
+        assert "--uninstall" in self.content
+        assert "systemctl stop" in self.content
+        assert "systemctl disable" in self.content
+
+    def test_no_rm_rf_dangerous(self):
+        """Install script should not have bare 'rm -rf /' patterns."""
+        # Ensure no dangerous rm -rf patterns
+        dangerous = re.findall(r"rm\s+-rf\s+/[^$\s]", self.content)
+        # Allow only specific paths like /etc/systemd/system/openbad*
+        for match in dangerous:
+            assert "openbad" in match or "SYSTEMD_DIR" in match


### PR DESCRIPTION
Closes #179

## Summary
- Create `config/openbad.service` systemd unit: Type=simple, After=openbad-broker.service, security-hardened (NoNewPrivileges, ProtectSystem=strict, PrivateTmp, ProtectKernelTunables, RestrictSUIDSGID), resource limits
- Create `scripts/install.sh`: creates openbad system user, pip-installs package, copies configs to /etc/openbad, creates data/log dirs, installs+enables systemd units, supports `--uninstall`
- Update setup wizard to include openbad.service in unit list
- 23 tests: service file syntax validation, install script structure checks, security validation (no dangerous rm patterns)

## How to Test
```bash
pytest tests/test_service_install.py -v
```