### PR TITLE
#180: TUI scaffold with Textual

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,16 @@ dependencies = [
 openbad = "openbad.cli:main"
 
 [project.optional-dependencies]
+tui = [
+    "textual>=0.80",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-aiohttp>=1.0",
     "ruff>=0.8",
     "grpcio-tools>=1.60",
+    "textual-dev>=1.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/openbad/cli.py
+++ b/src/openbad/cli.py
@@ -101,9 +101,17 @@ def setup(
 
 
 @main.command()
-def tui() -> None:
+@click.option("--host", default="localhost", help="MQTT broker host.")
+@click.option("--port", default=1883, type=int, help="MQTT broker port.")
+def tui(host: str, port: int) -> None:
     """Launch the terminal UI."""
-    click.echo("TUI not yet implemented. See issue #180.")
+    try:
+        from openbad.tui.app import OpenBaDApp
+    except ImportError:
+        click.echo("TUI requires the 'tui' extra: pip install openbad[tui]", err=True)
+        sys.exit(1)
+    app = OpenBaDApp(mqtt_host=host, mqtt_port=port)
+    app.run()
 
 
 def _configure_logging(verbose: bool) -> None:

--- a/src/openbad/tui/__init__.py
+++ b/src/openbad/tui/__init__.py
@@ -1,0 +1,1 @@
+"""OpenBaD Terminal UI package."""

--- a/src/openbad/tui/app.py
+++ b/src/openbad/tui/app.py
@@ -1,0 +1,145 @@
+"""OpenBaD Terminal UI application.
+
+Provides the main Textual ``App`` with a layout containing a sidebar for
+navigation and a main content area with placeholder panels (wired in by
+subsequent issues).
+"""
+
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Footer, Header, Static
+
+from openbad.tui.mqtt_feed import MqttDisconnected, MqttFeed
+
+# ── Placeholder panels (replaced by #181-#183) ──────────────────────
+
+
+class StatusPanel(Static):
+    """Connection and FSM status bar across the top of the main area."""
+
+    DEFAULT_CSS = """
+    StatusPanel {
+        height: 3;
+        border: solid $accent;
+        padding: 0 1;
+    }
+    """
+
+    def on_mount(self) -> None:
+        self.update("FSM: -- | MQTT: disconnected | Hormones: --")
+
+
+class PlaceholderPanel(Static):
+    """Generic placeholder for panels not yet implemented."""
+
+    DEFAULT_CSS = """
+    PlaceholderPanel {
+        height: 1fr;
+        border: solid $surface;
+        padding: 1;
+    }
+    """
+
+
+# ── Sidebar ──────────────────────────────────────────────────────────
+
+
+class Sidebar(Static):
+    """Navigation sidebar showing subsystem list."""
+
+    DEFAULT_CSS = """
+    Sidebar {
+        width: 24;
+        border: solid $primary;
+        padding: 1;
+    }
+    """
+
+    def on_mount(self) -> None:
+        self.update(
+            "[b]Subsystems[/b]\n"
+            "──────────────\n"
+            "• Hormones\n"
+            "• FSM State\n"
+            "• Inference\n"
+            "• Vitals\n"
+            "• Event Log\n"
+        )
+
+
+# ── Main App ─────────────────────────────────────────────────────────
+
+
+class OpenBaDApp(App):
+    """OpenBaD interactive terminal dashboard."""
+
+    TITLE = "OpenBaD"
+    SUB_TITLE = "Biological-as-Digital Agent"
+
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+    #main-area {
+        height: 1fr;
+    }
+    #panels {
+        height: 1fr;
+    }
+    #top-panels {
+        height: 1fr;
+    }
+    #bottom-panels {
+        height: 1fr;
+    }
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit", show=True),
+        Binding("d", "toggle_dark", "Dark/Light", show=True),
+        Binding("r", "reconnect", "Reconnect", show=True),
+    ]
+
+    def __init__(
+        self,
+        mqtt_host: str = "localhost",
+        mqtt_port: int = 1883,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.feed = MqttFeed(host=mqtt_host, port=mqtt_port)
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Horizontal(id="main-area"):
+            yield Sidebar()
+            with Vertical(id="panels"):
+                yield StatusPanel()
+                with Horizontal(id="top-panels"):
+                    yield PlaceholderPanel("[dim]Hormone gauges (issue #181)[/dim]")
+                    yield PlaceholderPanel("[dim]FSM state (issue #181)[/dim]")
+                with Horizontal(id="bottom-panels"):
+                    yield PlaceholderPanel("[dim]Inference (issue #182)[/dim]")
+                    yield PlaceholderPanel("[dim]Vitals (issue #182)[/dim]")
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        await self.feed.connect(self)
+
+    async def on_unmount(self) -> None:
+        await self.feed.disconnect()
+
+    def on_mqtt_disconnected(self, _message: MqttDisconnected) -> None:
+        status = self.query_one(StatusPanel)
+        status.update("FSM: -- | [red]MQTT: disconnected[/red] | Hormones: --")
+
+    def action_reconnect(self) -> None:
+        """Reconnect to the MQTT broker."""
+        self.run_worker(self.feed.disconnect())
+        self.run_worker(self.feed.connect(self))
+
+    def action_toggle_dark(self) -> None:
+        self.dark = not self.dark

--- a/src/openbad/tui/mqtt_feed.py
+++ b/src/openbad/tui/mqtt_feed.py
@@ -1,0 +1,118 @@
+"""MQTT data feed for the TUI.
+
+Bridges the NervousSystemClient subscription model into Textual message
+posting so widgets can react to live data without touching MQTT directly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from textual.message import Message
+
+if TYPE_CHECKING:
+    from textual.app import App
+
+log = logging.getLogger(__name__)
+
+# ── Textual messages ────────────────────────────────────────────────
+
+
+class MqttConnected(Message):
+    """Posted when the MQTT connection succeeds."""
+
+
+class MqttDisconnected(Message):
+    """Posted when the MQTT connection is lost."""
+
+
+class MqttPayload(Message):
+    """Posted when a message arrives on a subscribed topic."""
+
+    def __init__(self, topic: str, payload: Any) -> None:  # noqa: ANN401
+        super().__init__()
+        self.topic = topic
+        self.payload = payload
+
+
+# ── Feed ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class MqttFeed:
+    """Manages a single MQTT connection and fans messages to a Textual App."""
+
+    host: str = "localhost"
+    port: int = 1883
+    _app: App | None = field(default=None, repr=False)
+    _client: Any = field(default=None, repr=False)
+    _connected: bool = field(default=False, repr=False)
+
+    # ── lifecycle ────────────────────────────────────────────────
+
+    async def connect(self, app: App) -> None:
+        """Connect to the MQTT broker and store the Textual app reference."""
+        self._app = app
+        try:
+            from openbad.nervous_system.client import NervousSystemClient
+
+            self._client = NervousSystemClient.get_instance(
+                host=self.host, port=self.port
+            )
+            self._client.connect(timeout=5.0)
+            self._connected = True
+            self._post(MqttConnected())
+            log.info("MQTT feed connected to %s:%s", self.host, self.port)
+        except Exception:
+            log.exception("MQTT feed connection failed")
+            self._connected = False
+            self._post(MqttDisconnected())
+
+    async def disconnect(self) -> None:
+        """Disconnect from the MQTT broker."""
+        if self._client is not None:
+            try:
+                self._client.disconnect()
+            except Exception:
+                log.exception("Error during MQTT disconnect")
+            finally:
+                from openbad.nervous_system.client import NervousSystemClient
+
+                NervousSystemClient.reset_instance()
+                self._client = None
+        self._connected = False
+
+    # ── subscriptions ────────────────────────────────────────────
+
+    def subscribe(self, topic: str, proto_type: type | None = None) -> None:
+        """Subscribe to *topic* and post ``MqttPayload`` messages to the app.
+
+        If *proto_type* is ``None`` the raw payload bytes are forwarded.
+        """
+        if self._client is None:
+            log.warning("subscribe() called before connect()")
+            return
+
+        def _on_message(topic_str: str, msg: Any) -> None:  # noqa: ANN401
+            payload = msg if proto_type is not None else msg
+            self._post(MqttPayload(topic=topic_str, payload=payload))
+
+        if proto_type is not None:
+            self._client.subscribe(topic, proto_type, _on_message)
+        else:
+            # Raw subscribe — use low-level paho callback if available
+            self._client.subscribe(topic, None, _on_message)
+
+    # ── helpers ──────────────────────────────────────────────────
+
+    def _post(self, message: Message) -> None:
+        if self._app is not None:
+            with contextlib.suppress(Exception):
+                self._app.post_message(message)
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,175 @@
+"""Tests for the TUI scaffold (app, mqtt_feed, CLI command)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openbad.tui.app import OpenBaDApp, PlaceholderPanel, Sidebar, StatusPanel
+from openbad.tui.mqtt_feed import MqttConnected, MqttDisconnected, MqttFeed, MqttPayload
+
+# ── MqttFeed unit tests ─────────────────────────────────────────────
+
+
+class TestMqttFeed:
+    def test_defaults(self):
+        feed = MqttFeed()
+        assert feed.host == "localhost"
+        assert feed.port == 1883
+        assert feed.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_success(self):
+        app = MagicMock()
+        app.post_message = MagicMock()
+        mock_client = MagicMock()
+
+        with patch(
+            "openbad.nervous_system.client.NervousSystemClient"
+        ) as cls:
+            cls.get_instance.return_value = mock_client
+            feed = MqttFeed(host="test", port=9999)
+            await feed.connect(app)
+
+        assert feed.is_connected is True
+        cls.get_instance.assert_called_once_with(host="test", port=9999)
+        mock_client.connect.assert_called_once_with(timeout=5.0)
+        # Should have posted MqttConnected
+        posted = [c[0][0] for c in app.post_message.call_args_list]
+        assert any(isinstance(m, MqttConnected) for m in posted)
+
+    @pytest.mark.asyncio
+    async def test_connect_failure(self):
+        app = MagicMock()
+        app.post_message = MagicMock()
+
+        with patch(
+            "openbad.nervous_system.client.NervousSystemClient"
+        ) as cls:
+            cls.get_instance.return_value = MagicMock(
+                connect=MagicMock(side_effect=ConnectionError("nope"))
+            )
+            feed = MqttFeed()
+            await feed.connect(app)
+
+        assert feed.is_connected is False
+        posted = [c[0][0] for c in app.post_message.call_args_list]
+        assert any(isinstance(m, MqttDisconnected) for m in posted)
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self):
+        app = MagicMock()
+        mock_client = MagicMock()
+
+        with patch(
+            "openbad.nervous_system.client.NervousSystemClient"
+        ) as cls:
+            cls.get_instance.return_value = mock_client
+            feed = MqttFeed()
+            await feed.connect(app)
+            assert feed.is_connected is True
+
+            await feed.disconnect()
+            assert feed.is_connected is False
+            mock_client.disconnect.assert_called_once()
+            cls.reset_instance.assert_called_once()
+
+    def test_subscribe_without_connect(self):
+        feed = MqttFeed()
+        # Should not raise, just warn
+        feed.subscribe("agent/telemetry/cpu")
+
+    @pytest.mark.asyncio
+    async def test_subscribe_with_proto(self):
+        app = MagicMock()
+        mock_client = MagicMock()
+        proto_type = MagicMock()
+
+        with patch(
+            "openbad.nervous_system.client.NervousSystemClient"
+        ) as cls:
+            cls.get_instance.return_value = mock_client
+            feed = MqttFeed()
+            await feed.connect(app)
+            feed.subscribe("agent/telemetry/cpu", proto_type)
+
+        mock_client.subscribe.assert_called_once()
+        call_args = mock_client.subscribe.call_args
+        assert call_args[0][0] == "agent/telemetry/cpu"
+        assert call_args[0][1] is proto_type
+
+
+# ── MqttPayload message ─────────────────────────────────────────────
+
+
+class TestMqttPayload:
+    def test_attributes(self):
+        msg = MqttPayload(topic="agent/reflex/state", payload={"state": "IDLE"})
+        assert msg.topic == "agent/reflex/state"
+        assert msg.payload == {"state": "IDLE"}
+
+
+# ── Widget instantiation ────────────────────────────────────────────
+
+
+class TestWidgets:
+    def test_status_panel_instance(self):
+        panel = StatusPanel()
+        assert isinstance(panel, StatusPanel)
+
+    def test_placeholder_panel_instance(self):
+        panel = PlaceholderPanel("test content")
+        assert isinstance(panel, PlaceholderPanel)
+
+    def test_sidebar_instance(self):
+        sidebar = Sidebar()
+        assert isinstance(sidebar, Sidebar)
+
+
+# ── App instantiation ───────────────────────────────────────────────
+
+
+class TestOpenBaDApp:
+    def test_app_creation(self):
+        app = OpenBaDApp(mqtt_host="testhost", mqtt_port=9999)
+        assert app.feed.host == "testhost"
+        assert app.feed.port == 9999
+        assert app.TITLE == "OpenBaD"
+
+    def test_app_default_params(self):
+        app = OpenBaDApp()
+        assert app.feed.host == "localhost"
+        assert app.feed.port == 1883
+
+    def test_app_has_bindings(self):
+        app = OpenBaDApp()
+        binding_keys = [b.key for b in app.BINDINGS]
+        assert "q" in binding_keys
+        assert "d" in binding_keys
+        assert "r" in binding_keys
+
+
+# ── CLI command ──────────────────────────────────────────────────────
+
+
+class TestTuiCliCommand:
+    def test_tui_command_exists(self):
+        from click.testing import CliRunner
+
+        from openbad.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["tui", "--help"])
+        assert result.exit_code == 0
+        assert "terminal ui" in result.output.lower()
+
+    def test_tui_command_accepts_host_port(self):
+        from click.testing import CliRunner
+
+        from openbad.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["tui", "--help"])
+        assert "--host" in result.output
+        assert "--port" in result.output


### PR DESCRIPTION
Closes #180

## Summary
- Add `textual>=0.80` as optional `tui` dependency in pyproject.toml
- Create `src/openbad/tui/` package:
  - `app.py` — Textual App with Header/Footer, Sidebar, StatusPanel, PlaceholderPanels for hormones/FSM/inference/vitals
  - `mqtt_feed.py` — MqttFeed bridge: connects NervousSystemClient, posts Textual messages (MqttConnected, MqttDisconnected, MqttPayload)
- Wire `openbad tui` CLI command with `--host`/`--port` options, graceful ImportError if textual not installed
- Key bindings: q (quit), d (dark/light toggle), r (reconnect)
- 15 tests: feed lifecycle, subscriptions, widget instantiation, app creation, CLI command

## How to Test
```bash
pip install textual>=0.80
pytest tests/test_tui.py -v
```