### PR TITLE
#181: TUI hormone gauges and FSM state panels

### DIFF
--- a/src/openbad/tui/app.py
+++ b/src/openbad/tui/app.py
@@ -12,7 +12,8 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Footer, Header, Static
 
-from openbad.tui.mqtt_feed import MqttDisconnected, MqttFeed
+from openbad.tui.mqtt_feed import MqttConnected, MqttDisconnected, MqttFeed, MqttPayload
+from openbad.tui.panels import FSMPanel, HormonePanel
 
 # ── Placeholder panels (replaced by #181-#183) ──────────────────────
 
@@ -119,8 +120,8 @@ class OpenBaDApp(App):
             with Vertical(id="panels"):
                 yield StatusPanel()
                 with Horizontal(id="top-panels"):
-                    yield PlaceholderPanel("[dim]Hormone gauges (issue #181)[/dim]")
-                    yield PlaceholderPanel("[dim]FSM state (issue #181)[/dim]")
+                    yield HormonePanel(id="hormone-panel")
+                    yield FSMPanel(id="fsm-panel")
                 with Horizontal(id="bottom-panels"):
                     yield PlaceholderPanel("[dim]Inference (issue #182)[/dim]")
                     yield PlaceholderPanel("[dim]Vitals (issue #182)[/dim]")
@@ -128,6 +129,16 @@ class OpenBaDApp(App):
 
     async def on_mount(self) -> None:
         await self.feed.connect(self)
+        self._subscribe_topics()
+
+    def _subscribe_topics(self) -> None:
+        """Subscribe to hormone and FSM state topics."""
+        if not self.feed.is_connected:
+            return
+        # Wildcard subscription for all endocrine hormones
+        self.feed.subscribe("agent/endocrine/+")
+        # FSM state changes
+        self.feed.subscribe("agent/reflex/state")
 
     async def on_unmount(self) -> None:
         await self.feed.disconnect()
@@ -135,6 +146,38 @@ class OpenBaDApp(App):
     def on_mqtt_disconnected(self, _message: MqttDisconnected) -> None:
         status = self.query_one(StatusPanel)
         status.update("FSM: -- | [red]MQTT: disconnected[/red] | Hormones: --")
+
+    def on_mqtt_connected(self, _message: MqttConnected) -> None:
+        status = self.query_one(StatusPanel)
+        status.update("FSM: -- | [green]MQTT: connected[/green] | Hormones: --")
+        self._subscribe_topics()
+
+    def on_mqtt_payload(self, message: MqttPayload) -> None:
+        """Route incoming MQTT messages to the appropriate panel."""
+        topic = message.topic
+        payload = message.payload
+
+        if topic.startswith("agent/endocrine/"):
+            hormone = topic.rsplit("/", 1)[-1]
+            try:
+                panel = self.query_one("#hormone-panel", HormonePanel)
+                level = float(getattr(payload, "level", payload))
+                panel.update_levels({hormone: level})
+            except Exception:  # noqa: BLE001, S110
+                pass
+
+        elif topic == "agent/reflex/state":
+            try:
+                fsm = self.query_one("#fsm-panel", FSMPanel)
+                state = str(getattr(payload, "state", payload))
+                fsm.state = state
+                # Also update the status bar
+                status = self.query_one(StatusPanel)
+                status.update(
+                    f"FSM: {state} | [green]MQTT: connected[/green] | Hormones: live"
+                )
+            except Exception:  # noqa: BLE001, S110
+                pass
 
     def action_reconnect(self) -> None:
         """Reconnect to the MQTT broker."""

--- a/src/openbad/tui/panels.py
+++ b/src/openbad/tui/panels.py
@@ -1,0 +1,128 @@
+"""Hormone gauge and FSM state panels for the TUI."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.reactive import reactive
+from textual.widgets import Static
+
+# ── Hormone constants ────────────────────────────────────────────────
+
+HORMONES = ("dopamine", "adrenaline", "cortisol", "endorphin")
+
+HORMONE_COLOURS = {
+    "dopamine": "green",
+    "adrenaline": "red",
+    "cortisol": "yellow",
+    "endorphin": "cyan",
+}
+
+# ── Gauge bar helper ─────────────────────────────────────────────────
+
+_BAR_WIDTH = 20
+
+
+def _bar(value: float, colour: str) -> str:
+    """Render a horizontal gauge bar using Rich markup."""
+    clamped = max(0.0, min(1.0, value))
+    filled = round(clamped * _BAR_WIDTH)
+    empty = _BAR_WIDTH - filled
+    return f"[{colour}]{'█' * filled}[/{colour}]{'░' * empty} {clamped:.0%}"
+
+
+# ── Single hormone gauge ─────────────────────────────────────────────
+
+
+class HormoneGauge(Static):
+    """Displays one hormone as a labelled progress bar."""
+
+    DEFAULT_CSS = """
+    HormoneGauge {
+        height: 1;
+        padding: 0 1;
+    }
+    """
+
+    level: reactive[float] = reactive(0.0)
+
+    def __init__(self, hormone: str, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self.hormone = hormone
+        self._colour = HORMONE_COLOURS.get(hormone, "white")
+
+    def render(self) -> str:  # type: ignore[override]
+        return f"{self.hormone:<12} {_bar(self.level, self._colour)}"
+
+
+# ── Hormone panel (groups all gauges) ────────────────────────────────
+
+
+class HormonePanel(Static):
+    """Panel containing gauges for all four hormones."""
+
+    DEFAULT_CSS = """
+    HormonePanel {
+        height: 1fr;
+        border: solid $accent;
+        padding: 1;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Static("[b]Hormones[/b]")
+        with Vertical():
+            for h in HORMONES:
+                yield HormoneGauge(h, id=f"gauge-{h}")
+
+    def update_levels(self, levels: dict[str, float]) -> None:
+        """Update gauge levels from a ``{hormone: float}`` dict."""
+        for name, value in levels.items():
+            gauge_id = f"gauge-{name}"
+            try:
+                gauge = self.query_one(f"#{gauge_id}", HormoneGauge)
+                gauge.level = value
+            except Exception:  # noqa: BLE001, S110
+                pass
+
+
+# ── FSM state panel ──────────────────────────────────────────────────
+
+FSM_STATES = ("IDLE", "ACTIVE", "THROTTLED", "SLEEP", "EMERGENCY")
+
+STATE_COLOURS = {
+    "IDLE": "dim white",
+    "ACTIVE": "green",
+    "THROTTLED": "yellow",
+    "SLEEP": "cyan",
+    "EMERGENCY": "bold red",
+}
+
+
+class FSMPanel(Static):
+    """Displays the current FSM state and available transitions."""
+
+    DEFAULT_CSS = """
+    FSMPanel {
+        height: 1fr;
+        border: solid $accent;
+        padding: 1;
+    }
+    """
+
+    state: reactive[str] = reactive("UNKNOWN")
+
+    def render(self) -> str:  # type: ignore[override]
+        colour = STATE_COLOURS.get(self.state, "white")
+        lines = [
+            "[b]FSM State[/b]",
+            "",
+            f"  Current: [{colour}]{self.state}[/{colour}]",
+            "",
+            "  States:",
+        ]
+        for s in FSM_STATES:
+            marker = "▸" if s == self.state else " "
+            sc = STATE_COLOURS.get(s, "white")
+            lines.append(f"    {marker} [{sc}]{s}[/{sc}]")
+        return "\n".join(lines)

--- a/tests/test_tui_panels.py
+++ b/tests/test_tui_panels.py
@@ -1,0 +1,124 @@
+"""Tests for TUI hormone gauge and FSM state panels."""
+
+from __future__ import annotations
+
+from openbad.tui.panels import (
+    FSM_STATES,
+    HORMONE_COLOURS,
+    HORMONES,
+    STATE_COLOURS,
+    FSMPanel,
+    HormoneGauge,
+    HormonePanel,
+    _bar,
+)
+
+# ── Bar helper ───────────────────────────────────────────────────────
+
+
+class TestBarHelper:
+    def test_zero(self):
+        result = _bar(0.0, "green")
+        assert "0%" in result
+
+    def test_full(self):
+        result = _bar(1.0, "green")
+        assert "100%" in result
+        assert "█" in result
+
+    def test_half(self):
+        result = _bar(0.5, "red")
+        assert "50%" in result
+
+    def test_clamps_above_one(self):
+        result = _bar(1.5, "green")
+        assert "100%" in result
+
+    def test_clamps_below_zero(self):
+        result = _bar(-0.5, "green")
+        assert "0%" in result
+
+
+# ── HormoneGauge ─────────────────────────────────────────────────────
+
+
+class TestHormoneGauge:
+    def test_creation(self):
+        g = HormoneGauge("dopamine")
+        assert g.hormone == "dopamine"
+        assert g.level == 0.0
+
+    def test_render_contains_name(self):
+        g = HormoneGauge("cortisol")
+        text = g.render()
+        assert "cortisol" in text
+
+    def test_level_reactive(self):
+        g = HormoneGauge("adrenaline")
+        g.level = 0.75
+        assert g.level == 0.75
+
+
+# ── HormonePanel ─────────────────────────────────────────────────────
+
+
+class TestHormonePanel:
+    def test_creation(self):
+        panel = HormonePanel()
+        assert isinstance(panel, HormonePanel)
+
+
+# ── FSMPanel ─────────────────────────────────────────────────────────
+
+
+class TestFSMPanel:
+    def test_creation(self):
+        panel = FSMPanel()
+        assert panel.state == "UNKNOWN"
+
+    def test_render_shows_state(self):
+        panel = FSMPanel()
+        panel.state = "ACTIVE"
+        text = panel.render()
+        assert "ACTIVE" in text
+        assert "FSM State" in text
+
+    def test_render_shows_all_states(self):
+        panel = FSMPanel()
+        text = panel.render()
+        for s in FSM_STATES:
+            assert s in text
+
+    def test_current_marker(self):
+        panel = FSMPanel()
+        panel.state = "THROTTLED"
+        text = panel.render()
+        # The current state should have marker ▸
+        for line in text.split("\n"):
+            if "THROTTLED" in line and "Current" not in line:
+                assert "▸" in line
+
+
+# ── Constants ────────────────────────────────────────────────────────
+
+
+class TestConstants:
+    def test_hormones_tuple(self):
+        assert len(HORMONES) == 4
+        assert "dopamine" in HORMONES
+        assert "adrenaline" in HORMONES
+        assert "cortisol" in HORMONES
+        assert "endorphin" in HORMONES
+
+    def test_hormone_colours_complete(self):
+        for h in HORMONES:
+            assert h in HORMONE_COLOURS
+
+    def test_fsm_states(self):
+        assert len(FSM_STATES) == 5
+        assert "IDLE" in FSM_STATES
+        assert "EMERGENCY" in FSM_STATES
+
+    def test_state_colours_complete(self):
+        for s in FSM_STATES:
+            assert s in STATE_COLOURS


### PR DESCRIPTION
Closes #181

## Summary
- Create `src/openbad/tui/panels.py`:
  - `HormoneGauge` — reactive widget displaying a single hormone as a labelled colour progress bar
  - `HormonePanel` — composite panel with gauges for dopamine, adrenaline, cortisol, endorphin; `update_levels()` API
  - `FSMPanel` — reactive widget showing current FSM state with colour-coded state list and current-state marker
  - Constants: `HORMONES`, `HORMONE_COLOURS`, `FSM_STATES`, `STATE_COLOURS`
- Update `app.py`: replace top placeholder panels with HormonePanel + FSMPanel, add MQTT subscriptions for `agent/endocrine/+` and `agent/reflex/state`, route MqttPayload messages to panels, handle MqttConnected
- 17 panel tests + 15 existing TUI tests = 32 total

## How to Test
```bash
pytest tests/test_tui.py tests/test_tui_panels.py -v
```