### PR TITLE
#182: TUI inference and vitals panels

### DIFF
--- a/src/openbad/tui/app.py
+++ b/src/openbad/tui/app.py
@@ -12,8 +12,19 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Footer, Header, Static
 
+from openbad.nervous_system import topics
+from openbad.nervous_system.schemas.cognitive_pb2 import ModelHealthStatus, ReasoningResponse
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexState
+from openbad.nervous_system.schemas.telemetry_pb2 import (
+    CpuTelemetry,
+    DiskTelemetry,
+    MemoryTelemetry,
+    NetworkTelemetry,
+    TokenTelemetry,
+)
 from openbad.tui.mqtt_feed import MqttConnected, MqttDisconnected, MqttFeed, MqttPayload
-from openbad.tui.panels import FSMPanel, HormonePanel
+from openbad.tui.panels import FSMPanel, HormonePanel, InferencePanel, VitalsPanel
 
 # ── Placeholder panels (replaced by #181-#183) ──────────────────────
 
@@ -123,8 +134,8 @@ class OpenBaDApp(App):
                     yield HormonePanel(id="hormone-panel")
                     yield FSMPanel(id="fsm-panel")
                 with Horizontal(id="bottom-panels"):
-                    yield PlaceholderPanel("[dim]Inference (issue #182)[/dim]")
-                    yield PlaceholderPanel("[dim]Vitals (issue #182)[/dim]")
+                    yield InferencePanel(id="inference-panel")
+                    yield VitalsPanel(id="vitals-panel")
         yield Footer()
 
     async def on_mount(self) -> None:
@@ -135,10 +146,15 @@ class OpenBaDApp(App):
         """Subscribe to hormone and FSM state topics."""
         if not self.feed.is_connected:
             return
-        # Wildcard subscription for all endocrine hormones
-        self.feed.subscribe("agent/endocrine/+")
-        # FSM state changes
-        self.feed.subscribe("agent/reflex/state")
+        self.feed.subscribe(topics.ENDOCRINE_ALL, EndocrineEvent)
+        self.feed.subscribe(topics.REFLEX_STATE, ReflexState)
+        self.feed.subscribe(topics.TELEMETRY_CPU, CpuTelemetry)
+        self.feed.subscribe(topics.TELEMETRY_MEMORY, MemoryTelemetry)
+        self.feed.subscribe(topics.TELEMETRY_DISK, DiskTelemetry)
+        self.feed.subscribe(topics.TELEMETRY_NETWORK, NetworkTelemetry)
+        self.feed.subscribe(topics.TELEMETRY_TOKENS, TokenTelemetry)
+        self.feed.subscribe(topics.COGNITIVE_HEALTH, ModelHealthStatus)
+        self.feed.subscribe(topics.COGNITIVE_RESPONSE, ReasoningResponse)
 
     async def on_unmount(self) -> None:
         await self.feed.disconnect()
@@ -166,10 +182,10 @@ class OpenBaDApp(App):
             except Exception:  # noqa: BLE001, S110
                 pass
 
-        elif topic == "agent/reflex/state":
+        elif topic == topics.REFLEX_STATE:
             try:
                 fsm = self.query_one("#fsm-panel", FSMPanel)
-                state = str(getattr(payload, "state", payload))
+                state = str(getattr(payload, "current_state", payload))
                 fsm.state = state
                 # Also update the status bar
                 status = self.query_one(StatusPanel)
@@ -178,6 +194,43 @@ class OpenBaDApp(App):
                 )
             except Exception:  # noqa: BLE001, S110
                 pass
+
+        elif topic == topics.TELEMETRY_CPU:
+            panel = self.query_one("#vitals-panel", VitalsPanel)
+            panel.cpu_usage = float(payload.usage_percent)
+
+        elif topic == topics.TELEMETRY_MEMORY:
+            panel = self.query_one("#vitals-panel", VitalsPanel)
+            panel.mem_usage = float(payload.usage_percent)
+
+        elif topic == topics.TELEMETRY_DISK:
+            panel = self.query_one("#vitals-panel", VitalsPanel)
+            panel.disk_usage = float(payload.usage_percent)
+
+        elif topic == topics.TELEMETRY_NETWORK:
+            panel = self.query_one("#vitals-panel", VitalsPanel)
+            panel.net_sent = float(payload.bytes_sent)
+            panel.net_recv = float(payload.bytes_recv)
+
+        elif topic == topics.TELEMETRY_TOKENS:
+            panel = self.query_one("#vitals-panel", VitalsPanel)
+            panel.tokens_used = int(payload.tokens_used)
+            panel.token_remaining = float(payload.budget_remaining_pct)
+            panel.model_tier = str(payload.model_tier)
+
+        elif topic == topics.COGNITIVE_HEALTH:
+            panel = self.query_one("#inference-panel", InferencePanel)
+            panel.provider = str(payload.provider)
+            panel.model_id = str(payload.model_id)
+            panel.available = bool(payload.available)
+            panel.latency_p50 = float(payload.latency_p50)
+            panel.latency_p99 = float(payload.latency_p99)
+
+        elif topic == topics.COGNITIVE_RESPONSE:
+            panel = self.query_one("#inference-panel", InferencePanel)
+            panel.last_model_used = str(payload.model_used)
+            panel.last_tokens = int(payload.tokens_used)
+            panel.last_latency_ms = float(payload.latency_ms)
 
     def action_reconnect(self) -> None:
         """Reconnect to the MQTT broker."""

--- a/src/openbad/tui/mqtt_feed.py
+++ b/src/openbad/tui/mqtt_feed.py
@@ -87,24 +87,16 @@ class MqttFeed:
 
     # ── subscriptions ────────────────────────────────────────────
 
-    def subscribe(self, topic: str, proto_type: type | None = None) -> None:
-        """Subscribe to *topic* and post ``MqttPayload`` messages to the app.
-
-        If *proto_type* is ``None`` the raw payload bytes are forwarded.
-        """
+    def subscribe(self, topic: str, proto_type: type) -> None:
+        """Subscribe to *topic* and post decoded payloads to the app."""
         if self._client is None:
             log.warning("subscribe() called before connect()")
             return
 
         def _on_message(topic_str: str, msg: Any) -> None:  # noqa: ANN401
-            payload = msg if proto_type is not None else msg
-            self._post(MqttPayload(topic=topic_str, payload=payload))
+            self._post(MqttPayload(topic=topic_str, payload=msg))
 
-        if proto_type is not None:
-            self._client.subscribe(topic, proto_type, _on_message)
-        else:
-            # Raw subscribe — use low-level paho callback if available
-            self._client.subscribe(topic, None, _on_message)
+        self._client.subscribe(topic, proto_type, _on_message)
 
     # ── helpers ──────────────────────────────────────────────────
 

--- a/src/openbad/tui/panels.py
+++ b/src/openbad/tui/panels.py
@@ -126,3 +126,88 @@ class FSMPanel(Static):
             sc = STATE_COLOURS.get(s, "white")
             lines.append(f"    {marker} [{sc}]{s}[/{sc}]")
         return "\n".join(lines)
+
+
+def _bytes_human(value: float) -> str:
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(value)
+    idx = 0
+    while size >= 1024 and idx < len(units) - 1:
+        size /= 1024.0
+        idx += 1
+    return f"{size:.1f} {units[idx]}"
+
+
+class VitalsPanel(Static):
+    """Displays key runtime telemetry from interoception topics."""
+
+    DEFAULT_CSS = """
+    VitalsPanel {
+        height: 1fr;
+        border: solid $accent;
+        padding: 1;
+    }
+    """
+
+    cpu_usage: reactive[float] = reactive(0.0)
+    mem_usage: reactive[float] = reactive(0.0)
+    disk_usage: reactive[float] = reactive(0.0)
+    net_sent: reactive[float] = reactive(0.0)
+    net_recv: reactive[float] = reactive(0.0)
+    tokens_used: reactive[int] = reactive(0)
+    token_remaining: reactive[float] = reactive(0.0)
+    model_tier: reactive[str] = reactive("--")
+
+    def render(self) -> str:  # type: ignore[override]
+        return "\n".join(
+            [
+                "[b]Vitals[/b]",
+                "",
+                f"CPU:    {self.cpu_usage:5.1f}%",
+                f"Memory: {self.mem_usage:5.1f}%",
+                f"Disk:   {self.disk_usage:5.1f}%",
+                f"Net TX: {_bytes_human(self.net_sent)}",
+                f"Net RX: {_bytes_human(self.net_recv)}",
+                f"Tokens: {self.tokens_used} ({self.token_remaining:4.1f}% left)",
+                f"Tier:   {self.model_tier}",
+            ]
+        )
+
+
+class InferencePanel(Static):
+    """Displays cognitive inference health and latest response metadata."""
+
+    DEFAULT_CSS = """
+    InferencePanel {
+        height: 1fr;
+        border: solid $accent;
+        padding: 1;
+    }
+    """
+
+    provider: reactive[str] = reactive("--")
+    model_id: reactive[str] = reactive("--")
+    available: reactive[bool] = reactive(False)
+    latency_p50: reactive[float] = reactive(0.0)
+    latency_p99: reactive[float] = reactive(0.0)
+    last_model_used: reactive[str] = reactive("--")
+    last_tokens: reactive[int] = reactive(0)
+    last_latency_ms: reactive[float] = reactive(0.0)
+
+    def render(self) -> str:  # type: ignore[override]
+        availability = "[green]up[/green]" if self.available else "[red]down[/red]"
+        return "\n".join(
+            [
+                "[b]Inference[/b]",
+                "",
+                f"Provider: {self.provider}",
+                f"Model:    {self.model_id}",
+                f"Health:   {availability}",
+                f"p50/p99:  {self.latency_p50:.1f}ms / {self.latency_p99:.1f}ms",
+                "",
+                "Last response:",
+                f"  model:  {self.last_model_used}",
+                f"  tokens: {self.last_tokens}",
+                f"  latency:{self.last_latency_ms:.1f}ms",
+            ]
+        )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -78,7 +78,7 @@ class TestMqttFeed:
     def test_subscribe_without_connect(self):
         feed = MqttFeed()
         # Should not raise, just warn
-        feed.subscribe("agent/telemetry/cpu")
+        feed.subscribe("agent/telemetry/cpu", MagicMock)
 
     @pytest.mark.asyncio
     async def test_subscribe_with_proto(self):

--- a/tests/test_tui_inference_vitals.py
+++ b/tests/test_tui_inference_vitals.py
@@ -1,0 +1,151 @@
+"""Tests for #182 inference and vitals TUI panels and message routing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from openbad.nervous_system import topics
+from openbad.nervous_system.schemas.cognitive_pb2 import ModelHealthStatus, ReasoningResponse
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.nervous_system.schemas.reflex_pb2 import ReflexState
+from openbad.nervous_system.schemas.telemetry_pb2 import (
+    CpuTelemetry,
+    DiskTelemetry,
+    MemoryTelemetry,
+    NetworkTelemetry,
+    TokenTelemetry,
+)
+from openbad.tui.app import OpenBaDApp
+from openbad.tui.mqtt_feed import MqttPayload
+from openbad.tui.panels import InferencePanel, VitalsPanel
+
+
+class TestVitalAndInferencePanels:
+    def test_panel_instantiation(self):
+        assert isinstance(VitalsPanel(), VitalsPanel)
+        assert isinstance(InferencePanel(), InferencePanel)
+
+
+class TestTopicSubscriptionWiring:
+    def test_subscribe_topics_registers_expected_proto_topics(self):
+        app = OpenBaDApp()
+        app.feed = MagicMock()
+        app.feed.is_connected = True
+
+        app._subscribe_topics()
+
+        subscribed = [c[0][0] for c in app.feed.subscribe.call_args_list]
+        assert topics.ENDOCRINE_ALL in subscribed
+        assert topics.REFLEX_STATE in subscribed
+        assert topics.TELEMETRY_CPU in subscribed
+        assert topics.TELEMETRY_MEMORY in subscribed
+        assert topics.TELEMETRY_DISK in subscribed
+        assert topics.TELEMETRY_NETWORK in subscribed
+        assert topics.TELEMETRY_TOKENS in subscribed
+        assert topics.COGNITIVE_HEALTH in subscribed
+        assert topics.COGNITIVE_RESPONSE in subscribed
+
+
+class TestMessageRoutingWithoutUIRuntime:
+    def test_reflex_payload_uses_current_state_field(self):
+        app = OpenBaDApp()
+        fsm = MagicMock()
+        status = MagicMock()
+
+        def _query_one(selector, _type=None):
+            if selector == "#fsm-panel":
+                return fsm
+            return status
+
+        app.query_one = _query_one  # type: ignore[method-assign]
+
+        msg = ReflexState(current_state="ACTIVE")
+        app.on_mqtt_payload(MqttPayload(topics.REFLEX_STATE, msg))
+
+        assert fsm.state == "ACTIVE"
+
+    def test_endocrine_payload_reads_level_field(self):
+        app = OpenBaDApp()
+        hormones = MagicMock()
+
+        def _query_one(selector, _type=None):
+            return hormones
+
+        app.query_one = _query_one  # type: ignore[method-assign]
+
+        msg = EndocrineEvent(hormone="cortisol", level=0.72)
+        app.on_mqtt_payload(MqttPayload("agent/endocrine/cortisol", msg))
+        hormones.update_levels.assert_called_once_with({"cortisol": 0.72})
+
+    def test_telemetry_updates_vitals_panel_fields(self):
+        app = OpenBaDApp()
+        vitals = MagicMock()
+
+        def _query_one(selector, _type=None):
+            return vitals
+
+        app.query_one = _query_one  # type: ignore[method-assign]
+
+        app.on_mqtt_payload(MqttPayload(topics.TELEMETRY_CPU, CpuTelemetry(usage_percent=40.5)))
+        app.on_mqtt_payload(
+            MqttPayload(topics.TELEMETRY_MEMORY, MemoryTelemetry(usage_percent=71.2))
+        )
+        app.on_mqtt_payload(MqttPayload(topics.TELEMETRY_DISK, DiskTelemetry(usage_percent=55.1)))
+        app.on_mqtt_payload(
+            MqttPayload(
+                topics.TELEMETRY_NETWORK,
+                NetworkTelemetry(bytes_sent=2048, bytes_recv=4096),
+            )
+        )
+        app.on_mqtt_payload(
+            MqttPayload(
+                topics.TELEMETRY_TOKENS,
+                TokenTelemetry(tokens_used=1234, budget_remaining_pct=83.3, model_tier="slm"),
+            )
+        )
+
+        assert vitals.cpu_usage == 40.5
+        assert vitals.mem_usage == 71.2
+        assert vitals.disk_usage == 55.1
+        assert vitals.net_sent == 2048.0
+        assert vitals.net_recv == 4096.0
+        assert vitals.tokens_used == 1234
+        assert vitals.token_remaining == 83.3
+        assert vitals.model_tier == "slm"
+
+    def test_cognitive_updates_inference_panel_fields(self):
+        app = OpenBaDApp()
+        inference = MagicMock()
+
+        def _query_one(selector, _type=None):
+            return inference
+
+        app.query_one = _query_one  # type: ignore[method-assign]
+
+        app.on_mqtt_payload(
+            MqttPayload(
+                topics.COGNITIVE_HEALTH,
+                ModelHealthStatus(
+                    provider="ollama",
+                    model_id="phi3",
+                    available=True,
+                    latency_p50=52.1,
+                    latency_p99=131.4,
+                ),
+            )
+        )
+        app.on_mqtt_payload(
+            MqttPayload(
+                topics.COGNITIVE_RESPONSE,
+                ReasoningResponse(model_used="phi3", tokens_used=218, latency_ms=87.5),
+            )
+        )
+
+        assert inference.provider == "ollama"
+        assert inference.model_id == "phi3"
+        assert inference.available is True
+        assert inference.latency_p50 == 52.1
+        assert inference.latency_p99 == 131.4
+        assert inference.last_model_used == "phi3"
+        assert inference.last_tokens == 218
+        assert inference.last_latency_ms == 87.5


### PR DESCRIPTION
Closes #182

## Summary
- Add Inference and Vitals panels to the Textual TUI
- Wire typed MQTT subscriptions for telemetry, endocrine, reflex, and cognitive topics
- Route protobuf payloads into reactive panel state updates
- Add focused tests for topic subscription and message routing

## How To Test
- .venv\\Scripts\\python.exe -m pytest tests/test_tui.py tests/test_tui_panels.py tests/test_tui_inference_vitals.py -q
- .venv\\Scripts\\python.exe -m ruff check src/openbad/tui/ tests/test_tui.py tests/test_tui_panels.py tests/test_tui_inference_vitals.py