### PR TITLE
#183: TUI event log and command bar

### DIFF
--- a/src/openbad/tui/app.py
+++ b/src/openbad/tui/app.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Footer, Header, Static
+from textual.widgets import Footer, Header, Input, Static
 
 from openbad.nervous_system import topics
 from openbad.nervous_system.schemas.cognitive_pb2 import ModelHealthStatus, ReasoningResponse
@@ -24,7 +24,14 @@ from openbad.nervous_system.schemas.telemetry_pb2 import (
     TokenTelemetry,
 )
 from openbad.tui.mqtt_feed import MqttConnected, MqttDisconnected, MqttFeed, MqttPayload
-from openbad.tui.panels import FSMPanel, HormonePanel, InferencePanel, VitalsPanel
+from openbad.tui.panels import (
+    CommandBar,
+    EventLogPanel,
+    FSMPanel,
+    HormonePanel,
+    InferencePanel,
+    VitalsPanel,
+)
 
 # ── Placeholder panels (replaced by #181-#183) ──────────────────────
 
@@ -107,12 +114,19 @@ class OpenBaDApp(App):
     #bottom-panels {
         height: 1fr;
     }
+    #event-row {
+        height: 14;
+    }
+    #command-bar {
+        height: 3;
+    }
     """
 
     BINDINGS = [
         Binding("q", "quit", "Quit", show=True),
         Binding("d", "toggle_dark", "Dark/Light", show=True),
         Binding("r", "reconnect", "Reconnect", show=True),
+        Binding(":", "focus_command", "Command", show=True),
     ]
 
     def __init__(
@@ -136,6 +150,12 @@ class OpenBaDApp(App):
                 with Horizontal(id="bottom-panels"):
                     yield InferencePanel(id="inference-panel")
                     yield VitalsPanel(id="vitals-panel")
+                with Horizontal(id="event-row"):
+                    yield EventLogPanel(id="event-log-panel")
+                yield CommandBar(
+                    placeholder="Type command: help | clear | reconnect | dark | quit",
+                    id="command-bar",
+                )
         yield Footer()
 
     async def on_mount(self) -> None:
@@ -167,11 +187,13 @@ class OpenBaDApp(App):
         status = self.query_one(StatusPanel)
         status.update("FSM: -- | [green]MQTT: connected[/green] | Hormones: --")
         self._subscribe_topics()
+        self._log_event("[green]MQTT connected[/green]")
 
     def on_mqtt_payload(self, message: MqttPayload) -> None:
         """Route incoming MQTT messages to the appropriate panel."""
         topic = message.topic
         payload = message.payload
+        self._log_event(f"[cyan]{topic}[/cyan] {self._payload_summary(payload)}")
 
         if topic.startswith("agent/endocrine/"):
             hormone = topic.rsplit("/", 1)[-1]
@@ -236,6 +258,52 @@ class OpenBaDApp(App):
         """Reconnect to the MQTT broker."""
         self.run_worker(self.feed.disconnect())
         self.run_worker(self.feed.connect(self))
+        self._log_event("[yellow]Reconnect requested[/yellow]")
+
+    def action_focus_command(self) -> None:
+        bar = self.query_one("#command-bar", CommandBar)
+        bar.focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id != "command-bar":
+            return
+        command = event.value.strip().lower()
+        event.input.value = ""
+        if not command:
+            return
+
+        self._log_event(f"[white]> {command}[/white]")
+        if command == "help":
+            self._log_event("Commands: help, clear, reconnect, dark, quit")
+        elif command == "clear":
+            panel = self.query_one("#event-log-panel", EventLogPanel)
+            panel.clear()
+            self._log_event("[dim]Event log cleared[/dim]")
+        elif command == "reconnect":
+            self.action_reconnect()
+        elif command == "dark":
+            self.action_toggle_dark()
+        elif command == "quit":
+            self.action_quit()
+        else:
+            self._log_event(f"[red]Unknown command:[/red] {command}")
 
     def action_toggle_dark(self) -> None:
         self.dark = not self.dark
+
+    def _log_event(self, line: str) -> None:
+        try:
+            panel = self.query_one("#event-log-panel", EventLogPanel)
+            panel.write(line)
+        except Exception:  # noqa: BLE001, S110
+            pass
+
+    @staticmethod
+    def _payload_summary(payload: object) -> str:
+        if hasattr(payload, "ListFields"):
+            fields = payload.ListFields()[:3]
+            if not fields:
+                return "{}"
+            parts = [f"{descriptor.name}={value}" for descriptor, value in fields]
+            return "{" + ", ".join(parts) + "}"
+        return str(payload)

--- a/src/openbad/tui/panels.py
+++ b/src/openbad/tui/panels.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.reactive import reactive
-from textual.widgets import Static
+from textual.widgets import Input, RichLog, Static
 
 # ── Hormone constants ────────────────────────────────────────────────
 
@@ -211,3 +211,46 @@ class InferencePanel(Static):
                 f"  latency:{self.last_latency_ms:.1f}ms",
             ]
         )
+
+
+class EventLogPanel(Static):
+    """Scrollable event log for incoming MQTT activity and user commands."""
+
+    DEFAULT_CSS = """
+    EventLogPanel {
+        height: 14;
+        border: solid $accent;
+        padding: 1;
+    }
+    #event-log-title {
+        height: 1;
+    }
+    #event-log-view {
+        height: 1fr;
+        border: solid $surface;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Static("[b]Event Log[/b]", id="event-log-title")
+        yield RichLog(highlight=True, wrap=True, id="event-log-view")
+
+    def write(self, line: str) -> None:
+        log = self.query_one("#event-log-view", RichLog)
+        log.write(line)
+
+    def clear(self) -> None:
+        log = self.query_one("#event-log-view", RichLog)
+        log.clear()
+
+
+class CommandBar(Input):
+    """Bottom command input for slash-like operator commands."""
+
+    DEFAULT_CSS = """
+    CommandBar {
+        dock: bottom;
+        height: 3;
+        border: solid $primary;
+    }
+    """

--- a/tests/test_tui_eventlog_commandbar.py
+++ b/tests/test_tui_eventlog_commandbar.py
@@ -1,0 +1,131 @@
+"""Tests for #183 TUI event log and command bar behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.tui.app import OpenBaDApp
+from openbad.tui.panels import CommandBar, EventLogPanel
+
+
+class TestPanelAndBarTypes:
+    def test_event_log_panel_instantiates(self):
+        assert isinstance(EventLogPanel(), EventLogPanel)
+
+    def test_command_bar_instantiates(self):
+        assert isinstance(CommandBar(), CommandBar)
+
+
+class TestAppEventHelpers:
+    def test_payload_summary_for_proto(self):
+        payload = EndocrineEvent(hormone="cortisol", level=0.4)
+        text = OpenBaDApp._payload_summary(payload)
+        assert "hormone" in text
+        assert "level" in text
+
+    def test_payload_summary_for_plain_object(self):
+        text = OpenBaDApp._payload_summary("plain")
+        assert text == "plain"
+
+    def test_focus_command_action(self):
+        app = OpenBaDApp()
+        bar = MagicMock()
+
+        def _query_one(selector, _type=None):
+            assert selector == "#command-bar"
+            return bar
+
+        app.query_one = _query_one  # type: ignore[method-assign]
+        app.action_focus_command()
+        bar.focus.assert_called_once()
+
+    def test_log_event_writes_to_panel(self):
+        app = OpenBaDApp()
+        panel = MagicMock()
+
+        def _query_one(selector, _type=None):
+            assert selector == "#event-log-panel"
+            return panel
+
+        app.query_one = _query_one  # type: ignore[method-assign]
+        app._log_event("hello")
+        panel.write.assert_called_once_with("hello")
+
+
+class TestCommandBarHandling:
+    def _setup_app_with_mocks(self) -> tuple[OpenBaDApp, MagicMock]:
+        app = OpenBaDApp()
+        panel = MagicMock()
+        app._log_event = MagicMock()  # type: ignore[method-assign]
+        app.action_reconnect = MagicMock()  # type: ignore[method-assign]
+        app.action_toggle_dark = MagicMock()  # type: ignore[method-assign]
+        app.action_quit = MagicMock()  # type: ignore[method-assign]
+
+        def _query_one(selector, _type=None):
+            assert selector == "#event-log-panel"
+            return panel
+
+        app.query_one = _query_one  # type: ignore[method-assign]
+        return app, panel
+
+    def test_help_command(self):
+        app, _ = self._setup_app_with_mocks()
+        event = SimpleNamespace(
+            input=SimpleNamespace(id="command-bar", value="help"),
+            value="help",
+        )
+        app.on_input_submitted(event)
+        assert app._log_event.call_count >= 2
+
+    def test_clear_command(self):
+        app, panel = self._setup_app_with_mocks()
+        event = SimpleNamespace(
+            input=SimpleNamespace(id="command-bar", value="clear"),
+            value="clear",
+        )
+        app.on_input_submitted(event)
+        panel.clear.assert_called_once()
+
+    def test_reconnect_command(self):
+        app, _ = self._setup_app_with_mocks()
+        event = SimpleNamespace(
+            input=SimpleNamespace(id="command-bar", value="reconnect"),
+            value="reconnect",
+        )
+        app.on_input_submitted(event)
+        app.action_reconnect.assert_called_once()
+
+    def test_dark_command(self):
+        app, _ = self._setup_app_with_mocks()
+        event = SimpleNamespace(
+            input=SimpleNamespace(id="command-bar", value="dark"),
+            value="dark",
+        )
+        app.on_input_submitted(event)
+        app.action_toggle_dark.assert_called_once()
+
+    def test_quit_command(self):
+        app, _ = self._setup_app_with_mocks()
+        event = SimpleNamespace(
+            input=SimpleNamespace(id="command-bar", value="quit"),
+            value="quit",
+        )
+        app.on_input_submitted(event)
+        app.action_quit.assert_called_once()
+
+    def test_unknown_command(self):
+        app, _ = self._setup_app_with_mocks()
+        event = SimpleNamespace(
+            input=SimpleNamespace(id="command-bar", value="boom"),
+            value="boom",
+        )
+        app.on_input_submitted(event)
+        assert app._log_event.call_count >= 2
+
+    def test_ignores_other_inputs(self):
+        app, _ = self._setup_app_with_mocks()
+        event = SimpleNamespace(input=SimpleNamespace(id="other", value="help"), value="help")
+        app.on_input_submitted(event)
+        app._log_event.assert_not_called()


### PR DESCRIPTION
Closes #183

## Summary
- Add EventLogPanel with scrollable log output
- Add CommandBar input to execute TUI operator commands
- Add command actions: help, clear, reconnect, dark, quit
- Log MQTT topic events and connection events in TUI
- Add tests for command handling and logging behavior

## How To Test
- .venv\\Scripts\\python.exe -m pytest tests/test_tui_eventlog_commandbar.py tests/test_tui.py tests/test_tui_panels.py tests/test_tui_inference_vitals.py -q
- .venv\\Scripts\\python.exe -m ruff check src/openbad/tui/ tests/test_tui.py tests/test_tui_panels.py tests/test_tui_inference_vitals.py tests/test_tui_eventlog_commandbar.py