### PR TITLE
#185: WUI dashboard scaffold and panels

### DIFF
--- a/src/openbad/cli.py
+++ b/src/openbad/cli.py
@@ -114,6 +114,25 @@ def tui(host: str, port: int) -> None:
     app.run()
 
 
+@main.command()
+@click.option("--host", default="127.0.0.1", help="Web UI bind host.")
+@click.option("--port", default=9200, type=int, help="Web UI bind port.")
+@click.option("--mqtt-host", default="localhost", help="MQTT broker host.")
+@click.option("--mqtt-port", default=1883, type=int, help="MQTT broker port.")
+def wui(host: str, port: int, mqtt_host: str, mqtt_port: int) -> None:
+    """Launch the web UI server with MQTT->WebSocket bridge."""
+    from openbad.wui.server import run_server
+
+    asyncio.run(
+        run_server(
+            host=host,
+            port=port,
+            mqtt_host=mqtt_host,
+            mqtt_port=mqtt_port,
+        )
+    )
+
+
 def _configure_logging(verbose: bool) -> None:
     level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(

--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -1,0 +1,58 @@
+"""Web UI server for OpenBaD.
+
+Serves the static dashboard assets and hosts the MQTT->WebSocket bridge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from aiohttp import web
+
+from openbad.wui.bridge import MqttWebSocketBridge
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+
+def create_app(
+    mqtt_host: str = "localhost",
+    mqtt_port: int = 1883,
+    *,
+    enable_mqtt: bool = True,
+) -> web.Application:
+    bridge = MqttWebSocketBridge(mqtt_host=mqtt_host, mqtt_port=mqtt_port)
+    app = bridge.create_app()
+    app["bridge"] = bridge
+
+    if not enable_mqtt:
+        # Tests can disable external broker dependency by skipping startup/shutdown hooks.
+        app.on_startup.clear()
+        app.on_shutdown.clear()
+
+    async def index(_request: web.Request) -> web.FileResponse:
+        return web.FileResponse(STATIC_DIR / "index.html")
+
+    app.router.add_get("/", index)
+    app.router.add_static("/static", STATIC_DIR)
+    return app
+
+
+async def run_server(
+    host: str = "127.0.0.1",
+    port: int = 9200,
+    mqtt_host: str = "localhost",
+    mqtt_port: int = 1883,
+) -> None:
+    app = create_app(mqtt_host=mqtt_host, mqtt_port=mqtt_port, enable_mqtt=True)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host=host, port=port)
+    await site.start()
+
+    try:
+        # Keep running until cancelled.
+        while True:
+            await asyncio.sleep(3600)
+    finally:
+        await runner.cleanup()

--- a/src/openbad/wui/static/app.js
+++ b/src/openbad/wui/static/app.js
@@ -1,0 +1,132 @@
+const els = {
+  status: document.getElementById('ws-status'),
+  fsm: document.getElementById('fsm-state'),
+  hormones: {
+    dopamine: document.getElementById('h-dopamine'),
+    adrenaline: document.getElementById('h-adrenaline'),
+    cortisol: document.getElementById('h-cortisol'),
+    endorphin: document.getElementById('h-endorphin'),
+  },
+  vitals: {
+    cpu: document.getElementById('v-cpu'),
+    memory: document.getElementById('v-memory'),
+    disk: document.getElementById('v-disk'),
+    netTx: document.getElementById('v-net-tx'),
+    netRx: document.getElementById('v-net-rx'),
+    tokens: document.getElementById('v-tokens'),
+    tier: document.getElementById('v-tier'),
+  },
+  inference: {
+    provider: document.getElementById('i-provider'),
+    model: document.getElementById('i-model'),
+    health: document.getElementById('i-health'),
+    p50: document.getElementById('i-p50'),
+    p99: document.getElementById('i-p99'),
+    lastTokens: document.getElementById('i-last-tokens'),
+    lastLatency: document.getElementById('i-last-latency'),
+  },
+  log: document.getElementById('event-log'),
+};
+
+function logLine(text) {
+  const div = document.createElement('div');
+  div.className = 'log-line';
+  div.textContent = text;
+  els.log.prepend(div);
+  while (els.log.children.length > 140) {
+    els.log.removeChild(els.log.lastChild);
+  }
+}
+
+function setOnline(online) {
+  els.status.textContent = online ? 'online' : 'offline';
+  els.status.classList.toggle('online', online);
+  els.status.classList.toggle('offline', !online);
+}
+
+function updateFromEvent(topic, payload) {
+  if (topic.startsWith('agent/endocrine/')) {
+    const hormone = topic.split('/').pop();
+    if (els.hormones[hormone] && typeof payload.level === 'number') {
+      els.hormones[hormone].textContent = payload.level.toFixed(2);
+    }
+    return;
+  }
+
+  if (topic === 'agent/reflex/state') {
+    els.fsm.textContent = payload.current_state || 'UNKNOWN';
+    return;
+  }
+
+  if (topic === 'agent/telemetry/cpu') {
+    els.vitals.cpu.textContent = `${Number(payload.usage_percent || 0).toFixed(1)}%`;
+    return;
+  }
+  if (topic === 'agent/telemetry/memory') {
+    els.vitals.memory.textContent = `${Number(payload.usage_percent || 0).toFixed(1)}%`;
+    return;
+  }
+  if (topic === 'agent/telemetry/disk') {
+    els.vitals.disk.textContent = `${Number(payload.usage_percent || 0).toFixed(1)}%`;
+    return;
+  }
+  if (topic === 'agent/telemetry/network') {
+    els.vitals.netTx.textContent = `${payload.bytes_sent || 0}`;
+    els.vitals.netRx.textContent = `${payload.bytes_recv || 0}`;
+    return;
+  }
+  if (topic === 'agent/telemetry/tokens') {
+    els.vitals.tokens.textContent = `${payload.tokens_used || 0}`;
+    els.vitals.tier.textContent = payload.model_tier || '--';
+    return;
+  }
+
+  if (topic === 'agent/cognitive/health') {
+    els.inference.provider.textContent = payload.provider || '--';
+    els.inference.model.textContent = payload.model_id || '--';
+    els.inference.health.textContent = payload.available ? 'up' : 'down';
+    els.inference.p50.textContent = `${Number(payload.latency_p50 || 0).toFixed(1)}ms`;
+    els.inference.p99.textContent = `${Number(payload.latency_p99 || 0).toFixed(1)}ms`;
+    return;
+  }
+
+  if (topic === 'agent/cognitive/response') {
+    els.inference.lastTokens.textContent = `${payload.tokens_used || 0}`;
+    els.inference.lastLatency.textContent = `${Number(payload.latency_ms || 0).toFixed(1)}ms`;
+  }
+}
+
+function connect() {
+  const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const ws = new WebSocket(`${proto}://${window.location.host}/ws`);
+
+  ws.addEventListener('open', () => {
+    setOnline(true);
+    logLine('socket connected');
+  });
+
+  ws.addEventListener('close', () => {
+    setOnline(false);
+    logLine('socket disconnected; retrying...');
+    setTimeout(connect, 1000);
+  });
+
+  ws.addEventListener('message', (ev) => {
+    try {
+      const msg = JSON.parse(ev.data);
+      if (msg.type === 'hello') {
+        logLine(`[${msg.ts}] ${msg.message}`);
+        return;
+      }
+      if (msg.type === 'event') {
+        const topic = msg.topic || 'unknown/topic';
+        updateFromEvent(topic, msg.payload || {});
+        logLine(`[${msg.ts}] ${topic}`);
+      }
+    } catch {
+      logLine('malformed socket payload received');
+    }
+  });
+}
+
+connect();

--- a/src/openbad/wui/static/index.html
+++ b/src/openbad/wui/static/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenBaD Live Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+  <div class="bg-grid"></div>
+  <main class="shell">
+    <header class="hero reveal">
+      <h1>OpenBaD</h1>
+      <p>Bio-digital runtime observability cockpit</p>
+      <span id="ws-status" class="pill offline">offline</span>
+    </header>
+
+    <section class="grid">
+      <article class="card reveal">
+        <h2>FSM</h2>
+        <p id="fsm-state" class="metric">UNKNOWN</p>
+      </article>
+
+      <article class="card reveal">
+        <h2>Hormones</h2>
+        <div id="hormones" class="stack">
+          <div class="row"><span>Dopamine</span><strong id="h-dopamine">0.00</strong></div>
+          <div class="row"><span>Adrenaline</span><strong id="h-adrenaline">0.00</strong></div>
+          <div class="row"><span>Cortisol</span><strong id="h-cortisol">0.00</strong></div>
+          <div class="row"><span>Endorphin</span><strong id="h-endorphin">0.00</strong></div>
+        </div>
+      </article>
+
+      <article class="card reveal">
+        <h2>Vitals</h2>
+        <div class="stack mono">
+          <div class="row"><span>CPU</span><strong id="v-cpu">0.0%</strong></div>
+          <div class="row"><span>Memory</span><strong id="v-memory">0.0%</strong></div>
+          <div class="row"><span>Disk</span><strong id="v-disk">0.0%</strong></div>
+          <div class="row"><span>Net TX</span><strong id="v-net-tx">0</strong></div>
+          <div class="row"><span>Net RX</span><strong id="v-net-rx">0</strong></div>
+          <div class="row"><span>Tokens</span><strong id="v-tokens">0</strong></div>
+          <div class="row"><span>Tier</span><strong id="v-tier">--</strong></div>
+        </div>
+      </article>
+
+      <article class="card reveal">
+        <h2>Inference</h2>
+        <div class="stack mono">
+          <div class="row"><span>Provider</span><strong id="i-provider">--</strong></div>
+          <div class="row"><span>Model</span><strong id="i-model">--</strong></div>
+          <div class="row"><span>Health</span><strong id="i-health">down</strong></div>
+          <div class="row"><span>p50</span><strong id="i-p50">0.0ms</strong></div>
+          <div class="row"><span>p99</span><strong id="i-p99">0.0ms</strong></div>
+          <div class="row"><span>Last Tokens</span><strong id="i-last-tokens">0</strong></div>
+          <div class="row"><span>Last Latency</span><strong id="i-last-latency">0.0ms</strong></div>
+        </div>
+      </article>
+    </section>
+
+    <section class="log reveal">
+      <h2>Event Stream</h2>
+      <div id="event-log" class="log-body" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <script src="/static/app.js" defer></script>
+</body>
+</html>

--- a/src/openbad/wui/static/styles.css
+++ b/src/openbad/wui/static/styles.css
@@ -1,0 +1,156 @@
+:root {
+  --bg-0: #081017;
+  --bg-1: #15293d;
+  --bg-2: #1f4f63;
+  --card: rgba(10, 22, 32, 0.78);
+  --stroke: rgba(163, 238, 255, 0.22);
+  --text: #ecf6fb;
+  --muted: #98b3c4;
+  --accent: #7af2d9;
+  --warn: #f6d36f;
+  --bad: #ff7d73;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  min-height: 100%;
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  color: var(--text);
+  background: radial-gradient(1200px 800px at 10% 0%, var(--bg-2), var(--bg-0));
+}
+
+.bg-grid {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.035) 1px, transparent 1px);
+  background-size: 36px 36px;
+  mask-image: radial-gradient(circle at center, black 35%, transparent 85%);
+}
+
+.shell {
+  position: relative;
+  z-index: 1;
+  width: min(1200px, 96vw);
+  margin: 1.4rem auto 2rem;
+}
+
+.hero {
+  display: flex;
+  align-items: end;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  letter-spacing: 0.04em;
+}
+
+.hero p { margin: 0 0 0.3rem; color: var(--muted); }
+
+.pill {
+  margin-left: auto;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--stroke);
+  font-size: 0.9rem;
+}
+
+.pill.online { color: var(--accent); border-color: var(--accent); }
+.pill.offline { color: var(--bad); border-color: var(--bad); }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 0.9rem;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--stroke);
+  border-radius: 14px;
+  padding: 0.8rem 1rem;
+  backdrop-filter: blur(6px);
+  animation: drift 10s ease-in-out infinite alternate;
+}
+
+.card:nth-child(1) { grid-column: span 3; }
+.card:nth-child(2) { grid-column: span 3; }
+.card:nth-child(3) { grid-column: span 3; }
+.card:nth-child(4) { grid-column: span 3; }
+
+.card h2, .log h2 {
+  margin: 0 0 0.65rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.metric { font-size: 2rem; margin: 0.3rem 0 0; }
+
+.stack { display: grid; gap: 0.28rem; }
+.row { display: flex; justify-content: space-between; gap: 1rem; }
+.row span { color: var(--muted); }
+.mono strong { font-family: "IBM Plex Mono", monospace; font-size: 0.92rem; }
+
+.log {
+  margin-top: 0.9rem;
+  background: var(--card);
+  border: 1px solid var(--stroke);
+  border-radius: 14px;
+  padding: 0.8rem 1rem;
+}
+
+.log-body {
+  height: 220px;
+  overflow: auto;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.85rem;
+  border: 1px solid var(--stroke);
+  border-radius: 10px;
+  padding: 0.55rem;
+  background: rgba(1, 8, 13, 0.6);
+}
+
+.log-line { opacity: 0; transform: translateY(3px); animation: fade-up 260ms ease forwards; }
+
+.reveal { opacity: 0; transform: translateY(10px); animation: fade-up 450ms ease forwards; }
+.reveal:nth-child(2) { animation-delay: 70ms; }
+.reveal:nth-child(3) { animation-delay: 120ms; }
+.reveal:nth-child(4) { animation-delay: 180ms; }
+
+@keyframes fade-up {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes drift {
+  from { transform: translateY(0); }
+  to { transform: translateY(-2px); }
+}
+
+@media (max-width: 900px) {
+  .card:nth-child(1),
+  .card:nth-child(2),
+  .card:nth-child(3),
+  .card:nth-child(4) {
+    grid-column: span 6;
+  }
+  .hero { flex-wrap: wrap; }
+  .pill { margin-left: 0; }
+}
+
+@media (max-width: 560px) {
+  .card:nth-child(1),
+  .card:nth-child(2),
+  .card:nth-child(3),
+  .card:nth-child(4) {
+    grid-column: span 12;
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ class TestMainGroup:
         assert "version" in result.output
         assert "setup" in result.output
         assert "tui" in result.output
+        assert "wui" in result.output
 
 
 class TestVersionCommand:
@@ -35,22 +36,37 @@ class TestVersionCommand:
         assert "0.1.0" in result.output
 
 
-class TestSetupPlaceholder:
-    """``openbad setup`` placeholder."""
+class TestSetupCommand:
+    """``openbad setup`` command surface."""
 
-    def test_setup_placeholder(self):
-        result = CliRunner().invoke(main, ["setup"])
+    def test_setup_help(self):
+        result = CliRunner().invoke(main, ["setup", "--help"])
         assert result.exit_code == 0
-        assert "Setup wizard" in result.output
+        assert "--config-dir" in result.output
+        assert "--check" in result.output
+        assert "--non-interactive" in result.output
 
 
-class TestTuiPlaceholder:
-    """``openbad tui`` placeholder."""
+class TestTuiCommand:
+    """``openbad tui`` command surface."""
 
-    def test_tui_placeholder(self):
-        result = CliRunner().invoke(main, ["tui"])
+    def test_tui_help(self):
+        result = CliRunner().invoke(main, ["tui", "--help"])
         assert result.exit_code == 0
-        assert "TUI" in result.output
+        assert "--host" in result.output
+        assert "--port" in result.output
+
+
+class TestWuiCommand:
+    """``openbad wui`` command surface."""
+
+    def test_wui_help(self):
+        result = CliRunner().invoke(main, ["wui", "--help"])
+        assert result.exit_code == 0
+        assert "--host" in result.output
+        assert "--port" in result.output
+        assert "--mqtt-host" in result.output
+        assert "--mqtt-port" in result.output
 
 
 class TestStatusCommand:

--- a/tests/test_wui_server.py
+++ b/tests/test_wui_server.py
@@ -1,0 +1,50 @@
+"""Tests for WUI server scaffold (#185)."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.wui.server import STATIC_DIR, create_app
+
+
+def test_static_assets_exist():
+    assert (STATIC_DIR / "index.html").exists()
+    assert (STATIC_DIR / "styles.css").exists()
+    assert (STATIC_DIR / "app.js").exists()
+
+
+@pytest.mark.asyncio
+async def test_index_route(aiohttp_client):
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+    resp = await client.get("/")
+    assert resp.status == 200
+    html = await resp.text()
+    assert "OpenBaD Live Dashboard" in html
+    assert "/static/app.js" in html
+
+
+@pytest.mark.asyncio
+async def test_static_css_route(aiohttp_client):
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+    resp = await client.get("/static/styles.css")
+    assert resp.status == 200
+    css = await resp.text()
+    assert ":root" in css
+
+
+@pytest.mark.asyncio
+async def test_ws_health_route(aiohttp_client):
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+    resp = await client.get("/health")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "ok" in data
+    assert "clients" in data
+
+
+def test_create_app_attaches_bridge():
+    app = create_app(enable_mqtt=False)
+    assert "bridge" in app


### PR DESCRIPTION
Closes #185

## Summary
- Add aiohttp WUI server integrating MQTT->WebSocket bridge
- Add new CLI command: openbad wui
- Add dashboard frontend assets (HTML/CSS/JS) with live panels for FSM, hormones, vitals, inference, and event stream
- Add test mode in server to disable broker startup in route tests
- Add tests for server routes/assets and updated CLI command surface

## How To Test
- .venv\\Scripts\\python.exe -m pytest tests/test_wui_server.py tests/test_wui_bridge.py tests/test_cli.py -q
- .venv\\Scripts\\python.exe -m ruff check src/openbad/wui/ src/openbad/cli.py tests/test_wui_server.py tests/test_wui_bridge.py tests/test_cli.py