### PR TITLE
#186: WUI anatomical visualization

### DIFF
--- a/src/openbad/wui/static/app.js
+++ b/src/openbad/wui/static/app.js
@@ -26,7 +26,35 @@ const els = {
     lastLatency: document.getElementById('i-last-latency'),
   },
   log: document.getElementById('event-log'),
+  anatomy: {
+    nervous: document.getElementById('organ-nervous'),
+    endocrine: document.getElementById('organ-endocrine'),
+    reflex: document.getElementById('organ-reflex'),
+    cognitive: document.getElementById('organ-cognitive'),
+    immune: document.getElementById('organ-immune'),
+    memory: document.getElementById('organ-memory'),
+    sensory: document.getElementById('organ-sensory'),
+  },
 };
+
+function pulseOrgan(name) {
+  const node = els.anatomy[name] || els.anatomy.nervous;
+  if (!node) {
+    return;
+  }
+  node.classList.add('pulse');
+  window.setTimeout(() => node.classList.remove('pulse'), 380);
+}
+
+function mapTopicToOrgan(topic) {
+  if (topic.startsWith('agent/cognitive/')) return 'cognitive';
+  if (topic.startsWith('agent/endocrine/')) return 'endocrine';
+  if (topic.startsWith('agent/reflex/')) return 'reflex';
+  if (topic.startsWith('agent/immune/')) return 'immune';
+  if (topic.startsWith('agent/memory/')) return 'memory';
+  if (topic.startsWith('agent/sensory/')) return 'sensory';
+  return 'nervous';
+}
 
 function logLine(text) {
   const div = document.createElement('div');
@@ -120,6 +148,7 @@ function connect() {
       }
       if (msg.type === 'event') {
         const topic = msg.topic || 'unknown/topic';
+        pulseOrgan(mapTopicToOrgan(topic));
         updateFromEvent(topic, msg.payload || {});
         logLine(`[${msg.ts}] ${topic}`);
       }

--- a/src/openbad/wui/static/index.html
+++ b/src/openbad/wui/static/index.html
@@ -65,6 +65,66 @@
       <h2>Event Stream</h2>
       <div id="event-log" class="log-body" aria-live="polite"></div>
     </section>
+
+    <section class="anatomy reveal">
+      <h2>Anatomical System Map</h2>
+      <div class="anatomy-wrap">
+        <svg id="anatomy-map" viewBox="0 0 760 360" role="img" aria-label="OpenBaD subsystem anatomical map">
+          <defs>
+            <linearGradient id="organFill" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#1f4f63"/>
+              <stop offset="100%" stop-color="#0c1d29"/>
+            </linearGradient>
+          </defs>
+
+          <rect x="2" y="2" width="756" height="356" rx="18" class="body-shell"/>
+          <circle cx="130" cy="88" r="52" class="outline"/>
+          <path d="M130,140 C84,150 64,198 66,246 C68,288 92,322 130,336 C168,322 192,288 194,246 C196,198 176,150 130,140" class="outline"/>
+
+          <g id="organ-cognitive" class="organ">
+            <circle cx="130" cy="88" r="28"/>
+            <text x="130" y="92">Cognitive</text>
+          </g>
+          <g id="organ-reflex" class="organ">
+            <rect x="114" y="146" width="32" height="46" rx="10"/>
+            <text x="130" y="173">Reflex</text>
+          </g>
+          <g id="organ-endocrine" class="organ">
+            <ellipse cx="98" cy="216" rx="20" ry="28"/>
+            <text x="98" y="220">Endocrine</text>
+          </g>
+          <g id="organ-immune" class="organ">
+            <ellipse cx="162" cy="216" rx="20" ry="28"/>
+            <text x="162" y="220">Immune</text>
+          </g>
+          <g id="organ-memory" class="organ">
+            <rect x="104" y="258" width="52" height="26" rx="9"/>
+            <text x="130" y="275">Memory</text>
+          </g>
+          <g id="organ-sensory" class="organ">
+            <circle cx="90" cy="120" r="12"/>
+            <circle cx="170" cy="120" r="12"/>
+            <text x="130" y="124">Sensory</text>
+          </g>
+          <g id="organ-nervous" class="organ">
+            <path d="M130,96 L130,312"/>
+            <text x="130" y="306">Nervous</text>
+          </g>
+        </svg>
+        <aside class="legend">
+          <p>Topics pulse corresponding subsystems in real time.</p>
+          <ul>
+            <li>Cognitive: agent/cognitive/*</li>
+            <li>Endocrine: agent/endocrine/*</li>
+            <li>Reflex: agent/reflex/*</li>
+            <li>Immune: agent/immune/*</li>
+            <li>Memory: agent/memory/*</li>
+            <li>Sensory: agent/sensory/*</li>
+            <li>Nervous: fallback for telemetry/system flow</li>
+          </ul>
+        </aside>
+      </div>
+    </section>
   </main>
 
   <script src="/static/app.js" defer></script>

--- a/src/openbad/wui/static/styles.css
+++ b/src/openbad/wui/static/styles.css
@@ -108,6 +108,69 @@ html, body {
   padding: 0.8rem 1rem;
 }
 
+.anatomy {
+  margin-top: 0.9rem;
+  background: var(--card);
+  border: 1px solid var(--stroke);
+  border-radius: 14px;
+  padding: 0.8rem 1rem;
+}
+
+.anatomy-wrap {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 0.9rem;
+  align-items: start;
+}
+
+#anatomy-map {
+  width: 100%;
+  border: 1px solid var(--stroke);
+  border-radius: 10px;
+  background: rgba(1, 8, 13, 0.55);
+}
+
+#anatomy-map .body-shell {
+  fill: rgba(10, 20, 30, 0.4);
+  stroke: var(--stroke);
+}
+
+#anatomy-map .outline {
+  fill: none;
+  stroke: rgba(152, 179, 196, 0.35);
+  stroke-width: 2;
+}
+
+#anatomy-map .organ {
+  fill: url(#organFill);
+  stroke: rgba(122, 242, 217, 0.25);
+  stroke-width: 1.5;
+  transition: filter 200ms ease, stroke 200ms ease;
+}
+
+#anatomy-map .organ text {
+  font-size: 10px;
+  text-anchor: middle;
+  fill: #cceaf5;
+  font-family: "IBM Plex Mono", monospace;
+}
+
+#anatomy-map .organ.pulse {
+  stroke: var(--accent);
+  filter: drop-shadow(0 0 8px rgba(122, 242, 217, 0.7));
+}
+
+.legend p,
+.legend li {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.legend ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1rem;
+}
+
 .log-body {
   height: 220px;
   overflow: auto;
@@ -152,5 +215,9 @@ html, body {
   .card:nth-child(3),
   .card:nth-child(4) {
     grid-column: span 12;
+  }
+
+  .anatomy-wrap {
+    grid-template-columns: 1fr;
   }
 }

--- a/tests/test_wui_anatomy.py
+++ b/tests/test_wui_anatomy.py
@@ -1,0 +1,32 @@
+"""Tests for #186 anatomical visualization assets."""
+
+from __future__ import annotations
+
+from openbad.wui.server import STATIC_DIR
+
+
+def test_index_contains_anatomy_svg():
+    html = (STATIC_DIR / "index.html").read_text(encoding="utf-8")
+    assert "anatomy-map" in html
+    assert "organ-cognitive" in html
+    assert "organ-endocrine" in html
+    assert "organ-reflex" in html
+    assert "organ-immune" in html
+    assert "organ-memory" in html
+    assert "organ-sensory" in html
+    assert "organ-nervous" in html
+
+
+def test_js_contains_topic_to_organ_mapping():
+    js = (STATIC_DIR / "app.js").read_text(encoding="utf-8")
+    assert "function mapTopicToOrgan" in js
+    assert "agent/cognitive/" in js
+    assert "agent/endocrine/" in js
+    assert "agent/reflex/" in js
+    assert "agent/immune/" in js
+
+
+def test_css_contains_pulse_style():
+    css = (STATIC_DIR / "styles.css").read_text(encoding="utf-8")
+    assert ".organ.pulse" in css
+    assert "drop-shadow" in css


### PR DESCRIPTION
Closes #186

## Summary
- Add anatomical subsystem SVG map to the web dashboard
- Add live subsystem pulse highlighting driven by topic prefixes
- Add legend and responsive styles for the anatomy section
- Add asset tests validating map structure and topic mapping script

## How To Test
- .venv\\Scripts\\python.exe -m pytest tests/test_wui_anatomy.py tests/test_wui_server.py tests/test_wui_bridge.py -q
- .venv\\Scripts\\python.exe -m ruff check tests/test_wui_anatomy.py src/openbad/wui/server.py src/openbad/wui/bridge.py