### PR TITLE
Installer: Linux/WSL bootstrap mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Enforce LF for scripts and Unix text assets
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Keep web/text files normalized
+*.py text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.css text eol=lf
+*.js text eol=lf
+*.html text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 
 # Virtual environments
 .venv/
+.venv-wsl/
 venv/
 env/
 

--- a/README.md
+++ b/README.md
@@ -52,3 +52,20 @@ Validate setup/config:
 ```bash
 openbad setup --check
 ```
+
+Control the installed stack with:
+
+```bash
+openbad start
+openbad stop
+openbad restart
+openbad health
+openbad tui
+openbad version
+```
+
+Notes:
+
+- `openbad start` starts the broker, daemon, and web UI services and returns immediately.
+- `openbad health` reports systemd service state, MQTT reachability, and the WUI health endpoint.
+- `openbad tui` attaches a terminal UI to the running MQTT-backed stack.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,23 @@ Phase 1 (Nervous System, Interoception, Reflexes)
   │     └── Phase 4 (Memory) ────────── requires cognitive traces
   └── Phase 5 (Endocrine) ──────────── modulates all phases
 ```
+
+## Install and Setup (Linux/WSL)
+
+Use the installer as root:
+
+```bash
+sudo ./scripts/install.sh --bootstrap
+```
+
+Notes:
+
+- `--bootstrap` installs Linux prerequisites (Ubuntu/Debian apt path).
+- On systems without systemd (some WSL setups), services are skipped automatically.
+- You can force no service operations with `--skip-services`.
+
+Validate setup/config:
+
+```bash
+openbad setup --check
+```

--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ Phase 1 (Nervous System, Interoception, Reflexes)
 Use the installer as root:
 
 ```bash
-sudo ./scripts/install.sh --bootstrap
+sudo ./scripts/install.sh --bootstrap --configure-wsl-systemd
 ```
 
 Notes:
 
-- `--bootstrap` installs Linux prerequisites (Ubuntu/Debian apt path).
-- On systems without systemd (some WSL setups), services are skipped automatically.
-- You can force no service operations with `--skip-services`.
+- `--bootstrap` installs Linux prerequisites (Ubuntu/Debian apt path) and broker deps.
+- Full install requires `systemd` (Linux + WSL).
+- In WSL, `--configure-wsl-systemd` writes `/etc/wsl.conf` and prompts for WSL restart.
+- Use `--skip-services` only for development mode.
 
 Validate setup/config:
 

--- a/config/openbad-wui.service
+++ b/config/openbad-wui.service
@@ -1,25 +1,21 @@
 [Unit]
-Description=OpenBaD Agent Daemon
+Description=OpenBaD Web UI
 Documentation=https://github.com/bruceamoser/OpenBaD
-After=openbad-broker.service network-online.target
+After=openbad.service network-online.target
 Wants=network-online.target
-Wants=openbad-broker.service
+Requires=openbad.service
 
 [Service]
 Type=simple
 User=openbad
 Group=openbad
-ExecStart=/usr/local/bin/openbad run --host localhost --port 1883
-ExecStop=/bin/kill -TERM $MAINPID
+ExecStart=/usr/local/bin/openbad wui --host 127.0.0.1 --port 9200 --mqtt-host localhost --mqtt-port 1883
 Restart=on-failure
 RestartSec=5s
-TimeoutStopSec=30s
 
-# Environment
 Environment=OPENBAD_CONFIG_DIR=/etc/openbad
 WorkingDirectory=/var/lib/openbad
 
-# Security hardening
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
@@ -29,9 +25,8 @@ ProtectKernelTunables=true
 ProtectControlGroups=true
 RestrictSUIDSGID=true
 
-# Resource limits
 LimitNOFILE=65536
-MemoryMax=512M
+MemoryMax=256M
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -327,10 +327,18 @@ install_units() {
         warn "  openbad.service not found in $CONFIG_SRC"
     fi
 
+    if [ -f "$CONFIG_SRC/openbad-wui.service" ]; then
+        cp "$CONFIG_SRC/openbad-wui.service" "$SYSTEMD_DIR/openbad-wui.service"
+        info "  Installed openbad-wui.service"
+    else
+        warn "  openbad-wui.service not found in $CONFIG_SRC"
+    fi
+
     systemctl daemon-reload
     info "Enabling services..."
     systemctl enable openbad-broker.service
     systemctl enable openbad.service
+    systemctl enable openbad-wui.service
 }
 
 # ------------------------------------------------------------------
@@ -346,6 +354,7 @@ start_services() {
     info "Starting services..."
     systemctl start openbad-broker.service
     systemctl start openbad.service
+    systemctl start openbad-wui.service
     info "Services started. Check status with: systemctl status openbad"
 }
 
@@ -355,8 +364,10 @@ start_services() {
 uninstall() {
     if has_systemd; then
         info "Stopping services..."
+        systemctl stop openbad-wui.service 2>/dev/null || true
         systemctl stop openbad.service 2>/dev/null || true
         systemctl stop openbad-broker.service 2>/dev/null || true
+        systemctl disable openbad-wui.service 2>/dev/null || true
         systemctl disable openbad.service 2>/dev/null || true
         systemctl disable openbad-broker.service 2>/dev/null || true
     else
@@ -364,6 +375,7 @@ uninstall() {
     fi
 
     info "Removing systemd units..."
+    rm -f "$SYSTEMD_DIR/openbad-wui.service"
     rm -f "$SYSTEMD_DIR/openbad.service"
     rm -f "$SYSTEMD_DIR/openbad-broker.service"
     if has_systemd; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 
 OPENBAD_USER="openbad"
 OPENBAD_GROUP="openbad"
+APP_HOME="/opt/openbad"
+VENV_DIR="/opt/openbad/venv"
+OPENBAD_BIN="/usr/local/bin/openbad"
 CONFIG_DIR="/etc/openbad"
 DATA_DIR="/var/lib/openbad"
 LOG_DIR="/var/log/openbad"
@@ -248,18 +251,26 @@ create_user() {
 # Install Python package
 # ------------------------------------------------------------------
 install_package() {
-    info "Installing openbad Python package..."
-    if command -v python3 &>/dev/null; then
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade "$PROJECT_ROOT"
-    elif command -v pip3 &>/dev/null; then
-        pip3 install --upgrade "$PROJECT_ROOT"
-    elif command -v pip &>/dev/null; then
-        pip install --upgrade "$PROJECT_ROOT"
-    else
+    info "Installing openbad Python package into dedicated virtualenv..."
+    if ! command -v python3 &>/dev/null; then
         error "pip not found. Install Python >= 3.11 and pip first."
         exit 1
     fi
+
+    mkdir -p "$APP_HOME"
+
+    # Use a private virtualenv to avoid PEP 668 'externally managed' failures
+    # on Debian/Ubuntu and WSL images.
+    if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+        python3 -m venv "$VENV_DIR"
+    fi
+
+    "$VENV_DIR/bin/python" -m pip install --upgrade pip
+    "$VENV_DIR/bin/python" -m pip install --upgrade "$PROJECT_ROOT"
+
+    # Keep CLI path stable for systemd and operators.
+    ln -sf "$VENV_DIR/bin/openbad" "$OPENBAD_BIN"
+    chmod 755 "$OPENBAD_BIN"
 }
 
 # ------------------------------------------------------------------
@@ -360,11 +371,11 @@ uninstall() {
     fi
 
     info "Removing Python package..."
-    if command -v python3 &>/dev/null; then
-        python3 -m pip uninstall -y openbad 2>/dev/null || true
-    else
-        pip3 uninstall -y openbad 2>/dev/null || true
+    if [[ -x "$VENV_DIR/bin/python" ]]; then
+        "$VENV_DIR/bin/python" -m pip uninstall -y openbad 2>/dev/null || true
     fi
+    rm -f "$OPENBAD_BIN"
+    rm -rf "$VENV_DIR"
 
     warn "Config ($CONFIG_DIR) and data ($DATA_DIR) directories preserved."
     warn "To fully remove: rm -rf $CONFIG_DIR $DATA_DIR $LOG_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # OpenBaD installation script
-# Usage: sudo ./install.sh [--bootstrap] [--skip-services] [--uninstall]
+# Usage: sudo ./install.sh [--bootstrap] [--configure-wsl-systemd] [--skip-services] [--uninstall]
 set -euo pipefail
 
 OPENBAD_USER="openbad"
@@ -16,6 +16,8 @@ CONFIG_SRC="$PROJECT_ROOT/config"
 DO_BOOTSTRAP=false
 SKIP_SERVICES=false
 DO_UNINSTALL=false
+CONFIGURE_WSL_SYSTEMD=false
+BROKER_IMPL=""
 
 # Colours (if terminal supports them)
 RED='\033[0;31m'
@@ -32,11 +34,12 @@ usage() {
 OpenBaD installer
 
 Usage:
-  sudo ./install.sh [--bootstrap] [--skip-services]
+    sudo ./install.sh [--bootstrap] [--configure-wsl-systemd] [--skip-services]
   sudo ./install.sh --uninstall
 
 Options:
   --bootstrap      Install Linux prerequisites (Ubuntu/Debian apt path)
+    --configure-wsl-systemd  Configure /etc/wsl.conf with systemd=true (requires WSL restart)
   --skip-services  Do not install/enable/start systemd units
   --uninstall      Remove OpenBaD package + units
   --help           Show this help
@@ -51,6 +54,9 @@ parse_args() {
                 ;;
             --skip-services)
                 SKIP_SERVICES=true
+                ;;
+            --configure-wsl-systemd)
+                CONFIGURE_WSL_SYSTEMD=true
                 ;;
             --uninstall)
                 DO_UNINSTALL=true
@@ -91,6 +97,58 @@ has_systemd() {
     [[ -d /run/systemd/system ]] && command -v systemctl &>/dev/null
 }
 
+configure_wsl_systemd() {
+    if ! is_wsl; then
+        warn "--configure-wsl-systemd ignored (not running inside WSL)."
+        return
+    fi
+
+    local wsl_conf="/etc/wsl.conf"
+    info "Configuring WSL systemd support in $wsl_conf ..."
+
+    if [[ -f "$wsl_conf" ]] && grep -Eq '^\s*systemd\s*=\s*true\s*$' "$wsl_conf"; then
+        info "systemd=true already present in $wsl_conf"
+        return
+    fi
+
+    if [[ -f "$wsl_conf" ]] && grep -Eq '^\s*\[boot\]\s*$' "$wsl_conf"; then
+        {
+            echo
+            echo "# Added by OpenBaD installer"
+            echo "systemd=true"
+        } >> "$wsl_conf"
+    else
+        {
+            echo "[boot]"
+            echo "systemd=true"
+        } >> "$wsl_conf"
+    fi
+
+    warn "WSL restart required: run 'wsl.exe --shutdown' from Windows, then reopen WSL and rerun installer."
+}
+
+ensure_systemd_ready() {
+    if [[ "$SKIP_SERVICES" == "true" ]]; then
+        return
+    fi
+
+    if has_systemd; then
+        return
+    fi
+
+    if is_wsl; then
+        if [[ "$CONFIGURE_WSL_SYSTEMD" == "true" ]]; then
+            configure_wsl_systemd
+        fi
+        error "systemd is required for full install. Enable systemd in WSL and retry, or pass --skip-services for dev-only mode."
+        exit 1
+    fi
+
+    error "systemd is required for full install on Linux."
+    error "Use --skip-services only for development mode."
+    exit 1
+}
+
 install_prereqs_apt() {
     info "Bootstrapping OS dependencies with apt..."
     apt-get update
@@ -100,6 +158,14 @@ install_prereqs_apt() {
     if ! python3 -m venv --help &>/dev/null; then
         py_minor="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
         apt-get install -y "python${py_minor}-venv"
+    fi
+
+    # MQTT broker: prefer NanoMQ, fallback to Mosquitto.
+    if ! command -v nanomq &>/dev/null && ! command -v mosquitto &>/dev/null; then
+        apt-get install -y nanomq || true
+        if ! command -v nanomq &>/dev/null; then
+            apt-get install -y mosquitto
+        fi
     fi
 }
 
@@ -115,6 +181,54 @@ bootstrap_os() {
         warn "No supported package manager detected for bootstrap."
         warn "Install manually: python3, python3-pip, python3-venv"
     fi
+}
+
+select_broker_impl() {
+    if command -v nanomq &>/dev/null; then
+        BROKER_IMPL="nanomq"
+        info "Broker selected: NanoMQ"
+        return
+    fi
+
+    if command -v mosquitto &>/dev/null; then
+        BROKER_IMPL="mosquitto"
+        warn "NanoMQ not found. Falling back to Mosquitto broker service."
+        return
+    fi
+
+    error "No MQTT broker found (nanomq/mosquitto)."
+    error "Run with --bootstrap or install a broker manually."
+    exit 1
+}
+
+install_broker_unit() {
+    local dst="$SYSTEMD_DIR/openbad-broker.service"
+
+    if [[ "$BROKER_IMPL" == "nanomq" ]]; then
+        cp "$CONFIG_SRC/openbad-broker.service" "$dst"
+        info "  Installed openbad-broker.service (NanoMQ)"
+        return
+    fi
+
+    # Mosquitto fallback unit.
+    local mosquitto_bin
+    mosquitto_bin="$(command -v mosquitto)"
+    cat > "$dst" <<EOF
+[Unit]
+Description=OpenBaD MQTT Broker (Mosquitto fallback)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${mosquitto_bin} -p 1883
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    info "  Installed openbad-broker.service (Mosquitto fallback)"
 }
 
 # ------------------------------------------------------------------
@@ -190,22 +304,17 @@ install_units() {
         warn "Skipping service installation (--skip-services set)."
         return
     fi
-    if ! has_systemd; then
-        warn "systemd not detected; skipping unit install."
-        warn "Tip: on WSL enable systemd in /etc/wsl.conf then restart WSL."
-        return
-    fi
+    ensure_systemd_ready
 
     info "Installing systemd units..."
-    for unit in openbad-broker.service openbad.service; do
-        src="$CONFIG_SRC/$unit"
-        if [ -f "$src" ]; then
-            cp "$src" "$SYSTEMD_DIR/$unit"
-            info "  Installed $unit"
-        else
-            warn "  $unit not found in $CONFIG_SRC"
-        fi
-    done
+    install_broker_unit
+
+    if [ -f "$CONFIG_SRC/openbad.service" ]; then
+        cp "$CONFIG_SRC/openbad.service" "$SYSTEMD_DIR/openbad.service"
+        info "  Installed openbad.service"
+    else
+        warn "  openbad.service not found in $CONFIG_SRC"
+    fi
 
     systemctl daemon-reload
     info "Enabling services..."
@@ -221,10 +330,7 @@ start_services() {
         warn "Skipping service start (--skip-services set)."
         return
     fi
-    if ! has_systemd; then
-        warn "systemd not detected; skipping service start."
-        return
-    fi
+    ensure_systemd_ready
 
     info "Starting services..."
     systemctl start openbad-broker.service
@@ -289,6 +395,11 @@ main() {
 
     if [[ "$DO_BOOTSTRAP" == "true" ]]; then
         bootstrap_os
+    fi
+
+    if [[ "$SKIP_SERVICES" != "true" ]]; then
+        select_broker_impl
+        ensure_systemd_ready
     fi
 
     info "=== OpenBaD Installation ==="

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # OpenBaD installation script
-# Usage: sudo ./install.sh [--uninstall]
+# Usage: sudo ./install.sh [--bootstrap] [--skip-services] [--uninstall]
 set -euo pipefail
 
 OPENBAD_USER="openbad"
@@ -13,6 +13,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 CONFIG_SRC="$PROJECT_ROOT/config"
 
+DO_BOOTSTRAP=false
+SKIP_SERVICES=false
+DO_UNINSTALL=false
+
 # Colours (if terminal supports them)
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -23,10 +27,93 @@ info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
+usage() {
+    cat <<'EOF'
+OpenBaD installer
+
+Usage:
+  sudo ./install.sh [--bootstrap] [--skip-services]
+  sudo ./install.sh --uninstall
+
+Options:
+  --bootstrap      Install Linux prerequisites (Ubuntu/Debian apt path)
+  --skip-services  Do not install/enable/start systemd units
+  --uninstall      Remove OpenBaD package + units
+  --help           Show this help
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --bootstrap)
+                DO_BOOTSTRAP=true
+                ;;
+            --skip-services)
+                SKIP_SERVICES=true
+                ;;
+            --uninstall)
+                DO_UNINSTALL=true
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                error "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+        shift
+    done
+}
+
 require_root() {
     if [[ $EUID -ne 0 ]]; then
         error "This script must be run as root (sudo)."
         exit 1
+    fi
+}
+
+is_linux() {
+    [[ "$(uname -s)" == "Linux" ]]
+}
+
+is_wsl() {
+    if [[ -f /proc/version ]] && grep -qi "microsoft" /proc/version; then
+        return 0
+    fi
+    return 1
+}
+
+has_systemd() {
+    [[ -d /run/systemd/system ]] && command -v systemctl &>/dev/null
+}
+
+install_prereqs_apt() {
+    info "Bootstrapping OS dependencies with apt..."
+    apt-get update
+    apt-get install -y ca-certificates curl python3 python3-pip python3-venv
+
+    # Some distros split venv by Python minor version.
+    if ! python3 -m venv --help &>/dev/null; then
+        py_minor="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+        apt-get install -y "python${py_minor}-venv"
+    fi
+}
+
+bootstrap_os() {
+    if ! is_linux; then
+        error "Bootstrap is supported on Linux only."
+        exit 1
+    fi
+
+    if command -v apt-get &>/dev/null; then
+        install_prereqs_apt
+    else
+        warn "No supported package manager detected for bootstrap."
+        warn "Install manually: python3, python3-pip, python3-venv"
     fi
 }
 
@@ -48,7 +135,10 @@ create_user() {
 # ------------------------------------------------------------------
 install_package() {
     info "Installing openbad Python package..."
-    if command -v pip3 &>/dev/null; then
+    if command -v python3 &>/dev/null; then
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade "$PROJECT_ROOT"
+    elif command -v pip3 &>/dev/null; then
         pip3 install --upgrade "$PROJECT_ROOT"
     elif command -v pip &>/dev/null; then
         pip install --upgrade "$PROJECT_ROOT"
@@ -96,6 +186,16 @@ create_dirs() {
 # Install systemd units
 # ------------------------------------------------------------------
 install_units() {
+    if [[ "$SKIP_SERVICES" == "true" ]]; then
+        warn "Skipping service installation (--skip-services set)."
+        return
+    fi
+    if ! has_systemd; then
+        warn "systemd not detected; skipping unit install."
+        warn "Tip: on WSL enable systemd in /etc/wsl.conf then restart WSL."
+        return
+    fi
+
     info "Installing systemd units..."
     for unit in openbad-broker.service openbad.service; do
         src="$CONFIG_SRC/$unit"
@@ -117,6 +217,15 @@ install_units() {
 # Start services
 # ------------------------------------------------------------------
 start_services() {
+    if [[ "$SKIP_SERVICES" == "true" ]]; then
+        warn "Skipping service start (--skip-services set)."
+        return
+    fi
+    if ! has_systemd; then
+        warn "systemd not detected; skipping service start."
+        return
+    fi
+
     info "Starting services..."
     systemctl start openbad-broker.service
     systemctl start openbad.service
@@ -127,19 +236,29 @@ start_services() {
 # Uninstall
 # ------------------------------------------------------------------
 uninstall() {
-    info "Stopping services..."
-    systemctl stop openbad.service 2>/dev/null || true
-    systemctl stop openbad-broker.service 2>/dev/null || true
-    systemctl disable openbad.service 2>/dev/null || true
-    systemctl disable openbad-broker.service 2>/dev/null || true
+    if has_systemd; then
+        info "Stopping services..."
+        systemctl stop openbad.service 2>/dev/null || true
+        systemctl stop openbad-broker.service 2>/dev/null || true
+        systemctl disable openbad.service 2>/dev/null || true
+        systemctl disable openbad-broker.service 2>/dev/null || true
+    else
+        warn "systemd not detected; skipping service stop/disable."
+    fi
 
     info "Removing systemd units..."
     rm -f "$SYSTEMD_DIR/openbad.service"
     rm -f "$SYSTEMD_DIR/openbad-broker.service"
-    systemctl daemon-reload
+    if has_systemd; then
+        systemctl daemon-reload
+    fi
 
     info "Removing Python package..."
-    pip3 uninstall -y openbad 2>/dev/null || true
+    if command -v python3 &>/dev/null; then
+        python3 -m pip uninstall -y openbad 2>/dev/null || true
+    else
+        pip3 uninstall -y openbad 2>/dev/null || true
+    fi
 
     warn "Config ($CONFIG_DIR) and data ($DATA_DIR) directories preserved."
     warn "To fully remove: rm -rf $CONFIG_DIR $DATA_DIR $LOG_DIR"
@@ -151,11 +270,25 @@ uninstall() {
 # Main
 # ------------------------------------------------------------------
 main() {
+    parse_args "$@"
     require_root
 
-    if [[ "${1:-}" == "--uninstall" ]]; then
+    if [[ "$DO_UNINSTALL" == "true" ]]; then
         uninstall
         exit 0
+    fi
+
+    if ! is_linux; then
+        error "OpenBaD installer currently supports Linux/WSL hosts only."
+        exit 1
+    fi
+
+    if is_wsl; then
+        info "WSL environment detected."
+    fi
+
+    if [[ "$DO_BOOTSTRAP" == "true" ]]; then
+        bootstrap_os
     fi
 
     info "=== OpenBaD Installation ==="

--- a/src/openbad/cli.py
+++ b/src/openbad/cli.py
@@ -8,11 +8,28 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import shutil
+import subprocess
 import sys
+from urllib import error as urllib_error
+from urllib import parse as urllib_parse
+from urllib import request as urllib_request
 
 import click
 
 import openbad
+
+SYSTEMCTL_BIN = shutil.which("systemctl") or "/bin/systemctl"
+SERVICE_UNITS = (
+    "openbad-broker.service",
+    "openbad.service",
+    "openbad-wui.service",
+)
+CORE_SERVICE_UNITS = (
+    "openbad.service",
+    "openbad-wui.service",
+)
+BROKER_SERVICE_UNIT = "openbad-broker.service"
 
 
 @click.group(invoke_without_command=True)
@@ -23,7 +40,7 @@ def main(ctx: click.Context) -> None:
         click.echo(ctx.get_help())
 
 
-@main.command()
+@main.command(hidden=True)
 @click.option("--host", default="localhost", help="MQTT broker host.")
 @click.option("--port", default=1883, type=int, help="MQTT broker port.")
 @click.option("--dry-run", is_flag=True, help="Validate config and exit.")
@@ -42,13 +59,48 @@ def run(host: str, port: int, dry_run: bool, verbose: bool) -> None:
 
 
 @main.command()
+def start() -> None:
+    """Start all OpenBaD services and return immediately."""
+    units = _managed_service_units()
+    _systemctl("start", *units)
+    click.echo("Started: " + ", ".join(units))
+
+
+@main.command()
+def stop() -> None:
+    """Stop all OpenBaD services and return immediately."""
+    units = tuple(reversed(_managed_service_units()))
+    _systemctl("stop", *units)
+    click.echo("Stopped: " + ", ".join(units))
+
+
+@main.command()
+def restart() -> None:
+    """Restart all OpenBaD services and return immediately."""
+    units = _managed_service_units()
+    _systemctl("restart", *units)
+    click.echo("Restarted: " + ", ".join(units))
+
+
+@main.command(name="health")
 @click.option("--host", default="localhost", help="MQTT broker host.")
 @click.option("--port", default=1883, type=int, help="MQTT broker port.")
-def status(host: str, port: int) -> None:
-    """Check daemon status (MQTT reachability and FSM state)."""
+@click.option("--wui-url", default="http://127.0.0.1:9200/health", help="Web UI health endpoint.")
+def health(host: str, port: int, wui_url: str) -> None:
+    """Report service, MQTT, and WUI health."""
     from openbad.nervous_system.client import NervousSystemClient
 
-    result: dict[str, object] = {"mqtt_reachable": False, "fsm_state": "UNKNOWN"}
+    _validate_health_url(wui_url)
+
+    services = {unit: _service_state(unit) for unit in SERVICE_UNITS}
+    enabled = {unit: _service_enabled_state(unit) for unit in SERVICE_UNITS}
+    result: dict[str, object] = {
+        "services": services,
+        "enabled": enabled,
+        "mqtt_reachable": False,
+        "wui_http": {"ok": False, "url": wui_url},
+    }
+
     try:
         client = NervousSystemClient(host=host, port=port)
         client.connect(timeout=3.0)
@@ -56,8 +108,44 @@ def status(host: str, port: int) -> None:
         client.disconnect()
     except ConnectionError:
         pass
+
+    try:
+        with urllib_request.urlopen(wui_url, timeout=3.0) as response:  # noqa: S310
+            payload = json.loads(response.read().decode("utf-8"))
+            result["wui_http"] = {
+                "ok": True,
+                "url": wui_url,
+                "status": response.status,
+                "payload": payload,
+            }
+    except (urllib_error.URLError, TimeoutError, json.JSONDecodeError):
+        pass
+
     click.echo(json.dumps(result, indent=2))
-    sys.exit(0 if result["mqtt_reachable"] else 1)
+    core_services_ok = all(services[unit] == "active" for unit in CORE_SERVICE_UNITS)
+    broker_optional_ok = (
+        services[BROKER_SERVICE_UNIT] == "active"
+        or enabled[BROKER_SERVICE_UNIT] == "disabled"
+        or bool(result["mqtt_reachable"])
+    )
+    wui_ok = bool(result["wui_http"]["ok"])
+    healthy = (
+        core_services_ok
+        and broker_optional_ok
+        and bool(result["mqtt_reachable"])
+        and wui_ok
+    )
+    sys.exit(0 if healthy else 1)
+
+
+@main.command(name="status", hidden=True)
+@click.option("--host", default="localhost", help="MQTT broker host.")
+@click.option("--port", default=1883, type=int, help="MQTT broker port.")
+@click.option("--wui-url", default="http://127.0.0.1:9200/health", help="Web UI health endpoint.")
+def status(host: str, port: int, wui_url: str) -> None:
+    """Backward-compatible alias for ``health``."""
+    ctx = click.get_current_context()
+    ctx.invoke(health, host=host, port=port, wui_url=wui_url)
 
 
 @main.command()
@@ -114,7 +202,7 @@ def tui(host: str, port: int) -> None:
     app.run()
 
 
-@main.command()
+@main.command(hidden=True)
 @click.option("--host", default="127.0.0.1", help="Web UI bind host.")
 @click.option("--port", default=9200, type=int, help="Web UI bind port.")
 @click.option("--mqtt-host", default="localhost", help="MQTT broker host.")
@@ -140,3 +228,74 @@ def _configure_logging(verbose: bool) -> None:
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         datefmt="%H:%M:%S",
     )
+
+
+def _systemctl(command: str, *units: str) -> None:
+    try:
+        cmd = [SYSTEMCTL_BIN, command, *units]
+        subprocess.run(  # noqa: S603
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise click.ClickException("systemctl not found; this command requires systemd") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() or exc.stdout.strip() or f"systemctl {command} failed"
+        if "Interactive authentication required" in stderr or "Access denied" in stderr:
+            message = (
+                f"systemd denied '{command}'. "
+                f"Run 'sudo openbad {command}' to manage system services."
+            )
+            raise click.ClickException(
+                message
+            ) from exc
+        raise click.ClickException(stderr) from exc
+
+
+def _service_state(unit: str) -> str:
+    try:
+        cmd = [SYSTEMCTL_BIN, "is-active", unit]
+        proc = subprocess.run(  # noqa: S603
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return "systemctl-unavailable"
+
+    state = proc.stdout.strip() or proc.stderr.strip()
+    return state or "unknown"
+
+
+def _service_enabled_state(unit: str) -> str:
+    try:
+        cmd = [SYSTEMCTL_BIN, "is-enabled", unit]
+        proc = subprocess.run(  # noqa: S603
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return "systemctl-unavailable"
+
+    state = proc.stdout.strip() or proc.stderr.strip()
+    return state or "unknown"
+
+
+def _managed_service_units() -> tuple[str, ...]:
+    units = []
+    for unit in SERVICE_UNITS:
+        if _service_enabled_state(unit) == "disabled":
+            continue
+        units.append(unit)
+    return tuple(units) if units else CORE_SERVICE_UNITS
+
+
+def _validate_health_url(wui_url: str) -> None:
+    parsed = urllib_parse.urlparse(wui_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise click.ClickException("--wui-url must use http or https")

--- a/src/openbad/daemon.py
+++ b/src/openbad/daemon.py
@@ -6,9 +6,16 @@ import asyncio
 import logging
 import signal
 import sys
+import time
 
 from openbad.endocrine.controller import EndocrineController
+from openbad.interoception.disk_network import DiskNetworkMonitor
+from openbad.interoception.monitor import TelemetryMonitor
 from openbad.nervous_system.client import NervousSystemClient
+from openbad.nervous_system.schemas.cognitive_pb2 import ModelHealthStatus
+from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.nervous_system.schemas.telemetry_pb2 import TokenTelemetry
 from openbad.reflex_arc.fsm import AgentFSM
 
 logger = logging.getLogger(__name__)
@@ -31,6 +38,8 @@ class Daemon:
         self._client: NervousSystemClient | None = None
         self._fsm: AgentFSM | None = None
         self._endocrine: EndocrineController | None = None
+        self._telemetry: TelemetryMonitor | None = None
+        self._disk_network: DiskNetworkMonitor | None = None
         self._stop_event: asyncio.Event | None = None
 
     # -- public --------------------------------------------------------- #
@@ -64,9 +73,20 @@ class Daemon:
 
         # 2. Finite state machine
         self._fsm = AgentFSM(client=self._client)
+        self._fsm.subscribe_triggers()
 
         # 3. Endocrine controller
         self._endocrine = EndocrineController()
+
+        # 4. Interoception publishers for vitals panels and dashboards
+        self._telemetry = TelemetryMonitor(self._client)
+        self._telemetry.start()
+        self._disk_network = DiskNetworkMonitor(self._client)
+        self._disk_network.start()
+
+        # Seed UI consumers with an initial state snapshot.
+        self._fsm.publish_current_state()
+        self._publish_bootstrap_snapshots()
 
         logger.info("All subsystems initialised")
 
@@ -75,7 +95,7 @@ class Daemon:
             await self.stop()
             return
 
-        # 4. Signal handlers (Unix only; no-op on Windows)
+        # 5. Signal handlers (Unix only; no-op on Windows)
         self._install_signal_handlers()
 
         self._running = True
@@ -93,6 +113,14 @@ class Daemon:
         self._running = False
 
         # Reverse-order teardown
+        if self._disk_network is not None:
+            self._disk_network.stop()
+            self._disk_network = None
+
+        if self._telemetry is not None:
+            self._telemetry.stop()
+            self._telemetry = None
+
         self._endocrine = None
         self._fsm = None
 
@@ -120,3 +148,44 @@ class Daemon:
         loop = asyncio.get_running_loop()
         for sig in (signal.SIGTERM, signal.SIGINT):
             loop.add_signal_handler(sig, self.request_stop)
+
+    def _publish_bootstrap_snapshots(self) -> None:
+        """Publish one-time retained snapshots for stateful dashboard panels."""
+        if self._client is None or self._endocrine is None:
+            return
+
+        now = time.time()
+        endocrine_state = self._endocrine.get_state()
+        for hormone, level in endocrine_state.to_dict().items():
+            self._client.publish(
+                f"agent/endocrine/{hormone}",
+                EndocrineEvent(
+                    header=Header(timestamp_unix=now, source_module="openbad.daemon"),
+                    hormone=hormone,
+                    level=level,
+                ),
+            )
+
+        self._client.publish(
+            "agent/telemetry/tokens",
+            TokenTelemetry(
+                header=Header(timestamp_unix=now, source_module="openbad.daemon"),
+                tokens_used=0,
+                budget_ceiling=0,
+                budget_remaining_pct=100.0,
+                cost_per_action_avg=0.0,
+                model_tier="idle",
+            ),
+        )
+
+        self._client.publish(
+            "agent/cognitive/health",
+            ModelHealthStatus(
+                header=Header(timestamp_unix=now, source_module="openbad.daemon"),
+                provider="inactive",
+                model_id="none",
+                available=False,
+                latency_p50=0.0,
+                latency_p99=0.0,
+            ),
+        )

--- a/src/openbad/interoception/disk_network.py
+++ b/src/openbad/interoception/disk_network.py
@@ -212,11 +212,11 @@ class DiskNetworkMonitor:
                 net_msg = network_to_proto(net_snap)
                 self._client.publish(
                     "agent/telemetry/disk",
-                    disk_msg.SerializeToString(),
+                    disk_msg,
                 )
                 self._client.publish(
                     "agent/telemetry/network",
-                    net_msg.SerializeToString(),
+                    net_msg,
                 )
             except Exception:
                 logger.exception("Disk/network telemetry error")

--- a/src/openbad/interoception/monitor.py
+++ b/src/openbad/interoception/monitor.py
@@ -202,8 +202,8 @@ class TelemetryMonitor:
                 mem_snap = self._memory_collector()
                 cpu_msg = cpu_to_proto(cpu_snap)
                 mem_msg = memory_to_proto(mem_snap)
-                self._client.publish("agent/telemetry/cpu", cpu_msg.SerializeToString())
-                self._client.publish("agent/telemetry/memory", mem_msg.SerializeToString())
+                self._client.publish("agent/telemetry/cpu", cpu_msg)
+                self._client.publish("agent/telemetry/memory", mem_msg)
             except Exception:
                 logger.exception("Telemetry collection error")
             self._stop.wait(self._interval)

--- a/src/openbad/interoception/thresholds.py
+++ b/src/openbad/interoception/thresholds.py
@@ -168,7 +168,7 @@ def publish_breaches(
     count = 0
     for breach in breaches:
         msg = breach_to_proto(breach)
-        client.publish("agent/endocrine/cortisol", msg.SerializeToString())  # type: ignore[union-attr]
+        client.publish("agent/endocrine/cortisol", msg)  # type: ignore[union-attr]
         logger.info(
             "Cortisol event: %s=%.2f (severity=%d)",
             breach.metric,

--- a/src/openbad/nervous_system/qos.py
+++ b/src/openbad/nervous_system/qos.py
@@ -66,6 +66,8 @@ _DEFAULT_QOS = 1
 _RETAIN_RULES: list[re.Pattern[str]] = [
     re.compile(r"^agent/reflex/state$"),
     re.compile(r"^agent/telemetry/"),
+    re.compile(r"^agent/endocrine/"),
+    re.compile(r"^agent/cognitive/health$"),
 ]
 
 

--- a/src/openbad/reflex_arc/fsm.py
+++ b/src/openbad/reflex_arc/fsm.py
@@ -17,6 +17,8 @@ import time
 from transitions import Machine, MachineError  # type: ignore[import-untyped]
 
 from openbad.nervous_system.schemas.common_pb2 import Header
+from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+from openbad.nervous_system.schemas.immune_pb2 import ImmuneAlert
 from openbad.nervous_system.schemas.reflex_pb2 import ReflexState
 
 logger = logging.getLogger(__name__)
@@ -50,6 +52,13 @@ TOPIC_TRIGGER_MAP: dict[str, str] = {
     "agent/endocrine/adrenaline": "emergency",
     "agent/endocrine/endorphin": "sleep",
     "agent/immune/alert": "emergency",
+}
+
+TOPIC_MESSAGE_MAP: dict[str, type[EndocrineEvent | ImmuneAlert]] = {
+    "agent/endocrine/cortisol": EndocrineEvent,
+    "agent/endocrine/adrenaline": EndocrineEvent,
+    "agent/endocrine/endorphin": EndocrineEvent,
+    "agent/immune/alert": ImmuneAlert,
 }
 
 
@@ -103,7 +112,19 @@ class AgentFSM:
                 current_state=self.state,
                 trigger_event=trigger_str,
             )
-            self._client.publish("agent/reflex/state", msg.SerializeToString())
+            self._client.publish("agent/reflex/state", msg)
+
+    def publish_current_state(self, trigger_event: str = "bootstrap") -> None:
+        """Publish the current state without requiring a transition."""
+        if self._client is None:
+            return
+        msg = ReflexState(
+            header=Header(timestamp_unix=time.time()),
+            previous_state=self.state,
+            current_state=self.state,
+            trigger_event=trigger_event,
+        )
+        self._client.publish("agent/reflex/state", msg)
 
     # ------------------------------------------------------------------
     # Thread-safe trigger dispatch
@@ -133,7 +154,7 @@ class AgentFSM:
     # Event-bus integration
     # ------------------------------------------------------------------
 
-    def handle_event(self, topic: str, payload: bytes) -> bool:
+    def handle_event(self, topic: str, payload: bytes | EndocrineEvent | ImmuneAlert) -> bool:
         """Route an event-bus message to the correct FSM trigger.
 
         For ``agent/endocrine/cortisol`` the trigger fires only when
@@ -146,6 +167,9 @@ class AgentFSM:
         if trigger_name is None:
             return False
 
+        if topic.startswith("agent/endocrine/") and self._extract_level(payload) <= 0.0:
+            return False
+
         # Severity gating for cortisol and immune/alert
         if topic in ("agent/endocrine/cortisol", "agent/immune/alert"):
             severity = self._extract_severity(topic, payload)
@@ -155,10 +179,10 @@ class AgentFSM:
         return self.fire(trigger_name)
 
     @staticmethod
-    def _extract_severity(topic: str, payload: bytes) -> int:
+    def _extract_severity(topic: str, payload: bytes | EndocrineEvent | ImmuneAlert) -> int:
         """Extract the severity int from the protobuf payload."""
-        from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
-        from openbad.nervous_system.schemas.immune_pb2 import ImmuneAlert
+        if hasattr(payload, "severity"):
+            return int(payload.severity)
 
         try:
             if topic.startswith("agent/endocrine/"):
@@ -173,9 +197,21 @@ class AgentFSM:
             logger.exception("FSM: failed to parse severity from %s", topic)
         return 0
 
+    @staticmethod
+    def _extract_level(payload: bytes | EndocrineEvent | ImmuneAlert) -> float:
+        if hasattr(payload, "level"):
+            return float(payload.level)
+
+        try:
+            msg = EndocrineEvent()
+            msg.ParseFromString(payload)
+            return float(msg.level)
+        except Exception:
+            return 0.0
+
     def subscribe_triggers(self) -> None:
         """Subscribe to all trigger topics via the MQTT client."""
         if self._client is None:
             return
         for topic in TOPIC_TRIGGER_MAP:
-            self._client.subscribe(topic, self.handle_event)
+            self._client.subscribe(topic, TOPIC_MESSAGE_MAP[topic], self.handle_event)

--- a/src/openbad/setup.py
+++ b/src/openbad/setup.py
@@ -32,7 +32,11 @@ CONFIG_FILES = [
     "threshold_policies.yaml",
 ]
 
-SYSTEMD_UNITS = ["openbad-broker.service", "openbad.service"]
+SYSTEMD_UNITS = [
+    "openbad-broker.service",
+    "openbad.service",
+    "openbad-wui.service",
+]
 
 DEFAULT_CONFIG_DIR = Path.home() / ".config" / "openbad"
 

--- a/src/openbad/wui/bridge.py
+++ b/src/openbad/wui/bridge.py
@@ -7,15 +7,30 @@ payloads to connected WebSocket clients as JSON.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from aiohttp import WSMsgType, web
 from google.protobuf.json_format import MessageToDict
 
+from openbad.cognitive.config import ProviderConfig, load_cognitive_config
+from openbad.cognitive.providers.anthropic import AnthropicProvider
+from openbad.cognitive.providers.github_copilot import GitHubCopilotProvider
+from openbad.cognitive.providers.ollama import OllamaProvider
+from openbad.cognitive.providers.openai_compat import (
+    custom_provider,
+    groq_provider,
+    mistral_provider,
+    openai_codex_provider,
+    openai_provider,
+    openrouter_provider,
+    xai_provider,
+)
 from openbad.nervous_system import topics
 from openbad.nervous_system.client import NervousSystemClient
 from openbad.nervous_system.schemas.cognitive_pb2 import ModelHealthStatus, ReasoningResponse
@@ -55,10 +70,23 @@ class MqttWebSocketBridge:
     _runner: web.AppRunner | None = field(default=None, init=False, repr=False)
     _site: web.TCPSite | None = field(default=None, init=False, repr=False)
     _mqtt: NervousSystemClient | None = field(default=None, init=False, repr=False)
+    _loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
     _clients: set[web.WebSocketResponse] = field(default_factory=set, init=False, repr=False)
+    _configured_provider_count: int = field(default=0, init=False, repr=False)
+    _latest_messages: dict[str, dict[str, Any]] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _event_clients: dict[web.StreamResponse, asyncio.Lock] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
 
     def create_app(self) -> web.Application:
         app = web.Application()
+        app.router.add_get("/events", self._sse_handler)
         app.router.add_get("/health", self._health)
         app.router.add_get("/ws", self._ws_handler)
         app.on_startup.append(self._on_startup)
@@ -84,6 +112,8 @@ class MqttWebSocketBridge:
             self._site = None
 
     async def _on_startup(self, _app: web.Application) -> None:
+        self._loop = asyncio.get_running_loop()
+        self._configured_provider_count = await _count_operational_providers()
         self._mqtt = NervousSystemClient.get_instance(host=self.mqtt_host, port=self.mqtt_port)
         self._mqtt.connect(timeout=5.0)
 
@@ -95,24 +125,76 @@ class MqttWebSocketBridge:
             await ws.close(code=1001, message=b"server shutdown")
         self._clients.clear()
 
+        for stream in list(self._event_clients):
+            with contextlib.suppress(Exception):
+                await stream.write_eof()
+        self._event_clients.clear()
+
         if self._mqtt is not None:
             self._mqtt.disconnect()
             NervousSystemClient.reset_instance()
             self._mqtt = None
+
+        self._loop = None
 
     async def _health(self, _request: web.Request) -> web.Response:
         return web.json_response(
             {
                 "ok": True,
                 "mqtt_connected": bool(self._mqtt and self._mqtt.is_connected),
-                "clients": len(self._clients),
+                "clients": len(self._clients) + len(self._event_clients),
+                "websocket_clients": len(self._clients),
+                "event_stream_clients": len(self._event_clients),
             }
         )
 
+    async def _sse_handler(self, request: web.Request) -> web.StreamResponse:
+        response = web.StreamResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+            },
+        )
+        await response.prepare(request)
+        lock = asyncio.Lock()
+        self._event_clients[response] = lock
+        logger.info("Event stream client connected")
+
+        await self._send_sse(
+            response,
+            lock,
+            {
+                "type": "hello",
+                "ts": _now_iso(),
+                "message": "openbad event stream connected",
+            },
+        )
+        await self._replay_latest_to_event_stream(response, lock)
+
+        try:
+            while True:
+                transport = request.transport
+                if transport is None or transport.is_closing():
+                    break
+                await asyncio.sleep(5)
+                await self._send_sse_comment(response, lock, "keepalive")
+        except Exception:
+            logger.exception("Event stream handler failed")
+        finally:
+            self._event_clients.pop(response, None)
+            logger.info("Event stream client disconnected")
+            with contextlib.suppress(Exception):
+                await response.write_eof()
+
+        return response
+
     async def _ws_handler(self, request: web.Request) -> web.WebSocketResponse:
-        ws = web.WebSocketResponse(heartbeat=20)
+        ws = web.WebSocketResponse()
         await ws.prepare(request)
         self._clients.add(ws)
+        logger.info("WebSocket client connected")
 
         await ws.send_json(
             {
@@ -121,6 +203,7 @@ class MqttWebSocketBridge:
                 "message": "openbad websocket bridge connected",
             }
         )
+        await self._replay_latest_to_websocket(ws)
 
         try:
             async for msg in ws:
@@ -129,44 +212,210 @@ class MqttWebSocketBridge:
                         await ws.send_str("pong")
                 elif msg.type in (WSMsgType.CLOSE, WSMsgType.ERROR):
                     break
+        except Exception:
+            logger.exception("WebSocket handler failed")
         finally:
             self._clients.discard(ws)
+            logger.info("WebSocket client disconnected (close_code=%s)", ws.close_code)
 
         return ws
 
     def _on_mqtt(self, topic: str, payload: Any) -> None:
-        """MQTT callback: schedule async fanout onto current event loop."""
+        """MQTT callback: schedule async fanout onto the aiohttp event loop."""
         message = {
             "type": "event",
             "ts": _now_iso(),
             "topic": topic,
-            "payload": _payload_to_jsonable(payload),
+            "payload": self._payload_to_jsonable(topic, payload),
         }
-        try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(self._broadcast(message))
-        except RuntimeError:
-            logger.debug("No running event loop available for MQTT fanout")
-
-    async def _broadcast(self, message: dict[str, Any]) -> None:
-        if not self._clients:
+        self._latest_messages[topic] = message
+        if self._loop is None:
+            logger.debug("No aiohttp event loop available for MQTT fanout")
             return
 
-        dead: list[web.WebSocketResponse] = []
+        future = asyncio.run_coroutine_threadsafe(self._broadcast(message), self._loop)
+        future.add_done_callback(self._log_broadcast_result)
+
+    async def _broadcast(self, message: dict[str, Any]) -> None:
+        if not self._clients and not self._event_clients:
+            return
+
+        dead_ws: list[web.WebSocketResponse] = []
         for ws in self._clients:
             try:
                 await ws.send_str(json.dumps(message))
-            except Exception:  # noqa: BLE001
-                dead.append(ws)
+            except Exception:
+                logger.exception("WebSocket broadcast failed; pruning client")
+                dead_ws.append(ws)
 
-        for ws in dead:
+        for ws in dead_ws:
             self._clients.discard(ws)
+
+        dead_streams: list[web.StreamResponse] = []
+        for stream, lock in self._event_clients.items():
+            try:
+                await self._send_sse(stream, lock, message)
+            except Exception:
+                logger.exception("Event stream broadcast failed; pruning client")
+                dead_streams.append(stream)
+
+        for stream in dead_streams:
+            self._event_clients.pop(stream, None)
+
+    async def _replay_latest_to_event_stream(
+        self,
+        stream: web.StreamResponse,
+        lock: asyncio.Lock,
+    ) -> None:
+        for message in self._latest_messages.values():
+            await self._send_sse(stream, lock, message)
+
+    async def _replay_latest_to_websocket(self, ws: web.WebSocketResponse) -> None:
+        for message in self._latest_messages.values():
+            await ws.send_str(json.dumps(message))
+
+
+    async def _send_sse(
+        self,
+        stream: web.StreamResponse,
+        lock: asyncio.Lock,
+        message: dict[str, Any],
+    ) -> None:
+        payload = json.dumps(message)
+        async with lock:
+            await stream.write(f"data: {payload}\n\n".encode())
+
+    async def _send_sse_comment(
+        self,
+        stream: web.StreamResponse,
+        lock: asyncio.Lock,
+        comment: str,
+    ) -> None:
+        async with lock:
+            await stream.write(f": {comment}\n\n".encode())
+
+    @staticmethod
+    def _log_broadcast_result(future: asyncio.Future[None]) -> None:
+        with contextlib.suppress(asyncio.CancelledError):
+            error = future.exception()
+            if error is not None:
+                logger.exception("MQTT fanout task failed", exc_info=error)
+
+    def _payload_to_jsonable(self, topic: str, payload: Any) -> dict[str, Any] | str:
+        result = _payload_to_jsonable(payload)
+        if topic == topics.COGNITIVE_HEALTH and isinstance(result, dict):
+            result["configured_provider_count"] = self._configured_provider_count
+        return result
 
 
 def _payload_to_jsonable(payload: Any) -> dict[str, Any] | str:
     if hasattr(payload, "DESCRIPTOR"):
-        return MessageToDict(payload, preserving_proto_field_name=True)
+        return MessageToDict(
+            payload,
+            preserving_proto_field_name=True,
+            always_print_fields_with_no_presence=True,
+        )
     return str(payload)
+
+
+async def _count_operational_providers() -> int:
+    for path in _candidate_cognitive_config_paths():
+        if not path.exists():
+            continue
+        try:
+            config = load_cognitive_config(path)
+            return await _count_operational_providers_from_config(config.providers)
+        except Exception:
+            logger.exception("Failed to load cognitive config from %s", path)
+            return 0
+    return 0
+
+
+async def _count_operational_providers_from_config(
+    providers: list[ProviderConfig],
+) -> int:
+    count = 0
+    for provider in providers:
+        if not provider.enabled:
+            continue
+
+        adapter = _build_provider_adapter(provider)
+        if adapter is None:
+            continue
+
+        try:
+            status = await adapter.health_check()
+        except Exception:
+            logger.exception("Failed health check for provider %s", provider.name)
+            continue
+
+        if status.available:
+            count += 1
+
+    return count
+
+
+def _build_provider_adapter(provider: ProviderConfig) -> Any | None:
+    timeout_s = max(1.0, min(provider.timeout_ms / 1000, 2.0))
+    common = {
+        "base_url": provider.base_url,
+        "default_model": provider.model,
+        "timeout_s": timeout_s,
+    }
+
+    if provider.name == "ollama":
+        return OllamaProvider(**common)
+    if provider.name == "openai":
+        return openai_provider(api_key_env=provider.api_key_env or "OPENAI_API_KEY", **common)
+    if provider.name == "openai-codex":
+        return openai_codex_provider(
+            api_key_env=provider.api_key_env or "OPENAI_CODEX_TOKEN",
+            **common,
+        )
+    if provider.name == "openrouter":
+        return openrouter_provider(
+            api_key_env=provider.api_key_env or "OPENROUTER_API_KEY",
+            **common,
+        )
+    if provider.name == "groq":
+        return groq_provider(api_key_env=provider.api_key_env or "GROQ_API_KEY", **common)
+    if provider.name == "xai":
+        return xai_provider(api_key_env=provider.api_key_env or "XAI_API_KEY", **common)
+    if provider.name == "mistral":
+        return mistral_provider(
+            api_key_env=provider.api_key_env or "MISTRAL_API_KEY",
+            **common,
+        )
+    if provider.name == "anthropic":
+        return AnthropicProvider(
+            base_url=provider.base_url,
+            api_key_env=provider.api_key_env or "ANTHROPIC_API_KEY",
+            default_model=provider.model,
+            timeout_s=timeout_s,
+        )
+    if provider.name == "github-copilot":
+        return GitHubCopilotProvider(
+            default_model=provider.model or "gpt-4o",
+            timeout_s=timeout_s,
+        )
+    if provider.name == "custom":
+        return custom_provider(
+            base_url=provider.base_url,
+            api_key_env=provider.api_key_env,
+            default_model=provider.model,
+            timeout_s=timeout_s,
+        )
+
+    logger.debug("Unsupported provider for WUI readiness count: %s", provider.name)
+    return None
+
+
+def _candidate_cognitive_config_paths() -> list[Path]:
+    return [
+        Path("/etc/openbad/cognitive.yaml"),
+        Path.home() / ".config" / "openbad" / "cognitive.yaml",
+        Path("config/cognitive.yaml"),
+    ]
 
 
 def _now_iso() -> str:

--- a/src/openbad/wui/static/app.js
+++ b/src/openbad/wui/static/app.js
@@ -37,6 +37,10 @@ const els = {
   },
 };
 
+let activeSocket = null;
+let reconnectTimer = null;
+let activeEventSource = null;
+
 function pulseOrgan(name) {
   const node = els.anatomy[name] || els.anatomy.nervous;
   if (!node) {
@@ -66,6 +70,16 @@ function logLine(text) {
   }
 }
 
+window.addEventListener('error', (event) => {
+  const message = event.message || 'unknown browser error';
+  logLine(`browser error: ${message}`);
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+  const reason = event.reason && event.reason.message ? event.reason.message : String(event.reason);
+  logLine(`browser rejection: ${reason}`);
+});
+
 function setOnline(online) {
   els.status.textContent = online ? 'online' : 'offline';
   els.status.classList.toggle('online', online);
@@ -75,8 +89,9 @@ function setOnline(online) {
 function updateFromEvent(topic, payload) {
   if (topic.startsWith('agent/endocrine/')) {
     const hormone = topic.split('/').pop();
-    if (els.hormones[hormone] && typeof payload.level === 'number') {
-      els.hormones[hormone].textContent = payload.level.toFixed(2);
+    if (els.hormones[hormone]) {
+      const level = Number(payload.level ?? 0);
+      els.hormones[hormone].textContent = level.toFixed(2);
     }
     return;
   }
@@ -110,9 +125,14 @@ function updateFromEvent(topic, payload) {
   }
 
   if (topic === 'agent/cognitive/health') {
-    els.inference.provider.textContent = payload.provider || '--';
+    const configuredProviders = Number(payload.configured_provider_count ?? 0);
+    els.inference.provider.textContent = `${configuredProviders}`;
     els.inference.model.textContent = payload.model_id || '--';
-    els.inference.health.textContent = payload.available ? 'up' : 'down';
+    if (payload.provider === 'inactive' || payload.model_id === 'none') {
+      els.inference.health.textContent = 'inactive';
+    } else {
+      els.inference.health.textContent = payload.available ? 'up' : 'down';
+    }
     els.inference.p50.textContent = `${Number(payload.latency_p50 || 0).toFixed(1)}ms`;
     els.inference.p99.textContent = `${Number(payload.latency_p99 || 0).toFixed(1)}ms`;
     return;
@@ -124,38 +144,93 @@ function updateFromEvent(topic, payload) {
   }
 }
 
-function connect() {
+function handleEventMessage(raw) {
+  try {
+    const msg = JSON.parse(raw);
+    if (msg.type === 'hello') {
+      logLine(`[${msg.ts}] ${msg.message}`);
+      return;
+    }
+    if (msg.type === 'event') {
+      const topic = msg.topic || 'unknown/topic';
+      pulseOrgan(mapTopicToOrgan(topic));
+      updateFromEvent(topic, msg.payload || {});
+      logLine(`[${msg.ts}] ${topic}`);
+    }
+  } catch {
+    logLine('malformed transport payload received');
+  }
+}
+
+function connectWebSocket() {
+  if (activeSocket && activeSocket.readyState === WebSocket.OPEN) {
+    return;
+  }
+  if (activeSocket && activeSocket.readyState === WebSocket.CONNECTING) {
+    return;
+  }
+  if (reconnectTimer !== null) {
+    window.clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
   const ws = new WebSocket(`${proto}://${window.location.host}/ws`);
+  activeSocket = ws;
 
   ws.addEventListener('open', () => {
     setOnline(true);
     logLine('socket connected');
   });
 
-  ws.addEventListener('close', () => {
+  ws.addEventListener('error', () => {
+    logLine('socket error');
+  });
+
+  ws.addEventListener('close', (event) => {
     setOnline(false);
-    logLine('socket disconnected; retrying...');
-    setTimeout(connect, 1000);
+    if (activeSocket === ws) {
+      activeSocket = null;
+    }
+    const reason = event.reason ? ` reason=${event.reason}` : '';
+    logLine(`socket disconnected; code=${event.code}${reason}; retrying...`);
+    reconnectTimer = window.setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, 1000);
   });
 
   ws.addEventListener('message', (ev) => {
-    try {
-      const msg = JSON.parse(ev.data);
-      if (msg.type === 'hello') {
-        logLine(`[${msg.ts}] ${msg.message}`);
-        return;
-      }
-      if (msg.type === 'event') {
-        const topic = msg.topic || 'unknown/topic';
-        pulseOrgan(mapTopicToOrgan(topic));
-        updateFromEvent(topic, msg.payload || {});
-        logLine(`[${msg.ts}] ${topic}`);
-      }
-    } catch {
-      logLine('malformed socket payload received');
-    }
+    handleEventMessage(ev.data);
   });
 }
 
-connect();
+function connectEventStream() {
+  if (!window.EventSource) {
+    connectWebSocket();
+    return;
+  }
+  if (activeEventSource) {
+    return;
+  }
+
+  const source = new EventSource('/events');
+  activeEventSource = source;
+
+  source.addEventListener('open', () => {
+    setOnline(true);
+    logLine('event stream connected');
+  });
+
+  source.addEventListener('error', () => {
+    setOnline(false);
+    const state = source.readyState;
+    logLine(`event stream disconnected; state=${state}; retrying...`);
+  });
+
+  source.onmessage = (event) => {
+    handleEventMessage(event.data);
+  };
+}
+
+connectEventStream();

--- a/src/openbad/wui/static/index.html
+++ b/src/openbad/wui/static/index.html
@@ -27,10 +27,34 @@
       <article class="card reveal">
         <h2>Hormones</h2>
         <div id="hormones" class="stack">
-          <div class="row"><span>Dopamine</span><strong id="h-dopamine">0.00</strong></div>
-          <div class="row"><span>Adrenaline</span><strong id="h-adrenaline">0.00</strong></div>
-          <div class="row"><span>Cortisol</span><strong id="h-cortisol">0.00</strong></div>
-          <div class="row"><span>Endorphin</span><strong id="h-endorphin">0.00</strong></div>
+          <div class="row hormone-row">
+            <div class="label-block">
+              <span class="label-title">Dopamine</span>
+              <span class="label-note">reward and motivation</span>
+            </div>
+            <strong id="h-dopamine">0.00</strong>
+          </div>
+          <div class="row hormone-row">
+            <div class="label-block">
+              <span class="label-title">Adrenaline</span>
+              <span class="label-note">fight-or-flight energy</span>
+            </div>
+            <strong id="h-adrenaline">0.00</strong>
+          </div>
+          <div class="row hormone-row">
+            <div class="label-block">
+              <span class="label-title">Cortisol</span>
+              <span class="label-note">stress load</span>
+            </div>
+            <strong id="h-cortisol">0.00</strong>
+          </div>
+          <div class="row hormone-row">
+            <div class="label-block">
+              <span class="label-title">Endorphin</span>
+              <span class="label-note">calm and relief</span>
+            </div>
+            <strong id="h-endorphin">0.00</strong>
+          </div>
         </div>
       </article>
 
@@ -50,9 +74,9 @@
       <article class="card reveal">
         <h2>Inference</h2>
         <div class="stack mono">
-          <div class="row"><span>Provider</span><strong id="i-provider">--</strong></div>
+          <div class="row"><span>Providers</span><strong id="i-provider">--</strong></div>
           <div class="row"><span>Model</span><strong id="i-model">--</strong></div>
-          <div class="row"><span>Health</span><strong id="i-health">down</strong></div>
+          <div class="row"><span>Health</span><strong id="i-health">--</strong></div>
           <div class="row"><span>p50</span><strong id="i-p50">0.0ms</strong></div>
           <div class="row"><span>p99</span><strong id="i-p99">0.0ms</strong></div>
           <div class="row"><span>Last Tokens</span><strong id="i-last-tokens">0</strong></div>

--- a/src/openbad/wui/static/styles.css
+++ b/src/openbad/wui/static/styles.css
@@ -100,6 +100,37 @@ html, body {
 .row span { color: var(--muted); }
 .mono strong { font-family: "IBM Plex Mono", monospace; font-size: 0.92rem; }
 
+.hormone-row {
+  align-items: flex-start;
+  padding: 0.18rem 0;
+}
+
+.label-block {
+  display: grid;
+  gap: 0.12rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.label-title {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.label-note {
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.2;
+}
+
+.hormone-row strong {
+  flex: 0 0 auto;
+  min-width: 3.4rem;
+  text-align: right;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.96rem;
+}
+
 .log {
   margin-top: 0.9rem;
   background: var(--card);

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
+from unittest.mock import MagicMock, patch
+
 from click.testing import CliRunner
 
 from openbad.cli import main
@@ -18,12 +21,16 @@ class TestMainGroup:
     def test_help_flag(self):
         result = CliRunner().invoke(main, ["--help"])
         assert result.exit_code == 0
-        assert "run" in result.output
-        assert "status" in result.output
+        assert "start" in result.output
+        assert "stop" in result.output
+        assert "restart" in result.output
+        assert "health" in result.output
         assert "version" in result.output
         assert "setup" in result.output
         assert "tui" in result.output
-        assert "wui" in result.output
+        assert "  run " not in result.output
+        assert "  status " not in result.output
+        assert "  wui " not in result.output
 
 
 class TestVersionCommand:
@@ -57,30 +64,153 @@ class TestTuiCommand:
         assert "--port" in result.output
 
 
-class TestWuiCommand:
-    """``openbad wui`` command surface."""
+class TestHealthCommand:
+    """``openbad health`` operator surface."""
 
-    def test_wui_help(self):
-        result = CliRunner().invoke(main, ["wui", "--help"])
+    def test_health_help(self):
+        result = CliRunner().invoke(main, ["health", "--help"])
         assert result.exit_code == 0
         assert "--host" in result.output
         assert "--port" in result.output
-        assert "--mqtt-host" in result.output
-        assert "--mqtt-port" in result.output
+        assert "--wui-url" in result.output
 
 
-class TestStatusCommand:
-    """``openbad status`` — MQTT reachability check."""
+class TestServiceControlCommands:
+    def test_start_invokes_systemctl_start(self):
+        with patch("openbad.cli.subprocess.run") as run:
+            run.side_effect = [
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="", stderr="", returncode=0),
+            ]
+            result = CliRunner().invoke(main, ["start"])
 
-    def test_status_no_broker(self):
-        """Without a running broker, exit code should be 1."""
-        result = CliRunner().invoke(main, ["status", "--port", "19999"])
+        assert result.exit_code == 0
+        assert run.call_args.args[0][0].endswith("systemctl")
+        assert run.call_args.args[0][1] == "start"
+
+    def test_stop_invokes_systemctl_stop(self):
+        with patch("openbad.cli.subprocess.run") as run:
+            run.side_effect = [
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="", stderr="", returncode=0),
+            ]
+            result = CliRunner().invoke(main, ["stop"])
+
+        assert result.exit_code == 0
+        assert run.call_args.args[0][0].endswith("systemctl")
+        assert run.call_args.args[0][1] == "stop"
+
+    def test_restart_invokes_systemctl_restart(self):
+        with patch("openbad.cli.subprocess.run") as run:
+            run.side_effect = [
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="", stderr="", returncode=0),
+            ]
+            result = CliRunner().invoke(main, ["restart"])
+
+        assert result.exit_code == 0
+        assert run.call_args.args[0][0].endswith("systemctl")
+        assert run.call_args.args[0][1] == "restart"
+
+    def test_restart_skips_disabled_broker_unit(self):
+        with patch("openbad.cli.subprocess.run") as run:
+            run.side_effect = [
+                MagicMock(stdout="disabled\n", stderr="", returncode=1),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="", stderr="", returncode=0),
+            ]
+            result = CliRunner().invoke(main, ["restart"])
+
+        assert result.exit_code == 0
+        assert run.call_args.args[0][-2:] == ["openbad.service", "openbad-wui.service"]
+
+    def test_service_command_reports_systemctl_failure(self):
+        with patch("openbad.cli.subprocess.run") as run:
+            run.side_effect = FileNotFoundError()
+            result = CliRunner().invoke(main, ["start"])
+
+        assert result.exit_code == 1
+        assert "systemctl not found" in result.output
+
+    def test_service_command_reports_sudo_requirement(self):
+        with patch("openbad.cli.subprocess.run") as run:
+            run.side_effect = [
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                subprocess.CalledProcessError(
+                    returncode=1,
+                    cmd=["/bin/systemctl", "start", "openbad.service"],
+                    stderr="Interactive authentication required.",
+                ),
+            ]
+            result = CliRunner().invoke(main, ["start"])
+
+        assert result.exit_code == 1
+        assert "sudo openbad start" in result.output
+
+
+class TestHealthStatusCommand:
+    def test_health_without_services_or_broker(self):
+        with patch("openbad.cli.subprocess.run") as run:
+            run.side_effect = [
+                MagicMock(stdout="inactive\n", stderr="", returncode=3),
+                MagicMock(stdout="inactive\n", stderr="", returncode=3),
+                MagicMock(stdout="inactive\n", stderr="", returncode=3),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+            ]
+            result = CliRunner().invoke(main, ["health", "--port", "19999"])
+
         assert result.exit_code == 1
         assert '"mqtt_reachable": false' in result.output
+        assert '"openbad.service": "inactive"' in result.output
+
+    def test_health_succeeds_with_disabled_broker_unit_and_external_broker(self):
+        with patch("openbad.cli.subprocess.run") as run, patch(
+            "openbad.cli.urllib_request.urlopen"
+        ) as urlopen, patch("openbad.nervous_system.client.NervousSystemClient") as client_cls:
+            run.side_effect = [
+                MagicMock(stdout="inactive\n", stderr="", returncode=3),
+                MagicMock(stdout="active\n", stderr="", returncode=0),
+                MagicMock(stdout="active\n", stderr="", returncode=0),
+                MagicMock(stdout="disabled\n", stderr="", returncode=1),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+                MagicMock(stdout="enabled\n", stderr="", returncode=0),
+            ]
+            client = MagicMock()
+            client_cls.return_value = client
+            response = MagicMock()
+            response.__enter__.return_value = response
+            response.read.return_value = b'{"ok": true}'
+            response.status = 200
+            urlopen.return_value = response
+
+            result = CliRunner().invoke(main, ["health"])
+
+        assert result.exit_code == 0
+        assert '"openbad-broker.service": "inactive"' in result.output
+        assert '"openbad-broker.service": "disabled"' in result.output
+
+    def test_status_alias_invokes_health(self):
+        with patch("openbad.cli.subprocess.run") as run:
+            run.return_value = MagicMock(stdout="inactive\n", stderr="", returncode=3)
+            result = CliRunner().invoke(main, ["status", "--port", "19999"])
+
+        assert result.exit_code == 1
+        assert '"services"' in result.output
 
 
-class TestRunCommand:
-    """``openbad run`` — daemon lifecycle."""
+class TestInternalCommands:
+    """Internal foreground commands remain invokable for systemd/debugging."""
 
     def test_run_help(self):
         result = CliRunner().invoke(main, ["run", "--help"])
@@ -89,3 +219,11 @@ class TestRunCommand:
         assert "--host" in result.output
         assert "--port" in result.output
         assert "--verbose" in result.output
+
+    def test_wui_help(self):
+        result = CliRunner().invoke(main, ["wui", "--help"])
+        assert result.exit_code == 0
+        assert "--host" in result.output
+        assert "--port" in result.output
+        assert "--mqtt-host" in result.output
+        assert "--mqtt-port" in result.output

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -121,3 +121,24 @@ class TestDaemonSubsystems:
         assert state.dopamine == 0.0
         await d.stop()
         await task
+
+    async def test_start_publishes_initial_dashboard_topics(self, mock_client):
+        d = Daemon()
+        task = asyncio.create_task(d.start())
+        await asyncio.sleep(0.1)
+
+        published_topics = [call.args[0] for call in mock_client.publish.call_args_list]
+        assert "agent/reflex/state" in published_topics
+        assert "agent/endocrine/dopamine" in published_topics
+        assert "agent/endocrine/adrenaline" in published_topics
+        assert "agent/endocrine/cortisol" in published_topics
+        assert "agent/endocrine/endorphin" in published_topics
+        assert "agent/telemetry/cpu" in published_topics
+        assert "agent/telemetry/memory" in published_topics
+        assert "agent/telemetry/disk" in published_topics
+        assert "agent/telemetry/network" in published_topics
+        assert "agent/telemetry/tokens" in published_topics
+        assert "agent/cognitive/health" in published_topics
+
+        await d.stop()
+        await task

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -135,14 +135,9 @@ class TestPublishing:
         client_mock.publish.assert_called_once()
         topic, payload = client_mock.publish.call_args[0]
         assert topic == "agent/reflex/state"
-        # Deserialize and verify
-        from openbad.nervous_system.schemas.reflex_pb2 import ReflexState
-
-        msg = ReflexState()
-        msg.ParseFromString(payload)
-        assert msg.previous_state == "IDLE"
-        assert msg.current_state == "ACTIVE"
-        assert msg.trigger_event == "activate"
+        assert payload.previous_state == "IDLE"
+        assert payload.current_state == "ACTIVE"
+        assert payload.trigger_event == "activate"
 
     def test_no_publish_on_invalid_transition(self, fsm_with_client: AgentFSM, client_mock):
         fsm_with_client.fire("deactivate")
@@ -156,6 +151,7 @@ def _cortisol_critical() -> bytes:
     return EndocrineEvent(
         header=Header(timestamp_unix=1.0),
         hormone="cortisol",
+        level=1.0,
         severity=3,  # CRITICAL
     ).SerializeToString()
 
@@ -164,6 +160,7 @@ def _cortisol_warning() -> bytes:
     return EndocrineEvent(
         header=Header(timestamp_unix=1.0),
         hormone="cortisol",
+        level=1.0,
         severity=2,  # WARNING
     ).SerializeToString()
 
@@ -185,6 +182,24 @@ def _immune_info() -> bytes:
 
 
 class TestHandleEvent:
+    def test_zero_adrenaline_snapshot_does_not_trigger_emergency(self, fsm: AgentFSM):
+        payload = EndocrineEvent(
+            header=Header(timestamp_unix=1.0),
+            hormone="adrenaline",
+            level=0.0,
+        ).SerializeToString()
+        assert not fsm.handle_event("agent/endocrine/adrenaline", payload)
+        assert fsm.state == "IDLE"
+
+    def test_zero_endorphin_snapshot_does_not_trigger_sleep(self, fsm: AgentFSM):
+        payload = EndocrineEvent(
+            header=Header(timestamp_unix=1.0),
+            hormone="endorphin",
+            level=0.0,
+        ).SerializeToString()
+        assert not fsm.handle_event("agent/endocrine/endorphin", payload)
+        assert fsm.state == "IDLE"
+
     def test_cortisol_critical_throttles(self, fsm: AgentFSM):
         assert fsm.handle_event("agent/endocrine/cortisol", _cortisol_critical())
         assert fsm.state == "THROTTLED"
@@ -197,6 +212,7 @@ class TestHandleEvent:
         payload = EndocrineEvent(
             header=Header(timestamp_unix=1.0),
             hormone="adrenaline",
+            level=1.0,
         ).SerializeToString()
         assert fsm.handle_event("agent/endocrine/adrenaline", payload)
         assert fsm.state == "EMERGENCY"
@@ -205,6 +221,7 @@ class TestHandleEvent:
         payload = EndocrineEvent(
             header=Header(timestamp_unix=1.0),
             hormone="endorphin",
+            level=1.0,
         ).SerializeToString()
         assert fsm.handle_event("agent/endocrine/endorphin", payload)
         assert fsm.state == "SLEEP"
@@ -230,6 +247,10 @@ class TestSubscribeTriggers:
         fsm_with_client.subscribe_triggers()
         subscribed_topics = {c.args[0] for c in client_mock.subscribe.call_args_list}
         assert subscribed_topics == set(TOPIC_TRIGGER_MAP)
+        assert all(
+            c.args[2] == fsm_with_client.handle_event
+            for c in client_mock.subscribe.call_args_list
+        )
 
     def test_no_subscribe_without_client(self, fsm: AgentFSM):
         # Should not raise

--- a/tests/test_qos.py
+++ b/tests/test_qos.py
@@ -80,10 +80,13 @@ class TestShouldRetain:
         "topic",
         [
             "agent/reflex/state",
+            "agent/endocrine/dopamine",
+            "agent/endocrine/cortisol",
             "agent/telemetry/cpu",
             "agent/telemetry/memory",
             "agent/telemetry/disk",
             "agent/telemetry/tokens",
+            "agent/cognitive/health",
         ],
     )
     def test_state_topics_are_retained(self, topic: str):
@@ -94,8 +97,8 @@ class TestShouldRetain:
         [
             "agent/reflex/thermal/trigger",
             "agent/cognitive/escalation",
+            "agent/cognitive/response",
             "agent/immune/alert",
-            "agent/endocrine/cortisol",
             "agent/memory/stm/write",
             "agent/proprioception/tool-a/heartbeat",
         ],

--- a/tests/test_service_install.py
+++ b/tests/test_service_install.py
@@ -88,6 +88,26 @@ class TestInstallScript:
         assert "require_root" in self.content
         assert "EUID" in self.content
 
+    def test_has_usage_and_arg_parsing(self):
+        assert "usage()" in self.content
+        assert "parse_args" in self.content
+        assert "--bootstrap" in self.content
+        assert "--skip-services" in self.content
+        assert "--uninstall" in self.content
+
+    def test_bootstrap_support_present(self):
+        assert "bootstrap_os" in self.content
+        assert "install_prereqs_apt" in self.content
+        assert "python3-venv" in self.content
+
+    def test_systemd_detection_present(self):
+        assert "has_systemd" in self.content
+        assert "systemd not detected" in self.content
+
+    def test_wsl_detection_present(self):
+        assert "is_wsl" in self.content
+        assert "WSL environment detected" in self.content
+
     def test_creates_user(self):
         assert "useradd" in self.content
         assert "openbad" in self.content

--- a/tests/test_service_install.py
+++ b/tests/test_service_install.py
@@ -121,7 +121,10 @@ class TestInstallScript:
         assert "openbad" in self.content
 
     def test_installs_package(self):
-        assert "pip" in self.content
+        assert "VENV_DIR" in self.content
+        assert "python3 -m venv" in self.content
+        assert "bin/python\" -m pip install" in self.content
+        assert "OPENBAD_BIN" in self.content
 
     def test_copies_configs(self):
         assert "CONFIG_DIR" in self.content

--- a/tests/test_service_install.py
+++ b/tests/test_service_install.py
@@ -92,6 +92,7 @@ class TestInstallScript:
         assert "usage()" in self.content
         assert "parse_args" in self.content
         assert "--bootstrap" in self.content
+        assert "--configure-wsl-systemd" in self.content
         assert "--skip-services" in self.content
         assert "--uninstall" in self.content
 
@@ -102,11 +103,18 @@ class TestInstallScript:
 
     def test_systemd_detection_present(self):
         assert "has_systemd" in self.content
-        assert "systemd not detected" in self.content
+        assert "ensure_systemd_ready" in self.content
+        assert "systemd is required for full install" in self.content
 
     def test_wsl_detection_present(self):
         assert "is_wsl" in self.content
         assert "WSL environment detected" in self.content
+        assert "configure_wsl_systemd" in self.content
+
+    def test_broker_fallback_support_present(self):
+        assert "select_broker_impl" in self.content
+        assert "install_broker_unit" in self.content
+        assert "mosquitto" in self.content
 
     def test_creates_user(self):
         assert "useradd" in self.content

--- a/tests/test_service_install.py
+++ b/tests/test_service_install.py
@@ -31,6 +31,10 @@ class TestOpenbadServiceFile:
     def test_after_broker(self):
         assert "openbad-broker.service" in self.content
 
+    def test_broker_is_optional(self):
+        assert "Wants=openbad-broker.service" in self.content
+        assert "Requires=openbad-broker.service" not in self.content
+
     def test_exec_start(self):
         match = re.search(r"ExecStart=.*openbad run", self.content)
         assert match is not None
@@ -45,6 +49,36 @@ class TestOpenbadServiceFile:
 
     def test_user_set(self):
         assert "User=openbad" in self.content
+
+    def test_wanted_by(self):
+        assert "WantedBy=multi-user.target" in self.content
+
+
+class TestOpenbadWuiServiceFile:
+    """Validate config/openbad-wui.service syntax."""
+
+    def setup_method(self):
+        self.path = CONFIG_DIR / "openbad-wui.service"
+        self.content = self.path.read_text()
+
+    def test_file_exists(self):
+        assert self.path.exists()
+
+    def test_has_all_sections(self):
+        for section in ("[Unit]", "[Service]", "[Install]"):
+            assert section in self.content
+
+    def test_requires_daemon(self):
+        assert "After=openbad.service" in self.content
+        assert "Requires=openbad.service" in self.content
+
+    def test_exec_start(self):
+        assert "openbad wui" in self.content
+
+    def test_security_hardening(self):
+        assert "NoNewPrivileges=true" in self.content
+        assert "ProtectSystem=strict" in self.content
+        assert "PrivateTmp=true" in self.content
 
     def test_wanted_by(self):
         assert "WantedBy=multi-user.target" in self.content
@@ -132,6 +166,7 @@ class TestInstallScript:
     def test_installs_systemd_units(self):
         assert "systemctl daemon-reload" in self.content
         assert "systemctl enable" in self.content
+        assert "openbad-wui.service" in self.content
 
     def test_has_uninstall(self):
         assert "--uninstall" in self.content

--- a/tests/test_wui_anatomy.py
+++ b/tests/test_wui_anatomy.py
@@ -24,9 +24,35 @@ def test_js_contains_topic_to_organ_mapping():
     assert "agent/endocrine/" in js
     assert "agent/reflex/" in js
     assert "agent/immune/" in js
+    assert "els.inference.health.textContent = 'inactive'" in js
 
 
 def test_css_contains_pulse_style():
     css = (STATIC_DIR / "styles.css").read_text(encoding="utf-8")
     assert ".organ.pulse" in css
     assert "drop-shadow" in css
+
+
+def test_index_uses_neutral_health_placeholder():
+    html = (STATIC_DIR / "index.html").read_text(encoding="utf-8")
+    assert 'id="i-health">--<' in html
+    assert '<span>Providers</span>' in html
+
+
+def test_index_contains_plain_language_hormone_labels():
+    html = (STATIC_DIR / "index.html").read_text(encoding="utf-8")
+    assert "<span class=\"label-title\">Dopamine</span>" in html
+    assert "<span class=\"label-note\">reward and motivation</span>" in html
+    assert "<span class=\"label-title\">Adrenaline</span>" in html
+    assert "<span class=\"label-note\">fight-or-flight energy</span>" in html
+    assert "<span class=\"label-title\">Cortisol</span>" in html
+    assert "<span class=\"label-note\">stress load</span>" in html
+    assert "<span class=\"label-title\">Endorphin</span>" in html
+    assert "<span class=\"label-note\">calm and relief</span>" in html
+
+
+def test_css_contains_hormone_label_layout():
+    css = (STATIC_DIR / "styles.css").read_text(encoding="utf-8")
+    assert ".hormone-row" in css
+    assert ".label-block" in css
+    assert ".label-note" in css

--- a/tests/test_wui_bridge.py
+++ b/tests/test_wui_bridge.py
@@ -15,6 +15,7 @@ from openbad.wui.bridge import (
     _payload_to_jsonable,
 )
 
+
 class TestPayloadSerialization:
     def test_plain_payload_fallback(self):
         assert _payload_to_jsonable(123) == "123"
@@ -62,9 +63,25 @@ class TestConfigLoading:
         unhealthy.health_check.return_value.available = False
 
         providers = [
-            ProviderConfig(name="ollama", base_url="http://localhost:11434", model="llama3.2", enabled=True),
-            ProviderConfig(name="openai", base_url="https://api.openai.com/v1", model="gpt-4o-mini", api_key_env="OPENAI_API_KEY", enabled=True),
-            ProviderConfig(name="anthropic", base_url="https://api.anthropic.com", model="claude-sonnet-4-20250514", enabled=False),
+            ProviderConfig(
+                name="ollama",
+                base_url="http://localhost:11434",
+                model="llama3.2",
+                enabled=True,
+            ),
+            ProviderConfig(
+                name="openai",
+                base_url="https://api.openai.com/v1",
+                model="gpt-4o-mini",
+                api_key_env="OPENAI_API_KEY",
+                enabled=True,
+            ),
+            ProviderConfig(
+                name="anthropic",
+                base_url="https://api.anthropic.com",
+                model="claude-sonnet-4-20250514",
+                enabled=False,
+            ),
         ]
 
         with patch(
@@ -93,7 +110,10 @@ class TestBridgeLifecycle:
         mock_client = MagicMock()
         with patch("openbad.wui.bridge.NervousSystemClient") as cls:
             cls.get_instance.return_value = mock_client
-            with patch("openbad.wui.bridge._count_operational_providers", AsyncMock(return_value=0)):
+            with patch(
+                "openbad.wui.bridge._count_operational_providers",
+                AsyncMock(return_value=0),
+            ):
                 await bridge._on_startup(app)
 
         mock_client.connect.assert_called_once()

--- a/tests/test_wui_bridge.py
+++ b/tests/test_wui_bridge.py
@@ -8,8 +8,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from openbad.wui.bridge import MqttWebSocketBridge, _payload_to_jsonable
-
+from openbad.cognitive.config import ProviderConfig
+from openbad.wui.bridge import (
+    MqttWebSocketBridge,
+    _count_operational_providers_from_config,
+    _payload_to_jsonable,
+)
 
 class TestPayloadSerialization:
     def test_plain_payload_fallback(self):
@@ -24,6 +28,52 @@ class TestPayloadSerialization:
         assert as_json["usage_percent"] == 12.5
         assert as_json["core_count"] == 8
 
+    def test_proto_payload_includes_zero_default_fields(self):
+        from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
+
+        payload = EndocrineEvent(hormone="dopamine", level=0.0)
+        as_json = _payload_to_jsonable(payload)
+        assert isinstance(as_json, dict)
+        assert as_json["level"] == 0.0
+
+    def test_bridge_enriches_cognitive_health_with_provider_count(self):
+        from openbad.nervous_system import topics
+        from openbad.nervous_system.schemas.cognitive_pb2 import ModelHealthStatus
+
+        bridge = MqttWebSocketBridge()
+        bridge._configured_provider_count = 2
+
+        as_json = bridge._payload_to_jsonable(
+            topics.COGNITIVE_HEALTH,
+            ModelHealthStatus(provider="inactive", model_id="none", available=False),
+        )
+
+        assert isinstance(as_json, dict)
+        assert as_json["configured_provider_count"] == 2
+
+
+class TestConfigLoading:
+    @pytest.mark.asyncio
+    async def test_count_operational_providers_only_counts_healthy_enabled(self):
+        healthy = AsyncMock()
+        healthy.health_check.return_value.available = True
+
+        unhealthy = AsyncMock()
+        unhealthy.health_check.return_value.available = False
+
+        providers = [
+            ProviderConfig(name="ollama", base_url="http://localhost:11434", model="llama3.2", enabled=True),
+            ProviderConfig(name="openai", base_url="https://api.openai.com/v1", model="gpt-4o-mini", api_key_env="OPENAI_API_KEY", enabled=True),
+            ProviderConfig(name="anthropic", base_url="https://api.anthropic.com", model="claude-sonnet-4-20250514", enabled=False),
+        ]
+
+        with patch(
+            "openbad.wui.bridge._build_provider_adapter",
+            side_effect=[healthy, unhealthy],
+        ):
+            assert await _count_operational_providers_from_config(providers) == 1
+
+
 
 class TestBridgeLifecycle:
     @pytest.mark.asyncio
@@ -31,6 +81,7 @@ class TestBridgeLifecycle:
         bridge = MqttWebSocketBridge()
         app = bridge.create_app()
         paths = sorted(route.resource.canonical for route in app.router.routes())
+        assert "/events" in paths
         assert "/health" in paths
         assert "/ws" in paths
 
@@ -42,7 +93,8 @@ class TestBridgeLifecycle:
         mock_client = MagicMock()
         with patch("openbad.wui.bridge.NervousSystemClient") as cls:
             cls.get_instance.return_value = mock_client
-            await bridge._on_startup(app)
+            with patch("openbad.wui.bridge._count_operational_providers", AsyncMock(return_value=0)):
+                await bridge._on_startup(app)
 
         mock_client.connect.assert_called_once()
         assert mock_client.subscribe.call_count >= 5
@@ -54,6 +106,8 @@ class TestBridgeLifecycle:
 
         ws = AsyncMock()
         bridge._clients.add(ws)
+        stream = AsyncMock()
+        bridge._event_clients[stream] = asyncio.Lock()
         mqtt = MagicMock()
         bridge._mqtt = mqtt
 
@@ -62,8 +116,10 @@ class TestBridgeLifecycle:
             cls.reset_instance.assert_called_once()
 
         ws.close.assert_awaited_once()
+        stream.write_eof.assert_awaited_once()
         mqtt.disconnect.assert_called_once()
         assert len(bridge._clients) == 0
+        assert len(bridge._event_clients) == 0
 
 
 class TestBroadcasting:
@@ -97,26 +153,74 @@ class TestBroadcasting:
         assert good in bridge._clients
         assert bad not in bridge._clients
 
+    @pytest.mark.asyncio
+    async def test_broadcast_to_event_stream_clients(self):
+        bridge = MqttWebSocketBridge()
+        stream = AsyncMock()
+        bridge._event_clients[stream] = asyncio.Lock()
+
+        await bridge._broadcast({"type": "event", "topic": "agent/test", "payload": {}})
+
+        stream.write.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_replay_latest_to_event_stream_clients(self):
+        bridge = MqttWebSocketBridge()
+        stream = AsyncMock()
+        lock = asyncio.Lock()
+        bridge._latest_messages = {
+            "agent/reflex/state": {
+                "type": "event",
+                "topic": "agent/reflex/state",
+                "payload": {"current_state": "IDLE"},
+            },
+            "agent/endocrine/dopamine": {
+                "type": "event",
+                "topic": "agent/endocrine/dopamine",
+                "payload": {"level": 0.0},
+            },
+        }
+
+        await bridge._replay_latest_to_event_stream(stream, lock)
+
+        assert stream.write.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_replay_latest_to_websocket_clients(self):
+        bridge = MqttWebSocketBridge()
+        ws = AsyncMock()
+        bridge._latest_messages = {
+            "agent/reflex/state": {
+                "type": "event",
+                "topic": "agent/reflex/state",
+                "payload": {"current_state": "IDLE"},
+            }
+        }
+
+        await bridge._replay_latest_to_websocket(ws)
+
+        ws.send_str.assert_awaited_once()
+        sent = json.loads(ws.send_str.call_args.args[0])
+        assert sent["topic"] == "agent/reflex/state"
+
 
 class TestMqttCallback:
     @pytest.mark.asyncio
     async def test_on_mqtt_schedules_broadcast(self):
         bridge = MqttWebSocketBridge()
+        bridge._loop = asyncio.get_running_loop()
         bridge._broadcast = AsyncMock()  # type: ignore[method-assign]
 
-        task_created = asyncio.Event()
-
-        original_create_task = asyncio.get_running_loop().create_task
-
-        def _wrapped_create_task(coro):
-            task_created.set()
-            return original_create_task(coro)
-
-        with patch.object(
-            asyncio.get_running_loop(),
-            "create_task",
-            side_effect=_wrapped_create_task,
-        ):
+        with patch("openbad.wui.bridge.asyncio.run_coroutine_threadsafe") as submit:
             bridge._on_mqtt("agent/test", {"k": "v"})
 
-        await asyncio.wait_for(task_created.wait(), timeout=1.0)
+        submit.assert_called_once()
+        submit.call_args.args[0].close()
+
+    def test_on_mqtt_without_loop_is_noop(self):
+        bridge = MqttWebSocketBridge()
+
+        with patch("openbad.wui.bridge.asyncio.run_coroutine_threadsafe") as submit:
+            bridge._on_mqtt("agent/test", {"k": "v"})
+
+        submit.assert_not_called()

--- a/tests/test_wui_server.py
+++ b/tests/test_wui_server.py
@@ -43,6 +43,18 @@ async def test_ws_health_route(aiohttp_client):
     data = await resp.json()
     assert "ok" in data
     assert "clients" in data
+    assert "websocket_clients" in data
+    assert "event_stream_clients" in data
+
+
+@pytest.mark.asyncio
+async def test_event_stream_route(aiohttp_client):
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+    resp = await client.get("/events")
+    assert resp.status == 200
+    first_line = await resp.content.readline()
+    assert first_line.startswith(b"data: ")
 
 
 def test_create_app_attaches_bridge():


### PR DESCRIPTION
## Summary
- add operator-facing service commands: `openbad start`, `stop`, `restart`, `health`, `tui`, and `version`
- add and install a dedicated `openbad-wui.service` and make the broker dependency optional for the daemon
- harden the Linux/WSL installer flow for a dedicated `/opt/openbad/venv` install and WUI service lifecycle
- start telemetry publishers from the daemon, publish retained bootstrap snapshots, and retain dashboard state topics
- fix typed MQTT publishing/subscription usage for telemetry, endocrine, and reflex state messages
- prevent zero-valued endocrine bootstrap snapshots from driving the FSM into `EMERGENCY` or `SLEEP`
- switch the WUI bridge to thread-safe fanout with SSE support, cached snapshot replay for new clients, and clearer health/provider labeling
- improve WUI formatting for hormone descriptions and expose operational provider count instead of raw sample config rows
- document the operator commands in the README and expand regression coverage across CLI, services, daemon, FSM, and WUI behavior

## Validation
- `c:/Repos/OpenBaD/.venv/Scripts/python.exe -m pytest tests/test_cli.py tests/test_daemon.py tests/test_fsm.py tests/test_qos.py tests/test_service_install.py tests/test_wui_anatomy.py tests/test_wui_bridge.py tests/test_wui_server.py -q`
- live WSL redeploy and verification of:
  - stable `openbad.service` and `openbad-wui.service`
  - retained `agent/reflex/state` replay to new browser sessions
  - explicit zero-valued hormone snapshots in the WUI
  - cognitive health payload enrichment with `configured_provider_count: 0`
