### PR TITLE
#201: Rename Wiring to Providers across codebase

### DIFF
--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 
 import asyncio
 import os
-from pathlib import Path
 import time
+from pathlib import Path
 from uuid import uuid4
 
-from aiohttp import web
 import yaml
+from aiohttp import web
 
 from openbad.cognitive.config import CognitiveConfig, ProviderConfig, load_cognitive_config
 from openbad.cognitive.providers.github_copilot import CopilotAuthError, GitHubCopilotProvider
@@ -76,7 +76,7 @@ def _serialize_cognitive_config(config: CognitiveConfig, path: Path) -> dict[str
     }
 
 
-def _read_wiring_config() -> tuple[Path, CognitiveConfig]:
+def _read_providers_config() -> tuple[Path, CognitiveConfig]:
     path = _resolve_cognitive_config_path()
     return path, load_cognitive_config(path)
 
@@ -123,7 +123,7 @@ def _coerce_timeout_ms(value: object, default: int = 30_000) -> int:
         raise web.HTTPBadRequest(text="timeout_ms must be an integer") from exc
 
 
-def _save_wiring_config(path: Path, payload: dict[str, object]) -> None:
+def _save_providers_config(path: Path, payload: dict[str, object]) -> None:
     providers_payload = payload.get("providers", [])
     if not isinstance(providers_payload, list):
         raise web.HTTPBadRequest(text="providers must be a list")
@@ -162,23 +162,25 @@ def _save_wiring_config(path: Path, payload: dict[str, object]) -> None:
     path.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
 
 
-async def _get_wiring_providers(_request: web.Request) -> web.Response:
-    path, config = _read_wiring_config()
+async def _get_providers(_request: web.Request) -> web.Response:
+    path, config = _read_providers_config()
     return web.json_response(_serialize_cognitive_config(config, path))
 
 
-async def _put_wiring_providers(request: web.Request) -> web.Response:
+async def _put_providers(request: web.Request) -> web.Response:
     payload = await request.json()
     if not isinstance(payload, dict):
         raise web.HTTPBadRequest(text="request body must be an object")
 
     path = _resolve_cognitive_config_path()
-    _save_wiring_config(path, payload)
+    _save_providers_config(path, payload)
     config = load_cognitive_config(path)
 
     bridge = request.app.get("bridge")
     if bridge is not None:
-        bridge._configured_provider_count = sum(1 for provider in config.providers if provider.enabled)
+        bridge._configured_provider_count = sum(
+            1 for provider in config.providers if provider.enabled
+        )
 
     return web.json_response(_serialize_cognitive_config(config, path))
 
@@ -253,7 +255,7 @@ async def _verify_wizard_provider(provider: ProviderConfig) -> dict[str, object]
     }
 
 
-async def _post_wiring_verify(request: web.Request) -> web.Response:
+async def _post_providers_verify(request: web.Request) -> web.Response:
     payload = await request.json()
     if not isinstance(payload, dict):
         raise web.HTTPBadRequest(text="request body must be an object")
@@ -261,7 +263,11 @@ async def _post_wiring_verify(request: web.Request) -> web.Response:
     provider = _wizard_provider_payload(payload)
     result = await _verify_wizard_provider(provider)
 
-    message = "Provider verified successfully." if bool(result["available"]) else "Provider verification failed. Confirm credentials, endpoint, and model access."
+    message = (
+        "Provider verified successfully."
+        if bool(result["available"])
+        else "Provider verification failed. Confirm credentials, endpoint, and model access."
+    )
     provider_type = str(payload.get("provider_type", "")).strip()
 
     return web.json_response(
@@ -275,6 +281,17 @@ async def _post_wiring_verify(request: web.Request) -> web.Response:
             "provider": result["provider"],
         }
     )
+
+
+def _legacy_providers_redirect_location(request: web.Request) -> str:
+    location = request.path.replace("/api/wiring/providers", "/api/providers", 1)
+    if request.query_string:
+        return f"{location}?{request.query_string}"
+    return location
+
+
+async def _redirect_legacy_wiring_providers(request: web.Request) -> web.StreamResponse:
+    raise web.HTTPMovedPermanently(location=_legacy_providers_redirect_location(request))
 
 
 def _cleanup_copilot_flows(app: web.Application) -> None:
@@ -349,7 +366,10 @@ async def _post_copilot_complete(request: web.Request) -> web.Response:
             {
                 "authorized": False,
                 "pending": True,
-                "message": "Authorization is still pending. Finish the GitHub step, then check again.",
+                "message": (
+                    "Authorization is still pending. Finish the GitHub step, "
+                    "then check again."
+                ),
             }
         )
     if state == "slow_down":
@@ -362,11 +382,12 @@ async def _post_copilot_complete(request: web.Request) -> web.Response:
             }
         )
     if state != "authorized":
+        error_message = result.get("error_description", result.get("error", "unknown error"))
         return web.json_response(
             {
                 "authorized": False,
                 "pending": False,
-                "message": f"GitHub authorization failed: {result.get('error_description', result.get('error', 'unknown error'))}",
+                "message": f"GitHub authorization failed: {error_message}",
             },
             status=400,
         )
@@ -386,7 +407,11 @@ async def _post_copilot_complete(request: web.Request) -> web.Response:
         {
             "authorized": bool(verified["available"]),
             "pending": False,
-            "message": "Copilot authorization complete." if bool(verified["available"]) else "Copilot token stored, but provider verification failed.",
+            "message": (
+                "Copilot authorization complete."
+                if bool(verified["available"])
+                else "Copilot token stored, but provider verification failed."
+            ),
             "provider": verified["provider"],
             "models": verified["models"],
             "latency_ms": verified["latency_ms"],
@@ -415,11 +440,21 @@ def create_app(
         return web.FileResponse(STATIC_DIR / "index.html")
 
     app.router.add_get("/", index)
-    app.router.add_get("/api/wiring/providers", _get_wiring_providers)
-    app.router.add_post("/api/wiring/providers/copilot/device-code", _post_copilot_device_code)
-    app.router.add_post("/api/wiring/providers/copilot/complete", _post_copilot_complete)
-    app.router.add_post("/api/wiring/providers/verify", _post_wiring_verify)
-    app.router.add_put("/api/wiring/providers", _put_wiring_providers)
+    app.router.add_get("/api/providers", _get_providers)
+    app.router.add_post("/api/providers/copilot/device-code", _post_copilot_device_code)
+    app.router.add_post("/api/providers/copilot/complete", _post_copilot_complete)
+    app.router.add_post("/api/providers/verify", _post_providers_verify)
+    app.router.add_put("/api/providers", _put_providers)
+    # TODO: Remove after v1.0 once external consumers have migrated to /api/providers/*.
+    app.router.add_get("/api/wiring/providers", _redirect_legacy_wiring_providers)
+    app.router.add_post(
+        "/api/wiring/providers/copilot/device-code", _redirect_legacy_wiring_providers
+    )
+    app.router.add_post(
+        "/api/wiring/providers/copilot/complete", _redirect_legacy_wiring_providers
+    )
+    app.router.add_post("/api/wiring/providers/verify", _redirect_legacy_wiring_providers)
+    app.router.add_put("/api/wiring/providers", _redirect_legacy_wiring_providers)
     app.router.add_static("/static", STATIC_DIR)
     return app
 

--- a/src/openbad/wui/static/app.js
+++ b/src/openbad/wui/static/app.js
@@ -34,10 +34,10 @@ const els = {
     lastLatency: document.getElementById('i-last-latency'),
   },
   log: document.getElementById('event-log'),
-  wiring: {
-    configPath: document.getElementById('wiring-config-path'),
-    status: document.getElementById('wiring-status'),
-    enabled: document.getElementById('wiring-enabled'),
+  providers: {
+    configPath: document.getElementById('providers-config-path'),
+    status: document.getElementById('providers-status'),
+    enabled: document.getElementById('providers-enabled'),
     defaultProvider: document.getElementById('default-provider'),
     providerList: document.getElementById('provider-list'),
     addProvider: document.getElementById('add-provider'),
@@ -74,8 +74,8 @@ const viewMeta = {
     title: 'Chat',
     subtitle: 'Operator conversation surface for the next integration step.',
   },
-  wiring: {
-    title: 'Wiring',
+  providers: {
+    title: 'Providers',
     subtitle: 'Verified providers and model access for the runtime.',
   },
   models: {
@@ -144,8 +144,8 @@ function setView(name) {
   els.viewTitle.textContent = viewMeta[name].title;
   els.viewSubtitle.textContent = viewMeta[name].subtitle;
 
-  if (name === 'wiring') {
-    loadWiringConfig();
+  if (name === 'providers') {
+    loadProvidersConfig();
   }
 }
 
@@ -355,24 +355,24 @@ function connectEventStream() {
 }
 
 function renderDefaultProviderOptions(selected) {
-  els.wiring.defaultProvider.innerHTML = '';
+  els.providers.defaultProvider.innerHTML = '';
   if (providerDrafts.length === 0) {
     const option = document.createElement('option');
     option.value = '';
     option.textContent = 'No providers configured';
     option.selected = true;
-    els.wiring.defaultProvider.append(option);
-    els.wiring.defaultProvider.disabled = true;
+    els.providers.defaultProvider.append(option);
+    els.providers.defaultProvider.disabled = true;
     return;
   }
 
-  els.wiring.defaultProvider.disabled = false;
+  els.providers.defaultProvider.disabled = false;
   for (const provider of providerDrafts) {
     const option = document.createElement('option');
     option.value = provider.name;
     option.textContent = providerLabel(provider);
     option.selected = provider.name === selected;
-    els.wiring.defaultProvider.append(option);
+    els.providers.defaultProvider.append(option);
   }
 }
 
@@ -400,7 +400,7 @@ function providerSummaryCard(provider, index) {
 
 function renderProviderList() {
   if (providerDrafts.length === 0) {
-    els.wiring.providerList.innerHTML = `
+    els.providers.providerList.innerHTML = `
       <div class="empty-state">
         <strong>No providers configured</strong>
         <p>Use Add provider to walk through GitHub Copilot or a local OpenAI-compatible llama endpoint.</p>
@@ -409,7 +409,7 @@ function renderProviderList() {
     return;
   }
 
-  els.wiring.providerList.innerHTML = providerDrafts
+  els.providers.providerList.innerHTML = providerDrafts
     .map((provider, index) => providerSummaryCard(provider, index))
     .join('');
 }
@@ -420,32 +420,32 @@ function openWizard(editIndex = null) {
   wizardState.verifiedProvider = null;
   wizardState.verifiedModels = [];
   wizardState.copilotFlow = null;
-  els.wiring.save.disabled = true;
-  els.wiring.modelSelect.disabled = true;
-  els.wiring.modelSelect.innerHTML = '<option value="">Verify provider first</option>';
-  els.wiring.wizard.classList.remove('hidden');
-  els.wiring.copilotAuthPanel.classList.add('hidden');
-  els.wiring.copilotUserCode.textContent = '----';
-  els.wiring.copilotCompleteAuth.disabled = true;
-  els.wiring.copilotOpenGitHub.disabled = true;
-  els.wiring.copilotCopyCode.disabled = true;
-  els.wiring.copilotAuthMessage.textContent = 'No active Copilot authorization yet.';
+  els.providers.save.disabled = true;
+  els.providers.modelSelect.disabled = true;
+  els.providers.modelSelect.innerHTML = '<option value="">Verify provider first</option>';
+  els.providers.wizard.classList.remove('hidden');
+  els.providers.copilotAuthPanel.classList.add('hidden');
+  els.providers.copilotUserCode.textContent = '----';
+  els.providers.copilotCompleteAuth.disabled = true;
+  els.providers.copilotOpenGitHub.disabled = true;
+  els.providers.copilotCopyCode.disabled = true;
+  els.providers.copilotAuthMessage.textContent = 'No active Copilot authorization yet.';
 
   if (editIndex === null) {
-    els.wiring.wizardTitle.textContent = 'Add Provider';
-    els.wiring.wizardType.value = 'github-copilot';
-    els.wiring.baseUrl.value = 'http://127.0.0.1:11434';
-    els.wiring.apiKeyEnv.value = '';
-    els.wiring.timeoutMs.value = '30000';
-    els.wiring.wizardStatus.textContent = 'Choose a provider type to begin the setup walkthrough.';
+    els.providers.wizardTitle.textContent = 'Add Provider';
+    els.providers.wizardType.value = 'github-copilot';
+    els.providers.baseUrl.value = 'http://127.0.0.1:11434';
+    els.providers.apiKeyEnv.value = '';
+    els.providers.timeoutMs.value = '30000';
+    els.providers.wizardStatus.textContent = 'Choose a provider type to begin the setup walkthrough.';
   } else {
     const provider = providerDrafts[editIndex];
-    els.wiring.wizardTitle.textContent = `Configure ${providerLabel(provider)}`;
-    els.wiring.wizardType.value = providerTypeFromDraft(provider);
-    els.wiring.baseUrl.value = provider.base_url || 'http://127.0.0.1:11434';
-    els.wiring.apiKeyEnv.value = provider.api_key_env || '';
-    els.wiring.timeoutMs.value = String(provider.timeout_ms || 30000);
-    els.wiring.wizardStatus.textContent = 'Verify the provider again before saving updated settings.';
+    els.providers.wizardTitle.textContent = `Configure ${providerLabel(provider)}`;
+    els.providers.wizardType.value = providerTypeFromDraft(provider);
+    els.providers.baseUrl.value = provider.base_url || 'http://127.0.0.1:11434';
+    els.providers.apiKeyEnv.value = provider.api_key_env || '';
+    els.providers.timeoutMs.value = String(provider.timeout_ms || 30000);
+    els.providers.wizardStatus.textContent = 'Verify the provider again before saving updated settings.';
   }
 
   applyWizardType();
@@ -457,46 +457,46 @@ function closeWizard() {
   wizardState.verifiedProvider = null;
   wizardState.verifiedModels = [];
   wizardState.copilotFlow = null;
-  els.wiring.wizard.classList.add('hidden');
+  els.providers.wizard.classList.add('hidden');
 }
 
 function applyWizardType() {
-  const type = els.wiring.wizardType.value;
+  const type = els.providers.wizardType.value;
   const local = type === 'local-openai';
-  els.wiring.localFields.classList.toggle('hidden', !local);
-  els.wiring.copilotFields.classList.toggle('hidden', local);
-  els.wiring.verify.classList.toggle('hidden', !local);
+  els.providers.localFields.classList.toggle('hidden', !local);
+  els.providers.copilotFields.classList.toggle('hidden', local);
+  els.providers.verify.classList.toggle('hidden', !local);
 }
 
-async function loadWiringConfig() {
-  els.wiring.status.textContent = 'Loading provider wiring...';
+async function loadProvidersConfig() {
+  els.providers.status.textContent = 'Loading providers...';
   try {
-    const response = await fetch('/api/wiring/providers');
+    const response = await fetch('/api/providers');
     if (!response.ok) {
       throw new Error(`load failed (${response.status})`);
     }
     const data = await response.json();
     providerDrafts = Array.isArray(data.providers) ? data.providers : [];
-    els.wiring.configPath.textContent = data.config_path || 'config path unavailable';
-    els.wiring.enabled.checked = Boolean(data.enabled);
+    els.providers.configPath.textContent = data.config_path || 'config path unavailable';
+    els.providers.enabled.checked = Boolean(data.enabled);
     renderDefaultProviderOptions(data.default_provider || providerDrafts[0]?.name || '');
     renderProviderList();
-    els.wiring.status.textContent = providerDrafts.length > 0
-      ? 'Provider wiring loaded.'
+    els.providers.status.textContent = providerDrafts.length > 0
+      ? 'Providers loaded.'
       : 'No providers configured yet.';
   } catch (error) {
-    els.wiring.status.textContent = `Unable to load provider wiring: ${error.message}`;
+    els.providers.status.textContent = `Unable to load providers: ${error.message}`;
   }
 }
 
-async function persistWiringConfig(statusMessage) {
+async function persistProvidersConfig(statusMessage) {
   const payload = {
-    enabled: els.wiring.enabled.checked,
-    default_provider: els.wiring.defaultProvider.value || '',
+    enabled: els.providers.enabled.checked,
+    default_provider: els.providers.defaultProvider.value || '',
     providers: providerDrafts,
   };
 
-  const response = await fetch('/api/wiring/providers', {
+  const response = await fetch('/api/providers', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -509,36 +509,36 @@ async function persistWiringConfig(statusMessage) {
   providerDrafts = Array.isArray(data.providers) ? data.providers : providerDrafts;
   renderDefaultProviderOptions(data.default_provider || providerDrafts[0]?.name || '');
   if (data.default_provider) {
-    els.wiring.defaultProvider.value = data.default_provider;
+    els.providers.defaultProvider.value = data.default_provider;
   }
   renderProviderList();
-  els.wiring.configPath.textContent = data.config_path || els.wiring.configPath.textContent;
-  els.wiring.status.textContent = statusMessage;
+  els.providers.configPath.textContent = data.config_path || els.providers.configPath.textContent;
+  els.providers.status.textContent = statusMessage;
 }
 
 function verificationPayload() {
   const payload = {
-    provider_type: els.wiring.wizardType.value,
-    timeout_ms: Number(els.wiring.timeoutMs.value || 30000),
+    provider_type: els.providers.wizardType.value,
+    timeout_ms: Number(els.providers.timeoutMs.value || 30000),
   };
 
   if (payload.provider_type === 'local-openai') {
-    payload.base_url = els.wiring.baseUrl.value.trim();
-    payload.api_key_env = els.wiring.apiKeyEnv.value.trim();
+    payload.base_url = els.providers.baseUrl.value.trim();
+    payload.api_key_env = els.providers.apiKeyEnv.value.trim();
   }
 
   return payload;
 }
 
 function populateModelChoices(models, preferredModel = '') {
-  els.wiring.modelSelect.innerHTML = '';
+  els.providers.modelSelect.innerHTML = '';
   const options = models.length > 0 ? models : [preferredModel].filter(Boolean);
   if (options.length === 0) {
     const option = document.createElement('option');
     option.value = '';
     option.textContent = 'No models returned';
-    els.wiring.modelSelect.append(option);
-    els.wiring.modelSelect.disabled = true;
+    els.providers.modelSelect.append(option);
+    els.providers.modelSelect.disabled = true;
     return;
   }
 
@@ -547,20 +547,20 @@ function populateModelChoices(models, preferredModel = '') {
     option.value = model;
     option.textContent = model;
     option.selected = model === preferredModel || (!preferredModel && model === options[0]);
-    els.wiring.modelSelect.append(option);
+    els.providers.modelSelect.append(option);
   }
-  els.wiring.modelSelect.disabled = false;
+  els.providers.modelSelect.disabled = false;
 }
 
 async function verifyWizardProvider() {
-  if (els.wiring.wizardType.value === 'github-copilot') {
-    els.wiring.wizardStatus.textContent = 'Use the Copilot sign-in flow below.';
+  if (els.providers.wizardType.value === 'github-copilot') {
+    els.providers.wizardStatus.textContent = 'Use the Copilot sign-in flow below.';
     return;
   }
-  els.wiring.wizardStatus.textContent = 'Verifying provider access...';
-  els.wiring.save.disabled = true;
+  els.providers.wizardStatus.textContent = 'Verifying provider access...';
+  els.providers.save.disabled = true;
   try {
-    const response = await fetch('/api/wiring/providers/verify', {
+    const response = await fetch('/api/providers/verify', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(verificationPayload()),
@@ -572,54 +572,54 @@ async function verifyWizardProvider() {
     wizardState.verifiedProvider = data.provider;
     wizardState.verifiedModels = Array.isArray(data.models) ? data.models : [];
     populateModelChoices(wizardState.verifiedModels, data.provider.model || '');
-    els.wiring.save.disabled = !data.available;
-    els.wiring.wizardStatus.textContent = data.message;
+    els.providers.save.disabled = !data.available;
+    els.providers.wizardStatus.textContent = data.message;
   } catch (error) {
     wizardState.verifiedProvider = null;
     wizardState.verifiedModels = [];
     populateModelChoices([], '');
-    els.wiring.save.disabled = true;
-    els.wiring.wizardStatus.textContent = `Unable to verify provider: ${error.message}`;
+    els.providers.save.disabled = true;
+    els.providers.wizardStatus.textContent = `Unable to verify provider: ${error.message}`;
   }
 }
 
 async function startCopilotAuthorization() {
-  els.wiring.copilotAuthMessage.textContent = 'Requesting GitHub verification code...';
-  els.wiring.copilotStartAuth.disabled = true;
+  els.providers.copilotAuthMessage.textContent = 'Requesting GitHub verification code...';
+  els.providers.copilotStartAuth.disabled = true;
   try {
-    const response = await fetch('/api/wiring/providers/copilot/device-code', {
+    const response = await fetch('/api/providers/copilot/device-code', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ timeout_ms: Number(els.wiring.timeoutMs.value || 30000) }),
+      body: JSON.stringify({ timeout_ms: Number(els.providers.timeoutMs.value || 30000) }),
     });
     if (!response.ok) {
       throw new Error(`sign-in start failed (${response.status})`);
     }
     const data = await response.json();
     wizardState.copilotFlow = data;
-    els.wiring.copilotAuthPanel.classList.remove('hidden');
-    els.wiring.copilotUserCode.textContent = data.user_code || '----';
-    els.wiring.copilotAuthMessage.textContent = data.message;
-    els.wiring.copilotCompleteAuth.disabled = false;
-    els.wiring.copilotOpenGitHub.disabled = false;
-    els.wiring.copilotCopyCode.disabled = false;
-    els.wiring.wizardStatus.textContent = 'Step 2: open GitHub, enter the code, then return here.';
+    els.providers.copilotAuthPanel.classList.remove('hidden');
+    els.providers.copilotUserCode.textContent = data.user_code || '----';
+    els.providers.copilotAuthMessage.textContent = data.message;
+    els.providers.copilotCompleteAuth.disabled = false;
+    els.providers.copilotOpenGitHub.disabled = false;
+    els.providers.copilotCopyCode.disabled = false;
+    els.providers.wizardStatus.textContent = 'Step 2: open GitHub, enter the code, then return here.';
   } catch (error) {
-    els.wiring.copilotAuthMessage.textContent = `Unable to start Copilot sign-in: ${error.message}`;
+    els.providers.copilotAuthMessage.textContent = `Unable to start Copilot sign-in: ${error.message}`;
   } finally {
-    els.wiring.copilotStartAuth.disabled = false;
+    els.providers.copilotStartAuth.disabled = false;
   }
 }
 
 async function completeCopilotAuthorization() {
   if (!wizardState.copilotFlow) {
-    els.wiring.copilotAuthMessage.textContent = 'Start GitHub sign-in first.';
+    els.providers.copilotAuthMessage.textContent = 'Start GitHub sign-in first.';
     return;
   }
 
-  els.wiring.copilotAuthMessage.textContent = 'Checking GitHub authorization state...';
+  els.providers.copilotAuthMessage.textContent = 'Checking GitHub authorization state...';
   try {
-    const response = await fetch('/api/wiring/providers/copilot/complete', {
+    const response = await fetch('/api/providers/copilot/complete', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ flow_id: wizardState.copilotFlow.flow_id }),
@@ -629,20 +629,20 @@ async function completeCopilotAuthorization() {
       throw new Error(data.message || `authorization check failed (${response.status})`);
     }
     if (data.pending) {
-      els.wiring.copilotAuthMessage.textContent = data.message;
+      els.providers.copilotAuthMessage.textContent = data.message;
       return;
     }
 
     wizardState.verifiedProvider = data.provider;
     wizardState.verifiedModels = Array.isArray(data.models) ? data.models : [];
     populateModelChoices(wizardState.verifiedModels, data.provider.model || '');
-    els.wiring.save.disabled = !data.authorized;
-    els.wiring.copilotAuthMessage.textContent = data.message;
-    els.wiring.wizardStatus.textContent = data.authorized
+    els.providers.save.disabled = !data.authorized;
+    els.providers.copilotAuthMessage.textContent = data.message;
+    els.providers.wizardStatus.textContent = data.authorized
       ? 'Copilot verified. Select a model and save the provider.'
       : data.message;
   } catch (error) {
-    els.wiring.copilotAuthMessage.textContent = `Unable to complete Copilot sign-in: ${error.message}`;
+    els.providers.copilotAuthMessage.textContent = `Unable to complete Copilot sign-in: ${error.message}`;
   }
 }
 
@@ -652,9 +652,9 @@ async function copyCopilotCode() {
   }
   try {
     await navigator.clipboard.writeText(wizardState.copilotFlow.user_code);
-    els.wiring.copilotAuthMessage.textContent = 'Verification code copied to clipboard.';
+    els.providers.copilotAuthMessage.textContent = 'Verification code copied to clipboard.';
   } catch {
-    els.wiring.copilotAuthMessage.textContent = 'Clipboard copy failed. Copy the code manually.';
+    els.providers.copilotAuthMessage.textContent = 'Clipboard copy failed. Copy the code manually.';
   }
 }
 
@@ -669,13 +669,13 @@ function openCopilotVerification() {
 async function saveWizardProvider(event) {
   event.preventDefault();
   if (!wizardState.verifiedProvider) {
-    els.wiring.wizardStatus.textContent = 'Verify the provider before saving it.';
+    els.providers.wizardStatus.textContent = 'Verify the provider before saving it.';
     return;
   }
 
   const provider = {
     ...wizardState.verifiedProvider,
-    model: els.wiring.modelSelect.value || wizardState.verifiedProvider.model,
+    model: els.providers.modelSelect.value || wizardState.verifiedProvider.model,
     enabled: true,
   };
 
@@ -685,39 +685,39 @@ async function saveWizardProvider(event) {
     providerDrafts[wizardState.editIndex] = provider;
   }
 
-  if (!els.wiring.defaultProvider.value) {
-    els.wiring.defaultProvider.value = provider.name;
+  if (!els.providers.defaultProvider.value) {
+    els.providers.defaultProvider.value = provider.name;
   }
 
-  if (wizardState.editIndex !== null && els.wiring.defaultProvider.value === '') {
-    els.wiring.defaultProvider.value = provider.name;
+  if (wizardState.editIndex !== null && els.providers.defaultProvider.value === '') {
+    els.providers.defaultProvider.value = provider.name;
   }
 
-  renderDefaultProviderOptions(els.wiring.defaultProvider.value || provider.name);
-  if (!els.wiring.defaultProvider.value) {
-    els.wiring.defaultProvider.value = provider.name;
+  renderDefaultProviderOptions(els.providers.defaultProvider.value || provider.name);
+  if (!els.providers.defaultProvider.value) {
+    els.providers.defaultProvider.value = provider.name;
   }
 
   try {
-    await persistWiringConfig(`${providerLabel(provider)} saved.`);
+    await persistProvidersConfig(`${providerLabel(provider)} saved.`);
     logLine(`[${new Date().toISOString()}] provider saved: ${providerLabel(provider)}`);
     closeWizard();
   } catch (error) {
-    els.wiring.wizardStatus.textContent = `Unable to save provider: ${error.message}`;
+    els.providers.wizardStatus.textContent = `Unable to save provider: ${error.message}`;
   }
 }
 
 async function removeProvider(index) {
   const [removed] = providerDrafts.splice(index, 1);
-  const currentDefault = els.wiring.defaultProvider.value;
+  const currentDefault = els.providers.defaultProvider.value;
   if (currentDefault === removed.name) {
     renderDefaultProviderOptions(providerDrafts[0]?.name || '');
   }
 
   try {
-    await persistWiringConfig(`${providerLabel(removed)} removed.`);
+    await persistProvidersConfig(`${providerLabel(removed)} removed.`);
   } catch (error) {
-    els.wiring.status.textContent = `Unable to remove provider: ${error.message}`;
+    els.providers.status.textContent = `Unable to remove provider: ${error.message}`;
   }
 }
 
@@ -726,41 +726,41 @@ function bindEvents() {
     link.addEventListener('click', () => setView(link.dataset.viewTarget));
   }
 
-  els.wiring.addProvider.addEventListener('click', () => openWizard(null));
-  els.wiring.closeWizard.addEventListener('click', closeWizard);
-  els.wiring.wizardType.addEventListener('change', () => {
+  els.providers.addProvider.addEventListener('click', () => openWizard(null));
+  els.providers.closeWizard.addEventListener('click', closeWizard);
+  els.providers.wizardType.addEventListener('change', () => {
     wizardState.verifiedProvider = null;
     wizardState.copilotFlow = null;
     applyWizardType();
-    els.wiring.save.disabled = true;
+    els.providers.save.disabled = true;
     populateModelChoices([], '');
-    els.wiring.copilotAuthPanel.classList.add('hidden');
-    els.wiring.copilotCompleteAuth.disabled = true;
-    els.wiring.copilotOpenGitHub.disabled = true;
-    els.wiring.copilotCopyCode.disabled = true;
+    els.providers.copilotAuthPanel.classList.add('hidden');
+    els.providers.copilotCompleteAuth.disabled = true;
+    els.providers.copilotOpenGitHub.disabled = true;
+    els.providers.copilotCopyCode.disabled = true;
   });
-  els.wiring.verify.addEventListener('click', verifyWizardProvider);
-  els.wiring.copilotStartAuth.addEventListener('click', startCopilotAuthorization);
-  els.wiring.copilotCompleteAuth.addEventListener('click', completeCopilotAuthorization);
-  els.wiring.copilotCopyCode.addEventListener('click', copyCopilotCode);
-  els.wiring.copilotOpenGitHub.addEventListener('click', openCopilotVerification);
-  els.wiring.wizardForm.addEventListener('submit', saveWizardProvider);
-  els.wiring.enabled.addEventListener('change', async () => {
+  els.providers.verify.addEventListener('click', verifyWizardProvider);
+  els.providers.copilotStartAuth.addEventListener('click', startCopilotAuthorization);
+  els.providers.copilotCompleteAuth.addEventListener('click', completeCopilotAuthorization);
+  els.providers.copilotCopyCode.addEventListener('click', copyCopilotCode);
+  els.providers.copilotOpenGitHub.addEventListener('click', openCopilotVerification);
+  els.providers.wizardForm.addEventListener('submit', saveWizardProvider);
+  els.providers.enabled.addEventListener('change', async () => {
     try {
-      await persistWiringConfig('Cognitive engine setting updated.');
+      await persistProvidersConfig('Cognitive engine setting updated.');
     } catch (error) {
-      els.wiring.status.textContent = `Unable to update wiring: ${error.message}`;
+      els.providers.status.textContent = `Unable to update providers: ${error.message}`;
     }
   });
-  els.wiring.defaultProvider.addEventListener('change', async () => {
+  els.providers.defaultProvider.addEventListener('change', async () => {
     try {
-      await persistWiringConfig('Default provider updated.');
+      await persistProvidersConfig('Default provider updated.');
     } catch (error) {
-      els.wiring.status.textContent = `Unable to update default provider: ${error.message}`;
+      els.providers.status.textContent = `Unable to update default provider: ${error.message}`;
     }
   });
 
-  els.wiring.providerList.addEventListener('click', (event) => {
+  els.providers.providerList.addEventListener('click', (event) => {
     const configure = event.target.closest('[data-configure-provider]');
     if (configure) {
       openWizard(Number(configure.dataset.configureProvider));

--- a/src/openbad/wui/static/index.html
+++ b/src/openbad/wui/static/index.html
@@ -21,7 +21,7 @@
       <nav class="nav-links" aria-label="Primary navigation">
         <button type="button" class="nav-link active" data-view-target="health">Health</button>
         <button type="button" class="nav-link" data-view-target="chat">Chat</button>
-        <button type="button" class="nav-link" data-view-target="wiring">Wiring</button>
+        <button type="button" class="nav-link" data-view-target="providers">Providers</button>
         <button type="button" class="nav-link" data-view-target="models">Models <span class="nav-chip">next</span></button>
       </nav>
       <div class="nav-status">
@@ -68,7 +68,7 @@
             </div>
           </article>
 
-          <article class="card section-card wiring-controls-card">
+          <article class="card section-card providers-controls-card">
             <div class="section-head">
               <h3>Hormonal State</h3>
               <span class="section-note">Live endocrine levels</span>
@@ -140,8 +140,8 @@
               <span class="section-note">Operator conversation surface</span>
             </div>
             <div class="chat-thread">
-              <div class="chat-bubble system">Chat surface is staged. Health and wiring are live now; model interaction hooks come next.</div>
-              <div class="chat-bubble user">Use the left rail to move between runtime health and provider wiring.</div>
+              <div class="chat-bubble system">Chat surface is staged. Health and provider controls are live now; model interaction hooks come next.</div>
+              <div class="chat-bubble user">Use the left rail to move between runtime health and providers.</div>
             </div>
             <form class="chat-composer" id="chat-form">
               <label class="sr-only" for="chat-input">Chat input</label>
@@ -152,26 +152,26 @@
         </div>
       </section>
 
-      <section id="view-wiring" class="view-panel reveal hidden" data-view="wiring">
-        <div class="panel-grid wiring-layout">
-          <article class="card section-card wiring-controls-card">
+      <section id="view-providers" class="view-panel reveal hidden" data-view="providers">
+        <div class="panel-grid providers-layout">
+          <article class="card section-card providers-controls-card">
             <div class="section-head">
-              <h3>Provider Wiring</h3>
-              <span id="wiring-config-path" class="section-note mono">Loading config...</span>
+              <h3>Providers</h3>
+              <span id="providers-config-path" class="section-note mono">Loading config...</span>
             </div>
-            <div class="wiring-toolbar">
+            <div class="providers-toolbar">
               <label for="default-provider">Default provider</label>
               <select id="default-provider"></select>
               <label class="toggle-row">
-                <input id="wiring-enabled" type="checkbox" checked>
+                <input id="providers-enabled" type="checkbox" checked>
                 <span>Cognitive engine enabled</span>
               </label>
               <button id="add-provider" type="button" class="secondary-button">Add provider</button>
             </div>
-            <p id="wiring-status" class="inline-status">Provider wiring has not been loaded yet.</p>
+            <p id="providers-status" class="inline-status">Providers have not been loaded yet.</p>
           </article>
 
-          <article class="card section-card wiring-providers-card">
+          <article class="card section-card providers-providers-card">
             <div class="section-head">
               <h3>Providers</h3>
               <span class="section-note">Verified providers available to the runtime</span>
@@ -257,7 +257,7 @@
               <h3>Model Surface</h3>
               <span class="section-note">Reserved for the next pass</span>
             </div>
-            <p>This slot is reserved for the dedicated model surface. Health, chat navigation, and wiring are in place now.</p>
+            <p>This slot is reserved for the dedicated model surface. Health, chat navigation, and providers are in place now.</p>
           </article>
         </div>
       </section>

--- a/src/openbad/wui/static/styles.css
+++ b/src/openbad/wui/static/styles.css
@@ -384,7 +384,7 @@ textarea {
 
 .chat-composer textarea,
 .provider-fields input,
-.wiring-toolbar select {
+.providers-toolbar select {
   width: 100%;
   border: 1px solid var(--stroke);
   border-radius: 16px;
@@ -429,11 +429,11 @@ textarea {
   font-size: 0.84rem;
 }
 
-.wiring-controls-card {
+.providers-controls-card {
   grid-column: span 4;
 }
 
-.wiring-providers-card {
+.providers-providers-card {
   grid-column: span 8;
   min-width: 0;
 }
@@ -443,7 +443,7 @@ textarea {
   background: linear-gradient(135deg, rgba(255, 184, 77, 0.1), rgba(119, 225, 212, 0.08));
 }
 
-.wiring-toolbar {
+.providers-toolbar {
   display: grid;
   gap: 0.7rem;
 }
@@ -661,8 +661,8 @@ textarea {
   #view-health .section-card:nth-child(3),
   .event-card,
   .wizard-card,
-  .wiring-controls-card,
-  .wiring-providers-card {
+  .providers-controls-card,
+  .providers-providers-card {
     grid-column: 1 / -1;
   }
 }

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -94,7 +94,7 @@ class TestDaemonStartStop:
 
 
 class TestDaemonSubsystems:
-    """Subsystem wiring."""
+    """Subsystem provider composition."""
 
     @pytest.fixture
     def mock_client(self):

--- a/tests/test_wui_anatomy.py
+++ b/tests/test_wui_anatomy.py
@@ -10,21 +10,21 @@ def test_index_contains_left_nav_shell():
     assert "side-nav" in html
     assert 'data-view-target="health"' in html
     assert 'data-view-target="chat"' in html
-    assert 'data-view-target="wiring"' in html
+    assert 'data-view-target="providers"' in html
     assert 'data-view-target="models"' in html
 
 
-def test_js_contains_view_and_wiring_logic():
+def test_js_contains_view_and_provider_logic():
     js = (STATIC_DIR / "app.js").read_text(encoding="utf-8")
     assert "function setView" in js
-    assert "loadWiringConfig" in js
+    assert "loadProvidersConfig" in js
     assert "verifyWizardProvider" in js
     assert "saveWizardProvider" in js
-    assert "/api/wiring/providers" in js
-    assert "/api/wiring/providers/verify" in js
+    assert "/api/providers" in js
+    assert "/api/providers/verify" in js
 
 
-def test_css_contains_nav_and_wiring_styles():
+def test_css_contains_nav_and_provider_styles():
     css = (STATIC_DIR / "styles.css").read_text(encoding="utf-8")
     assert ".side-nav" in css
     assert ".provider-card" in css
@@ -34,7 +34,7 @@ def test_css_contains_nav_and_wiring_styles():
 def test_index_uses_neutral_health_placeholder():
     html = (STATIC_DIR / "index.html").read_text(encoding="utf-8")
     assert 'id="i-health">--<' in html
-    assert 'id="wiring-config-path"' in html
+    assert 'id="providers-config-path"' in html
     assert 'id="provider-wizard"' in html
     assert 'id="copilot-user-code"' in html
     assert 'id="copilot-start-auth"' in html

--- a/tests/test_wui_server.py
+++ b/tests/test_wui_server.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-import pytest
-import yaml
 from unittest.mock import AsyncMock, patch
 
-from openbad.wui.server import STATIC_DIR, create_app
+import pytest
+import yaml
+
 from openbad.cognitive.providers.github_copilot import GitHubCopilotProvider
+from openbad.wui.server import STATIC_DIR, create_app
 
 
 def test_static_assets_exist():
@@ -25,7 +26,7 @@ async def test_index_route(aiohttp_client):
     html = await resp.text()
     assert "OpenBaD Control Surface" in html
     assert "/static/app.js" in html
-    assert "Provider Wiring" in html
+    assert "Providers" in html
 
 
 @pytest.mark.asyncio
@@ -67,7 +68,7 @@ def test_create_app_attaches_bridge():
 
 
 @pytest.mark.asyncio
-async def test_get_wiring_providers_route(aiohttp_client, tmp_path, monkeypatch):
+async def test_get_providers_route(aiohttp_client, tmp_path, monkeypatch):
     config_dir = tmp_path / "openbad"
     config_dir.mkdir()
     config_path = config_dir / "cognitive.yaml"
@@ -88,7 +89,7 @@ cognitive:
 
     app = create_app(enable_mqtt=False)
     client = await aiohttp_client(app)
-    resp = await client.get("/api/wiring/providers")
+    resp = await client.get("/api/providers")
 
     assert resp.status == 200
     data = await resp.json()
@@ -98,7 +99,7 @@ cognitive:
 
 
 @pytest.mark.asyncio
-async def test_put_wiring_providers_route(aiohttp_client, tmp_path, monkeypatch):
+async def test_put_providers_route(aiohttp_client, tmp_path, monkeypatch):
     config_dir = tmp_path / "openbad"
     config_dir.mkdir()
     monkeypatch.setenv("OPENBAD_CONFIG_DIR", str(config_dir))
@@ -120,7 +121,7 @@ async def test_put_wiring_providers_route(aiohttp_client, tmp_path, monkeypatch)
         ],
     }
 
-    resp = await client.put("/api/wiring/providers", json=payload)
+    resp = await client.put("/api/providers", json=payload)
 
     assert resp.status == 200
     data = await resp.json()
@@ -138,12 +139,19 @@ async def test_verify_copilot_provider_route(aiohttp_client):
     with patch("openbad.wui.server.GitHubCopilotProvider") as provider_cls:
         provider = provider_cls.return_value
         provider.health_check = AsyncMock(
-            return_value=type("Status", (), {"available": True, "latency_ms": 12.0, "models_available": 4})()
+            return_value=type(
+                "Status",
+                (),
+                {"available": True, "latency_ms": 12.0, "models_available": 4},
+            )()
         )
         provider.list_models = AsyncMock(
-            return_value=[type("Model", (), {"model_id": "gpt-4o"})(), type("Model", (), {"model_id": "claude-sonnet-4-20250514"})()]
+            return_value=[
+                type("Model", (), {"model_id": "gpt-4o"})(),
+                type("Model", (), {"model_id": "claude-sonnet-4-20250514"})(),
+            ]
         )
-        resp = await client.post("/api/wiring/providers/verify", json={"provider_type": "github-copilot"})
+        resp = await client.post("/api/providers/verify", json={"provider_type": "github-copilot"})
 
     assert resp.status == 200
     data = await resp.json()
@@ -172,7 +180,7 @@ async def test_start_copilot_device_flow_route(aiohttp_client):
                 },
             )()
         )
-        resp = await client.post("/api/wiring/providers/copilot/device-code", json={"timeout_ms": 30000})
+        resp = await client.post("/api/providers/copilot/device-code", json={"timeout_ms": 30000})
 
     assert resp.status == 200
     data = await resp.json()
@@ -195,14 +203,23 @@ async def test_complete_copilot_device_flow_route(aiohttp_client):
 
     with patch("openbad.wui.server.GitHubCopilotProvider") as provider_cls:
         provider = provider_cls.return_value
-        provider.poll_for_token_once = AsyncMock(return_value={"state": "authorized", "access_token": "token"})
+        provider.poll_for_token_once = AsyncMock(
+            return_value={"state": "authorized", "access_token": "token"}
+        )
         provider.health_check = AsyncMock(
-            return_value=type("Status", (), {"available": True, "latency_ms": 12.0, "models_available": 2})()
+            return_value=type(
+                "Status",
+                (),
+                {"available": True, "latency_ms": 12.0, "models_available": 2},
+            )()
         )
         provider.list_models = AsyncMock(
-            return_value=[type("Model", (), {"model_id": "gpt-4o"})(), type("Model", (), {"model_id": "claude-sonnet-4-20250514"})()]
+            return_value=[
+                type("Model", (), {"model_id": "gpt-4o"})(),
+                type("Model", (), {"model_id": "claude-sonnet-4-20250514"})(),
+            ]
         )
-        resp = await client.post("/api/wiring/providers/copilot/complete", json={"flow_id": "flow-1"})
+        resp = await client.post("/api/providers/copilot/complete", json={"flow_id": "flow-1"})
 
     assert resp.status == 200
     data = await resp.json()
@@ -219,13 +236,17 @@ async def test_verify_local_provider_route(aiohttp_client):
     with patch("openbad.wui.server.custom_provider") as provider_factory:
         provider = provider_factory.return_value
         provider.health_check = AsyncMock(
-            return_value=type("Status", (), {"available": True, "latency_ms": 7.5, "models_available": 1})()
+            return_value=type(
+                "Status",
+                (),
+                {"available": True, "latency_ms": 7.5, "models_available": 1},
+            )()
         )
         provider.list_models = AsyncMock(
             return_value=[type("Model", (), {"model_id": "bonsai-8b"})()]
         )
         resp = await client.post(
-            "/api/wiring/providers/verify",
+            "/api/providers/verify",
             json={
                 "provider_type": "local-openai",
                 "base_url": "http://127.0.0.1:11434",
@@ -239,6 +260,52 @@ async def test_verify_local_provider_route(aiohttp_client):
     assert data["available"] is True
     assert data["provider"]["name"] == "custom"
     assert data["models"] == ["bonsai-8b"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path", "payload", "location"),
+    [
+        ("get", "/api/wiring/providers", None, "/api/providers"),
+        (
+            "put",
+            "/api/wiring/providers",
+            {"enabled": True, "default_provider": "", "providers": []},
+            "/api/providers",
+        ),
+        (
+            "post",
+            "/api/wiring/providers/verify",
+            {"provider_type": "github-copilot"},
+            "/api/providers/verify",
+        ),
+        (
+            "post",
+            "/api/wiring/providers/copilot/device-code",
+            {"timeout_ms": 30000},
+            "/api/providers/copilot/device-code",
+        ),
+        (
+            "post",
+            "/api/wiring/providers/copilot/complete",
+            {"flow_id": "flow-1"},
+            "/api/providers/copilot/complete",
+        ),
+    ],
+)
+async def test_legacy_wiring_routes_redirect(aiohttp_client, method, path, payload, location):
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    request = getattr(client, method)
+    kwargs = {"allow_redirects": False}
+    if payload is not None:
+        kwargs["json"] = payload
+
+    resp = await request(path, **kwargs)
+
+    assert resp.status == 301
+    assert resp.headers["Location"] == location
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #201

Summary of changes
- Rename the WUI server routes and handlers from wiring to providers
- Update the legacy static WUI navigation, copy, DOM ids, JS state, and CSS classes to use providers terminology
- Add 301 redirect shims for the old /api/wiring/* endpoints and cover them with tests

How to test
- .venv/bin/ruff check src/openbad/wui/server.py tests/test_wui_server.py tests/test_wui_anatomy.py tests/test_daemon.py
- .venv/bin/pytest tests/test_wui_server.py tests/test_wui_anatomy.py tests/test_daemon.py