### PR TITLE
#202: Add cognitive system provider fallbacks

### DIFF
--- a/config/cognitive.yaml
+++ b/config/cognitive.yaml
@@ -2,6 +2,33 @@ cognitive:
   enabled: true
   default_provider: ""
   providers: []
+  # Assigned provider/model per cognitive system.
+  systems:
+    chat:
+      provider: ollama
+      model: llama3.2
+    reasoning:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+    reactions:
+      provider: ollama
+      model: llama3.2
+    sleep:
+      provider: ollama
+      model: llama3.2
+  # Shared fallback chain used when the assigned system provider is unavailable.
+  default_fallback_chain:
+    - provider: ollama
+      model: llama3.2
+    - provider: openai
+      model: gpt-4o-mini
+  fallback_cortisol:
+    release_per_step: 0.1
+    escalation_after: 5
+  # Intrinsic systems do not route through external model assignments:
+  # - Instincts / FSM
+  # - Memory (Valkey + Chroma)
+  # - Immune / Interceptor
   context_budget:
     slm_max_tokens: 8192
     llm_max_tokens: 32768

--- a/config/cognitive.yaml
+++ b/config/cognitive.yaml
@@ -5,23 +5,23 @@ cognitive:
   # Assigned provider/model per cognitive system.
   systems:
     chat:
-      provider: ollama
-      model: llama3.2
+      provider: anthropic
+      model: claude-sonnet-4
     reasoning:
       provider: anthropic
-      model: claude-sonnet-4-20250514
+      model: claude-opus-4
     reactions:
       provider: ollama
-      model: llama3.2
+      model: bonsai-8b
     sleep:
       provider: ollama
-      model: llama3.2
+      model: bonsai-8b
   # Shared fallback chain used when the assigned system provider is unavailable.
   default_fallback_chain:
     - provider: ollama
+      model: bonsai-8b
+    - provider: ollama
       model: llama3.2
-    - provider: openai
-      model: gpt-4o-mini
   fallback_cortisol:
     release_per_step: 0.1
     escalation_after: 5

--- a/src/openbad/cognitive/config.py
+++ b/src/openbad/cognitive/config.py
@@ -3,9 +3,35 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 
 import yaml
+
+
+class CognitiveSystem(StrEnum):
+    """Named cognitive systems that receive explicit provider assignments."""
+
+    CHAT = "chat"
+    SLEEP = "sleep"
+    REASONING = "reasoning"
+    REACTIONS = "reactions"
+
+
+@dataclass(frozen=True)
+class SystemAssignment:
+    """Provider/model pair assigned to a cognitive system."""
+
+    provider: str = ""
+    model: str = ""
+
+
+@dataclass(frozen=True)
+class FallbackCortisolConfig:
+    """Fallback stress-release and escalation thresholds."""
+
+    release_per_step: float = 0.1
+    escalation_after: int = 5
 
 
 @dataclass(frozen=True)
@@ -54,6 +80,15 @@ class CognitiveConfig:
     )
     default_provider: str = "ollama"
     enabled: bool = True
+    systems: dict[CognitiveSystem, SystemAssignment] = field(
+        default_factory=lambda: {
+            system: SystemAssignment() for system in CognitiveSystem
+        }
+    )
+    default_fallback_chain: tuple[SystemAssignment, ...] = field(default_factory=tuple)
+    fallback_cortisol: FallbackCortisolConfig = field(
+        default_factory=FallbackCortisolConfig
+    )
 
 
 def load_cognitive_config(
@@ -80,10 +115,42 @@ def load_cognitive_config(
         ReasoningDefaults(**reasoning_data) if reasoning_data else ReasoningDefaults()
     )
 
+    systems = {system: SystemAssignment() for system in CognitiveSystem}
+    for system_name, assignment in cog.get("systems", {}).items():
+        try:
+            system = CognitiveSystem(str(system_name).strip().lower())
+        except ValueError:
+            continue
+        if not isinstance(assignment, dict):
+            continue
+        systems[system] = SystemAssignment(
+            provider=str(assignment.get("provider", "")).strip(),
+            model=str(assignment.get("model", "")).strip(),
+        )
+
+    fallback_chain = tuple(
+        SystemAssignment(
+            provider=str(step.get("provider", "")).strip(),
+            model=str(step.get("model", "")).strip(),
+        )
+        for step in cog.get("default_fallback_chain", [])
+        if isinstance(step, dict)
+    )
+
+    fallback_cortisol_data = cog.get("fallback_cortisol", {})
+    fallback_cortisol = (
+        FallbackCortisolConfig(**fallback_cortisol_data)
+        if fallback_cortisol_data
+        else FallbackCortisolConfig()
+    )
+
     return CognitiveConfig(
         providers=providers,
         context_budget=budget,
         reasoning=reasoning,
         default_provider=cog.get("default_provider", "ollama"),
         enabled=cog.get("enabled", True),
+        systems=systems,
+        default_fallback_chain=fallback_chain,
+        fallback_cortisol=fallback_cortisol,
     )

--- a/src/openbad/cognitive/model_router.py
+++ b/src/openbad/cognitive/model_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from dataclasses import dataclass
 from enum import IntEnum
@@ -9,6 +10,7 @@ from typing import Any
 
 import yaml
 
+from openbad.cognitive.config import CognitiveSystem
 from openbad.cognitive.providers.base import ProviderAdapter
 from openbad.cognitive.providers.registry import ProviderRegistry
 
@@ -51,9 +53,12 @@ class RoutingDecision:
     provider: str
     model_id: str
     fallback_index: int
+    system: str = ""
     cortisol_downgrade: bool = False
     budget_exhausted: bool = False
     latency_ms: float = 0.0
+    fallback_count: int = 0
+    consecutive_fallback_count: int = 0
 
 
 @dataclass
@@ -64,6 +69,15 @@ class ProviderHealth:
     last_check: float = 0.0
     avg_latency_ms: float = 0.0
     failure_count: int = 0
+
+
+@dataclass
+class FallbackTelemetry:
+    """Observable counters for provider fallback activity."""
+
+    fallback_count: int = 0
+    consecutive_fallback_count: int = 0
+    last_fallback_time: float = 0.0
 
 
 class ModelRouter:
@@ -87,18 +101,31 @@ class ModelRouter:
         self,
         registry: ProviderRegistry,
         chains: dict[Priority, FallbackChain] | None = None,
+        system_assignments: dict[CognitiveSystem, RouteStep] | None = None,
+        default_fallback_chain: FallbackChain | None = None,
         cortisol_threshold: float = 0.8,
         budget_limit: float = 0,
         health_ttl_s: float = 60,
+        endocrine_controller: Any = None,
+        escalation_gateway: Any = None,
+        fallback_release_per_step: float = 0.1,
+        fallback_escalation_after: int = 5,
     ) -> None:
         self._registry = registry
         self._chains = chains or _default_chains()
+        self._system_assignments = system_assignments or {}
+        self._default_fallback_chain = default_fallback_chain or FallbackChain(steps=())
         self._cortisol_threshold = cortisol_threshold
         self._budget_limit = budget_limit
         self._health_ttl_s = health_ttl_s
+        self._endocrine_controller = endocrine_controller
+        self._escalation_gateway = escalation_gateway
+        self._fallback_release_per_step = fallback_release_per_step
+        self._fallback_escalation_after = fallback_escalation_after
         self._health: dict[str, ProviderHealth] = {}
         self._spend: float = 0.0
         self._latencies: dict[str, list[float]] = {}
+        self._fallback_telemetry = FallbackTelemetry()
 
     # ------------------------------------------------------------------ #
     # Public API
@@ -107,6 +134,8 @@ class ModelRouter:
     async def route(
         self,
         priority: Priority,
+        *,
+        system: CognitiveSystem | None = None,
         cortisol: float = 0.0,
     ) -> tuple[ProviderAdapter, str, RoutingDecision]:
         """Select the best provider/model for the given priority.
@@ -114,6 +143,9 @@ class ModelRouter:
         Returns (adapter, model_id, decision).
         Raises ``RuntimeError`` if no provider is available.
         """
+        if system is not None:
+            return await self._route_for_system(system, priority, cortisol)
+
         effective_priority = priority
         cortisol_downgrade = False
         budget_exhausted = self._is_budget_exhausted()
@@ -141,6 +173,10 @@ class ModelRouter:
                 fallback_index=idx,
                 cortisol_downgrade=cortisol_downgrade,
                 budget_exhausted=budget_exhausted,
+            )
+            self._record_fallback_outcome(
+                decision,
+                assigned_step=chain.steps[0] if len(chain) > 0 else None,
             )
             return adapter, step.model_id, decision
 
@@ -177,12 +213,118 @@ class ModelRouter:
         obs = self._latencies.get(provider, [])
         return sum(obs) / len(obs) if obs else 0.0
 
+    def get_fallback_telemetry(self) -> FallbackTelemetry:
+        """Return the current fallback telemetry snapshot."""
+        return FallbackTelemetry(
+            fallback_count=self._fallback_telemetry.fallback_count,
+            consecutive_fallback_count=self._fallback_telemetry.consecutive_fallback_count,
+            last_fallback_time=self._fallback_telemetry.last_fallback_time,
+        )
+
     # ------------------------------------------------------------------ #
     # Internals
     # ------------------------------------------------------------------ #
 
     def _is_budget_exhausted(self) -> bool:
         return self._budget_limit > 0 and self._spend >= self._budget_limit
+
+    async def _route_for_system(
+        self,
+        system: CognitiveSystem,
+        priority: Priority,
+        cortisol: float,
+    ) -> tuple[ProviderAdapter, str, RoutingDecision]:
+        assigned_step = self._system_assignments.get(system)
+        if assigned_step is None:
+            msg = f"No provider assignment configured for system {system.value}"
+            raise RuntimeError(msg)
+
+        candidates = [assigned_step]
+        for step in self._default_fallback_chain:
+            if step == assigned_step:
+                continue
+            candidates.append(step)
+
+        for idx, step in enumerate(candidates):
+            adapter = self._registry.get(step.provider)
+            if adapter is None:
+                continue
+            if not await self._is_healthy(step.provider, adapter):
+                continue
+
+            decision = RoutingDecision(
+                priority=priority,
+                provider=step.provider,
+                model_id=step.model_id,
+                fallback_index=idx,
+                system=system.value,
+                cortisol_downgrade=idx > 0 and cortisol > self._cortisol_threshold,
+            )
+            self._record_fallback_outcome(decision, assigned_step=assigned_step)
+            return adapter, step.model_id, decision
+
+        msg = f"No available provider for system {system.value}"
+        raise RuntimeError(msg)
+
+    def _record_fallback_outcome(
+        self,
+        decision: RoutingDecision,
+        *,
+        assigned_step: RouteStep | None,
+    ) -> None:
+        if decision.fallback_index <= 0:
+            self._fallback_telemetry.consecutive_fallback_count = 0
+            decision.fallback_count = self._fallback_telemetry.fallback_count
+            decision.consecutive_fallback_count = 0
+            return
+
+        self._fallback_telemetry.fallback_count += 1
+        self._fallback_telemetry.consecutive_fallback_count += 1
+        self._fallback_telemetry.last_fallback_time = time.time()
+        decision.fallback_count = self._fallback_telemetry.fallback_count
+        decision.consecutive_fallback_count = (
+            self._fallback_telemetry.consecutive_fallback_count
+        )
+
+        if self._endocrine_controller is not None and self._fallback_release_per_step > 0:
+            self._endocrine_controller.trigger(
+                "cortisol",
+                self._fallback_release_per_step * decision.fallback_index,
+            )
+
+        should_escalate = (
+            self._escalation_gateway is not None
+            and self._fallback_escalation_after > 0
+            and self._fallback_telemetry.consecutive_fallback_count
+            == self._fallback_escalation_after
+        )
+        if should_escalate:
+            assigned_provider = assigned_step.provider if assigned_step else ""
+            assigned_model = assigned_step.model_id if assigned_step else ""
+            payload = json.dumps(
+                {
+                    "system": decision.system,
+                    "assigned_provider": assigned_provider,
+                    "assigned_model": assigned_model,
+                    "fallback_provider": decision.provider,
+                    "fallback_model": decision.model_id,
+                    "fallback_count": self._fallback_telemetry.fallback_count,
+                    "consecutive_fallback_count": (
+                        self._fallback_telemetry.consecutive_fallback_count
+                    ),
+                }
+            ).encode()
+            self._escalation_gateway.escalate(
+                event_topic="agent/cognitive/provider-fallback",
+                event_payload=payload,
+                reason=(
+                    "Consecutive provider fallbacks exceeded threshold: "
+                    f"{self._fallback_telemetry.consecutive_fallback_count}"
+                ),
+                reflex_id="model_router",
+                current_state=decision.system,
+                priority=int(decision.priority),
+            )
 
     async def _is_healthy(self, name: str, adapter: ProviderAdapter) -> bool:
         h = self._health.get(name)

--- a/tests/test_cognitive_scaffold.py
+++ b/tests/test_cognitive_scaffold.py
@@ -8,9 +8,12 @@ import pytest
 
 from openbad.cognitive.config import (
     CognitiveConfig,
+    CognitiveSystem,
     ContextBudgetConfig,
+    FallbackCortisolConfig,
     ProviderConfig,
     ReasoningDefaults,
+    SystemAssignment,
     load_cognitive_config,
 )
 from openbad.nervous_system import topics
@@ -56,6 +59,8 @@ class TestCognitiveConfig:
         assert cc.default_provider == "ollama"
         assert cc.enabled is True
         assert cc.providers == []
+        assert cc.systems[CognitiveSystem.CHAT] == SystemAssignment()
+        assert cc.fallback_cortisol == FallbackCortisolConfig()
 
     def test_frozen(self) -> None:
         cc = CognitiveConfig()
@@ -86,6 +91,21 @@ class TestLoadCognitiveConfig:
                   model: "llama3.2"
                   timeout_ms: 5000
                   enabled: true
+              systems:
+                chat:
+                  provider: openai
+                  model: gpt-4o-mini
+                reasoning:
+                  provider: anthropic
+                  model: claude-sonnet-4-20250514
+              default_fallback_chain:
+                - provider: ollama
+                  model: llama3.2
+                - provider: openai
+                  model: gpt-4o-mini
+              fallback_cortisol:
+                release_per_step: 0.25
+                escalation_after: 3
               context_budget:
                 slm_max_tokens: 4096
                 llm_max_tokens: 16384
@@ -104,6 +124,20 @@ class TestLoadCognitiveConfig:
         assert len(config.providers) == 1
         assert config.providers[0].name == "ollama"
         assert config.providers[0].timeout_ms == 5000
+        assert config.systems[CognitiveSystem.CHAT] == SystemAssignment(
+            provider="openai", model="gpt-4o-mini"
+        )
+        assert config.systems[CognitiveSystem.REASONING] == SystemAssignment(
+            provider="anthropic", model="claude-sonnet-4-20250514"
+        )
+        assert config.default_fallback_chain == (
+            SystemAssignment(provider="ollama", model="llama3.2"),
+            SystemAssignment(provider="openai", model="gpt-4o-mini"),
+        )
+        assert config.fallback_cortisol == FallbackCortisolConfig(
+            release_per_step=0.25,
+            escalation_after=3,
+        )
         assert config.context_budget.slm_max_tokens == 4096
         assert config.context_budget.llm_max_tokens == 16384
         assert config.reasoning.default_max_tokens == 1024

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from openbad.cognitive.config import CognitiveSystem
 from openbad.cognitive.model_router import (
     FallbackChain,
+    FallbackTelemetry,
     ModelRouter,
     Priority,
     RouteStep,
@@ -34,9 +36,15 @@ def _mock_adapter(healthy: bool = True, latency: float = 50.0) -> ProviderAdapte
 def _build_router(
     providers: dict[str, ProviderAdapter] | None = None,
     chains: dict[Priority, FallbackChain] | None = None,
+    system_assignments: dict[CognitiveSystem, RouteStep] | None = None,
+    default_fallback_chain: FallbackChain | None = None,
     cortisol_threshold: float = 0.8,
     budget_limit: float = 0,
     health_ttl_s: float = 0,
+    endocrine_controller: object | None = None,
+    escalation_gateway: object | None = None,
+    fallback_release_per_step: float = 0.1,
+    fallback_escalation_after: int = 5,
 ) -> ModelRouter:
     reg = ProviderRegistry()
     for name, adapter in (providers or {}).items():
@@ -44,9 +52,15 @@ def _build_router(
     return ModelRouter(
         registry=reg,
         chains=chains,
+        system_assignments=system_assignments,
+        default_fallback_chain=default_fallback_chain,
         cortisol_threshold=cortisol_threshold,
         budget_limit=budget_limit,
         health_ttl_s=health_ttl_s,
+        endocrine_controller=endocrine_controller,
+        escalation_gateway=escalation_gateway,
+        fallback_release_per_step=fallback_release_per_step,
+        fallback_escalation_after=fallback_escalation_after,
     )
 
 
@@ -142,6 +156,100 @@ class TestFallback:
         router = _build_router(providers={}, chains=chains)
         with pytest.raises(RuntimeError, match="No available provider"):
             await router.route(Priority.HIGH)
+
+    async def test_system_assignment_uses_shared_fallback_chain(self) -> None:
+        endocrine = MagicMock()
+        router = _build_router(
+            providers={
+                "anthropic": _mock_adapter(healthy=False),
+                "ollama": _mock_adapter(),
+            },
+            system_assignments={
+                CognitiveSystem.REASONING: RouteStep("anthropic", "claude-opus-4")
+            },
+            default_fallback_chain=FallbackChain(
+                steps=(RouteStep("ollama", "bonsai-8b"),)
+            ),
+            endocrine_controller=endocrine,
+            fallback_release_per_step=0.2,
+        )
+
+        _, model, decision = await router.route(
+            Priority.HIGH,
+            system=CognitiveSystem.REASONING,
+        )
+
+        assert model == "bonsai-8b"
+        assert decision.provider == "ollama"
+        assert decision.system == "reasoning"
+        assert decision.fallback_index == 1
+        assert decision.fallback_count == 1
+        assert decision.consecutive_fallback_count == 1
+        endocrine.trigger.assert_called_once_with("cortisol", 0.2)
+
+    async def test_system_primary_resets_consecutive_fallbacks(self) -> None:
+        router = _build_router(
+            providers={
+                "anthropic": _mock_adapter(healthy=False),
+                "ollama": _mock_adapter(),
+            },
+            system_assignments={
+                CognitiveSystem.CHAT: RouteStep("anthropic", "claude-sonnet-4")
+            },
+            default_fallback_chain=FallbackChain(
+                steps=(RouteStep("ollama", "llama3.2"),)
+            ),
+        )
+
+        await router.route(Priority.MEDIUM, system=CognitiveSystem.CHAT)
+        telemetry = router.get_fallback_telemetry()
+        assert telemetry == FallbackTelemetry(
+            fallback_count=1,
+            consecutive_fallback_count=1,
+            last_fallback_time=telemetry.last_fallback_time,
+        )
+
+        router = _build_router(
+            providers={"anthropic": _mock_adapter()},
+            system_assignments={
+                CognitiveSystem.CHAT: RouteStep("anthropic", "claude-sonnet-4")
+            },
+            default_fallback_chain=FallbackChain(
+                steps=(RouteStep("ollama", "llama3.2"),)
+            ),
+        )
+
+        _, _, decision = await router.route(Priority.MEDIUM, system=CognitiveSystem.CHAT)
+        assert decision.fallback_index == 0
+        assert router.get_fallback_telemetry().consecutive_fallback_count == 0
+
+    async def test_consecutive_fallbacks_escalate_at_threshold(self) -> None:
+        endocrine = MagicMock()
+        escalation = MagicMock()
+        router = _build_router(
+            providers={
+                "anthropic": _mock_adapter(healthy=False),
+                "ollama": _mock_adapter(),
+            },
+            system_assignments={
+                CognitiveSystem.REACTIONS: RouteStep("anthropic", "claude-haiku-4")
+            },
+            default_fallback_chain=FallbackChain(
+                steps=(RouteStep("ollama", "llama3.2"),)
+            ),
+            endocrine_controller=endocrine,
+            escalation_gateway=escalation,
+            fallback_escalation_after=2,
+        )
+
+        await router.route(Priority.HIGH, system=CognitiveSystem.REACTIONS)
+        escalation.escalate.assert_not_called()
+
+        await router.route(Priority.HIGH, system=CognitiveSystem.REACTIONS)
+        escalation.escalate.assert_called_once()
+        telemetry = router.get_fallback_telemetry()
+        assert telemetry.fallback_count == 2
+        assert telemetry.consecutive_fallback_count == 2
 
 
 # ---------------------------------------------------------------- #


### PR DESCRIPTION
Closes #202

Summary of changes:
- add CognitiveSystem config schema, per-system assignments, shared fallback chain, and fallback cortisol settings
- extend ModelRouter with system-aware routing, fallback telemetry, cortisol release, and escalation publishing
- document intrinsic non-LLM systems in the cognitive config and cover the new behavior with focused tests

How to test:
- . .venv/bin/activate && pytest tests/test_cognitive_scaffold.py tests/test_model_router.py tests/test_cognitive_event_loop.py
- . .venv/bin/activate && ruff check src/openbad/cognitive/config.py src/openbad/cognitive/model_router.py tests/test_cognitive_scaffold.py tests/test_model_router.py