### PR TITLE
#216: Route cognitive event loop by system

### DIFF
--- a/src/openbad/cognitive/event_loop.py
+++ b/src/openbad/cognitive/event_loop.py
@@ -9,6 +9,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from openbad.cognitive.config import CognitiveSystem
 from openbad.cognitive.context_manager import ContextWindowManager
 from openbad.cognitive.model_router import ModelRouter, Priority
 from openbad.cognitive.reasoning.base import ReasoningStrategy
@@ -36,6 +37,7 @@ class CognitiveRequest:
     request_id: str
     prompt: str
     context: str = ""
+    system: CognitiveSystem = CognitiveSystem.CHAT
     priority: Priority = Priority.MEDIUM
     cortisol: float = 0.0
 
@@ -82,7 +84,7 @@ class CognitiveEventLoop:
         self,
         model_router: ModelRouter,
         context_manager: ContextWindowManager,
-        strategies: dict[Priority, ReasoningStrategy],
+        strategies: dict[Priority | CognitiveSystem, ReasoningStrategy],
         publish_fn: Any = None,
         validate_fn: Any = None,
     ) -> None:
@@ -118,11 +120,11 @@ class CognitiveEventLoop:
     async def handle_request(self, request: CognitiveRequest) -> CognitiveResponse:
         """Process a single reasoning request (can be called directly or via MQTT)."""
         if self._validate and not self._validate(request):
-                return CognitiveResponse(
-                    request_id=request.request_id,
-                    answer="",
-                    error="Request rejected by immune system",
-                )
+            return CognitiveResponse(
+                request_id=request.request_id,
+                answer="",
+                error="Request rejected by immune system",
+            )
 
         timeout = _TIMEOUTS.get(request.priority, 10.0)
 
@@ -165,6 +167,7 @@ class CognitiveEventLoop:
             request_id=data.get("request_id", ""),
             prompt=data.get("prompt", ""),
             context=data.get("context", ""),
+            system=_parse_system(data.get("system")),
             priority=Priority(data.get("priority", Priority.MEDIUM)),
             cortisol=data.get("cortisol", 0.0),
         )
@@ -179,7 +182,9 @@ class CognitiveEventLoop:
 
         # 1. Allocate context budget
         adapter, model_id, decision = await self._router.route(
-            request.priority, cortisol=request.cortisol,
+            request.priority,
+            system=request.system,
+            cortisol=request.cortisol,
         )
         budget = self._ctx.allocate(model_id)
 
@@ -189,7 +194,7 @@ class CognitiveEventLoop:
         )
 
         # 3. Select and execute reasoning strategy
-        strategy = self._strategies.get(request.priority)
+        strategy = self._select_strategy(request)
         if strategy:
             result = await strategy.reason(
                 request.prompt, compressed.text, self._router,
@@ -222,6 +227,14 @@ class CognitiveEventLoop:
             strategy=strategy_name,
         )
 
+    def _select_strategy(
+        self,
+        request: CognitiveRequest,
+    ) -> ReasoningStrategy | None:
+        return self._strategies.get(request.system) or self._strategies.get(
+            request.priority
+        )
+
 
 # ------------------------------------------------------------------ #
 # Helpers
@@ -230,6 +243,17 @@ class CognitiveEventLoop:
 
 async def _noop_publish(_topic: str, _payload: dict[str, Any]) -> None:
     pass
+
+
+def _parse_system(value: Any) -> CognitiveSystem:
+    if isinstance(value, CognitiveSystem):
+        return value
+    if isinstance(value, str):
+        try:
+            return CognitiveSystem(value.strip().lower())
+        except ValueError:
+            return CognitiveSystem.CHAT
+    return CognitiveSystem.CHAT
 
 
 def _response_to_dict(r: CognitiveResponse) -> dict[str, Any]:

--- a/tests/test_cognitive_event_loop.py
+++ b/tests/test_cognitive_event_loop.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+from openbad.cognitive.config import CognitiveSystem
 from openbad.cognitive.context_manager import (
     CompressedContext,
     CompressionStrategy,
@@ -16,10 +17,17 @@ from openbad.cognitive.event_loop import (
     CognitiveEventLoop,
     CognitiveRequest,
     CognitiveResponse,
+    _parse_system,
 )
-from openbad.cognitive.model_router import ModelRouter, Priority, RoutingDecision
+from openbad.cognitive.model_router import (
+    FallbackChain,
+    ModelRouter,
+    Priority,
+    RouteStep,
+    RoutingDecision,
+)
 from openbad.cognitive.orchestrator import CognitiveOrchestrator
-from openbad.cognitive.providers.base import CompletionResult, HealthStatus
+from openbad.cognitive.providers.base import CompletionResult, HealthStatus, ProviderAdapter
 from openbad.cognitive.providers.registry import ProviderRegistry
 from openbad.cognitive.reasoning.base import ReasoningResult, ReasoningStrategy
 
@@ -55,6 +63,32 @@ def _mock_router() -> ModelRouter:
     return router
 
 
+def _mock_adapter(
+    *,
+    provider: str,
+    content: str = "answer-42",
+    model_id: str = "llama3.2",
+    healthy: bool = True,
+) -> ProviderAdapter:
+    adapter = AsyncMock(spec=ProviderAdapter)
+    adapter.complete = AsyncMock(
+        return_value=CompletionResult(
+            content=content,
+            model_id=model_id,
+            provider=provider,
+            tokens_used=50,
+        )
+    )
+    adapter.health_check = AsyncMock(
+        return_value=HealthStatus(
+            provider=provider,
+            available=healthy,
+            latency_ms=10,
+        )
+    )
+    return adapter
+
+
 def _mock_ctx() -> ContextWindowManager:
     ctx = MagicMock(spec=ContextWindowManager)
     ctx.allocate = MagicMock(
@@ -88,7 +122,7 @@ def _mock_strategy() -> ReasoningStrategy:
 
 
 def _event_loop(
-    strategies: dict[Priority, ReasoningStrategy] | None = None,
+    strategies: dict[Priority | CognitiveSystem, ReasoningStrategy] | None = None,
     publish_fn: AsyncMock | None = None,
     validate_fn: MagicMock | None = None,
 ) -> CognitiveEventLoop:
@@ -119,6 +153,10 @@ class TestHandleRequest:
         assert resp.tokens_used == 50
         assert resp.request_id == "r1"
 
+    async def test_request_defaults_to_chat_system(self) -> None:
+        req = CognitiveRequest(request_id="r0", prompt="hello")
+        assert req.system is CognitiveSystem.CHAT
+
     async def test_strategy_used(self) -> None:
         strategies = {Priority.MEDIUM: _mock_strategy()}
         loop = _event_loop(strategies=strategies)
@@ -128,6 +166,45 @@ class TestHandleRequest:
         resp = await loop.handle_request(req)
         assert resp.answer == "cot-answer"
         assert resp.tokens_used == 75
+
+    async def test_system_strategy_overrides_priority_strategy(self) -> None:
+        system_strategy = _mock_strategy()
+        priority_strategy = _mock_strategy()
+        loop = _event_loop(
+            strategies={
+                CognitiveSystem.REACTIONS: system_strategy,
+                Priority.HIGH: priority_strategy,
+            }
+        )
+        req = CognitiveRequest(
+            request_id="r2b",
+            prompt="react",
+            priority=Priority.HIGH,
+            system=CognitiveSystem.REACTIONS,
+        )
+
+        resp = await loop.handle_request(req)
+
+        assert resp.answer == "cot-answer"
+        system_strategy.reason.assert_awaited_once()
+        priority_strategy.reason.assert_not_awaited()
+
+    async def test_routes_with_system_assignment(self) -> None:
+        loop = _event_loop()
+        req = CognitiveRequest(
+            request_id="r2c",
+            prompt="think",
+            priority=Priority.HIGH,
+            system=CognitiveSystem.REASONING,
+        )
+
+        await loop.handle_request(req)
+
+        loop._router.route.assert_awaited_once_with(  # noqa: SLF001
+            Priority.HIGH,
+            system=CognitiveSystem.REASONING,
+            cortisol=0.0,
+        )
 
     async def test_publishes_result(self) -> None:
         pub = AsyncMock()
@@ -211,6 +288,35 @@ class TestOnMessage:
         await asyncio.sleep(0.1)
         await loop.stop()
 
+    async def test_message_defaults_system_to_chat(self) -> None:
+        loop = _event_loop()
+        loop.submit = MagicMock()
+
+        payload = json.dumps({
+            "request_id": "m-chat",
+            "prompt": "test",
+            "priority": 2,
+        }).encode()
+        await loop.on_message("agent/cognitive/request", payload)
+
+        submitted = loop.submit.call_args.args[0]
+        assert submitted.system is CognitiveSystem.CHAT
+
+    async def test_message_parses_explicit_system(self) -> None:
+        loop = _event_loop()
+        loop.submit = MagicMock()
+
+        payload = json.dumps({
+            "request_id": "m-reason",
+            "prompt": "test",
+            "priority": 3,
+            "system": "reasoning",
+        }).encode()
+        await loop.on_message("agent/cognitive/request", payload)
+
+        submitted = loop.submit.call_args.args[0]
+        assert submitted.system is CognitiveSystem.REASONING
+
     async def test_invalid_json(self) -> None:
         loop = _event_loop()
         await loop.on_message("agent/cognitive/request", b"not json")
@@ -269,3 +375,65 @@ class TestOrchestrator:
             registry=reg, router=router, context_manager=ctx,
         )
         assert isinstance(orch.event_loop, CognitiveEventLoop)
+
+
+class TestSystemRoutingIntegration:
+    async def test_fallback_flow_returns_response(self) -> None:
+        registry = ProviderRegistry()
+        registry.register(
+            "anthropic",
+            _mock_adapter(
+                provider="anthropic",
+                model_id="claude-opus-4",
+                healthy=False,
+            ),
+        )
+        registry.register(
+            "ollama",
+            _mock_adapter(
+                provider="ollama",
+                content="fallback-answer",
+                model_id="bonsai-8b",
+            ),
+        )
+        router = ModelRouter(
+            registry=registry,
+            system_assignments={
+                CognitiveSystem.REASONING: RouteStep("anthropic", "claude-opus-4")
+            },
+            default_fallback_chain=FallbackChain(
+                steps=(RouteStep("ollama", "bonsai-8b"),)
+            ),
+            health_ttl_s=0,
+        )
+        ctx = _mock_ctx()
+        loop = CognitiveEventLoop(
+            model_router=router,
+            context_manager=ctx,
+            strategies={},
+        )
+
+        response = await loop.handle_request(
+            CognitiveRequest(
+                request_id="integration-1",
+                prompt="analyze",
+                context="ctx",
+                priority=Priority.HIGH,
+                system=CognitiveSystem.REASONING,
+            )
+        )
+
+        assert response.answer == "fallback-answer"
+        assert response.provider == "ollama"
+        assert response.model_id == "bonsai-8b"
+        telemetry = router.get_fallback_telemetry()
+        assert telemetry.fallback_count == 1
+        assert telemetry.consecutive_fallback_count == 1
+
+
+class TestParseSystem:
+    def test_invalid_value_defaults_to_chat(self) -> None:
+        assert _parse_system("unknown") is CognitiveSystem.CHAT
+
+    def test_enum_passthrough(self) -> None:
+        assert _parse_system(CognitiveSystem.SLEEP) is CognitiveSystem.SLEEP


### PR DESCRIPTION
Closes #216

Summary of changes:
- add `system: CognitiveSystem` to `CognitiveRequest` with `CHAT` as the backward-compatible default
- route `CognitiveEventLoop` through `ModelRouter` by system assignment and choose reasoning strategies by system before priority
- add unit and integration coverage for system parsing, strategy selection, and assigned-provider fallback through the event loop

How to test:
- . .venv/bin/activate && pytest tests/test_cognitive_event_loop.py tests/test_phase3_e2e.py
- . .venv/bin/activate && ruff check src/openbad/cognitive/event_loop.py tests/test_cognitive_event_loop.py