### PR TITLE
#220: Route sleep consolidation through event loop

### DIFF
--- a/src/openbad/memory/sleep/orchestrator.py
+++ b/src/openbad/memory/sleep/orchestrator.py
@@ -14,12 +14,14 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from openbad.cognitive.config import CognitiveSystem
+from openbad.cognitive.event_loop import CognitiveEventLoop, CognitiveRequest
+from openbad.cognitive.model_router import Priority
 from openbad.memory.forgetting import prune_store
 
 if TYPE_CHECKING:
+    from openbad.memory.base import MemoryEntry
     from openbad.memory.controller import MemoryController
-    from openbad.memory.sleep.rem import RapidEyeMovement
-    from openbad.memory.sleep.sws import SlowWaveSleep
 
 logger = logging.getLogger(__name__)
 
@@ -75,9 +77,10 @@ class SleepReport:
     started_at: float = 0.0
     finished_at: float = 0.0
     phase_durations: dict[str, float] = field(default_factory=dict)
-    constraints_extracted: int = 0
-    skills_created: int = 0
+    entries_consolidated: int = 0
     entries_pruned: int = 0
+    skipped: bool = False
+    error: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -85,26 +88,29 @@ class SleepReport:
             "finished_at": self.finished_at,
             "duration_seconds": self.finished_at - self.started_at,
             "phase_durations": self.phase_durations,
-            "constraints_extracted": self.constraints_extracted,
-            "skills_created": self.skills_created,
+            "entries_consolidated": self.entries_consolidated,
             "entries_pruned": self.entries_pruned,
+            "skipped": self.skipped,
+            "error": self.error,
         }
 
 
 class SleepOrchestrator:
-    """Orchestrates SWS → REM → pruning sleep consolidation cycles."""
+    """Orchestrates sleep consolidation through the cognitive event loop."""
 
     def __init__(
         self,
-        sws: SlowWaveSleep,
-        rem: RapidEyeMovement,
-        pruner: MemoryPruner,
+        memory_controller: MemoryController,
+        cognitive_event_loop: CognitiveEventLoop,
+        pruner: MemoryPruner | None = None,
+        fsm: Any = None,
         idle_threshold_seconds: float = 300.0,
         publish_fn: Callable[[str, bytes], None] | None = None,
     ) -> None:
-        self._sws = sws
-        self._rem = rem
+        self._memory_controller = memory_controller
+        self._event_loop = cognitive_event_loop
         self._pruner = pruner
+        self._fsm = fsm
         self._idle_threshold = idle_threshold_seconds
         self._publish_fn = publish_fn
         self._phase = SleepPhase.AWAKE
@@ -126,41 +132,49 @@ class SleepOrchestrator:
     # Run a single sleep cycle
     # ------------------------------------------------------------------ #
 
-    def run_cycle(self) -> SleepReport:
-        """Execute SWS → REM → pruning in sequence."""
+    async def run_cycle(self) -> SleepReport:
+        """Execute summarization → extraction/scoring → pruning in sequence."""
         report = SleepReport(started_at=time.time())
+        self._enter_sleep_state()
 
-        # SWS phase
-        self._set_phase(SleepPhase.SWS)
-        t0 = time.time()
-        report.constraints_extracted = self._sws.run()
-        report.phase_durations[SleepPhase.SWS.value] = time.time() - t0
+        entries = self._memory_controller.stm.query("")
 
-        # REM phase
-        self._set_phase(SleepPhase.REM)
-        t0 = time.time()
-        report.skills_created = self._rem.run()
-        report.phase_durations[SleepPhase.REM.value] = time.time() - t0
+        try:
+            # SWS phase: summarize pending STM entries.
+            self._set_phase(SleepPhase.SWS)
+            t0 = time.time()
+            summaries = await self._summarize_entries(entries)
+            report.phase_durations[SleepPhase.SWS.value] = time.time() - t0
 
-        # Pruning phase
-        self._set_phase(SleepPhase.PRUNING)
-        t0 = time.time()
-        report.entries_pruned = self._pruner.run()
-        report.phase_durations[SleepPhase.PRUNING.value] = time.time() - t0
+            # REM phase: extract tags, score importance, and write LTM.
+            self._set_phase(SleepPhase.REM)
+            t0 = time.time()
+            report.entries_consolidated = await self._write_ltm(entries, summaries)
+            report.phase_durations[SleepPhase.REM.value] = time.time() - t0
 
-        # Complete
-        report.finished_at = time.time()
-        self._set_phase(SleepPhase.COMPLETE)
+            # Pruning phase.
+            self._set_phase(SleepPhase.PRUNING)
+            t0 = time.time()
+            report.entries_pruned = self._pruner.run() if self._pruner else 0
+            report.phase_durations[SleepPhase.PRUNING.value] = time.time() - t0
 
-        logger.info(
-            "Sleep cycle complete: %d constraints, %d skills, %d pruned",
-            report.constraints_extracted,
-            report.skills_created,
-            report.entries_pruned,
-        )
+            report.finished_at = time.time()
+            self._set_phase(SleepPhase.COMPLETE)
 
-        # Return to awake
-        self._set_phase(SleepPhase.AWAKE)
+            logger.info(
+                "Sleep cycle complete: %d consolidated, %d pruned",
+                report.entries_consolidated,
+                report.entries_pruned,
+            )
+        except Exception as exc:
+            report.finished_at = time.time()
+            report.skipped = True
+            report.error = str(exc)
+            logger.warning("Sleep cycle skipped: %s", exc)
+        finally:
+            self._set_phase(SleepPhase.AWAKE)
+            self._wake_sleep_state()
+
         return report
 
     # ------------------------------------------------------------------ #
@@ -184,7 +198,7 @@ class SleepOrchestrator:
                 last = get_last_activity()
                 if self.is_idle(last):
                     logger.info("Agent idle — starting sleep cycle")
-                    self.run_cycle()
+                    await self.run_cycle()
         except asyncio.CancelledError:
             logger.info("Sleep orchestrator background task cancelled")
 
@@ -205,3 +219,112 @@ class SleepOrchestrator:
                 "agent/memory/sleep/phase",
                 phase.value.encode(),
             )
+
+    def _enter_sleep_state(self) -> None:
+        if self._fsm is not None and getattr(self._fsm, "state", None) != "SLEEP":
+            self._fsm.fire("sleep")
+
+    def _wake_sleep_state(self) -> None:
+        if self._fsm is not None and getattr(self._fsm, "state", None) == "SLEEP":
+            self._fsm.fire("wake")
+
+    async def _summarize_entries(
+        self,
+        entries: list[MemoryEntry],
+    ) -> dict[str, str]:
+        summaries: dict[str, str] = {}
+        for entry in entries:
+            response = await self._request_sleep_pass(
+                entry=entry,
+                stage="summarize",
+                prompt=(
+                    "Summarize this memory entry for long-term recall in 1-2 "
+                    "sentences."
+                ),
+                context=str(entry.value),
+            )
+            summaries[entry.key] = response.answer.strip()
+        return summaries
+
+    async def _write_ltm(
+        self,
+        entries: list[MemoryEntry],
+        summaries: dict[str, str],
+    ) -> int:
+        consolidated = 0
+        for entry in entries:
+            summary = summaries.get(entry.key, "").strip()
+            if not summary:
+                continue
+            tags_response = await self._request_sleep_pass(
+                entry=entry,
+                stage="extract",
+                prompt=(
+                    "Extract up to 5 short retrieval tags for this summary. Return "
+                    "a comma-separated list only."
+                ),
+                context=summary,
+            )
+            score_response = await self._request_sleep_pass(
+                entry=entry,
+                stage="score",
+                prompt=(
+                    "Score the long-term importance of this summary from 0.0 to 1.0. "
+                    "Return only the numeric score."
+                ),
+                context=summary,
+            )
+            tags = _parse_tags(tags_response.answer)
+            importance = _parse_importance(score_response.answer)
+            self._memory_controller.write_semantic(
+                f"sleep/{entry.key}",
+                summary,
+                context="sleep_consolidation",
+                metadata={
+                    "source_stm_key": entry.key,
+                    "source_entry_id": entry.entry_id,
+                    "importance": importance,
+                    "tags": tags,
+                },
+            )
+            self._memory_controller.stm.delete(entry.key)
+            consolidated += 1
+        return consolidated
+
+    async def _request_sleep_pass(
+        self,
+        *,
+        entry: MemoryEntry,
+        stage: str,
+        prompt: str,
+        context: str,
+    ) -> Any:
+        response = await self._event_loop.handle_request(
+            CognitiveRequest(
+                request_id=f"sleep-{stage}-{entry.entry_id}",
+                prompt=prompt,
+                context=context,
+                system=CognitiveSystem.SLEEP,
+                priority=Priority.LOW,
+            )
+        )
+        if response.error:
+            raise RuntimeError(response.error)
+        return response
+
+
+def _parse_tags(raw: str) -> list[str]:
+    tags: list[str] = []
+    for chunk in raw.replace("\n", ",").split(","):
+        tag = chunk.strip()
+        if tag and tag not in tags:
+            tags.append(tag)
+    return tags[:5]
+
+
+def _parse_importance(raw: str) -> float:
+    try:
+        score = float(raw.strip())
+    except ValueError:
+        return 0.5
+    return max(0.0, min(1.0, score))

--- a/tests/test_phase4_e2e.py
+++ b/tests/test_phase4_e2e.py
@@ -10,9 +10,25 @@ import asyncio
 import contextlib
 import time
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from openbad.cognitive.config import CognitiveSystem
+from openbad.cognitive.context_manager import (
+    CompressedContext,
+    CompressionStrategy,
+    ContextBudget,
+    ContextWindowManager,
+)
+from openbad.cognitive.event_loop import CognitiveEventLoop
+from openbad.cognitive.model_router import FallbackChain, ModelRouter, RouteStep
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ProviderAdapter,
+)
+from openbad.cognitive.providers.registry import ProviderRegistry
 from openbad.memory.base import MemoryEntry, MemoryTier
 from openbad.memory.config import MemoryConfig
 from openbad.memory.controller import MemoryController
@@ -22,8 +38,6 @@ from openbad.memory.sleep.orchestrator import (
     MemoryPruner,
     SleepOrchestrator,
 )
-from openbad.memory.sleep.rem import RapidEyeMovement
-from openbad.memory.sleep.sws import SlowWaveSleep
 from openbad.memory.stm import ShortTermMemory
 
 integration = pytest.mark.integration
@@ -31,6 +45,79 @@ integration = pytest.mark.integration
 
 def _mc(tmp_path: Path, **kwargs: object) -> MemoryController:
     return MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path, **kwargs))
+
+
+def _sleep_event_loop() -> CognitiveEventLoop:
+    registry = ProviderRegistry()
+    adapter = AsyncMock(spec=ProviderAdapter)
+    adapter.complete = AsyncMock(
+        side_effect=[
+            CompletionResult(
+                content="failure summary",
+                model_id="bonsai-8b",
+                provider="ollama",
+                tokens_used=10,
+            ),
+            CompletionResult(
+                content="ops, error",
+                model_id="bonsai-8b",
+                provider="ollama",
+                tokens_used=10,
+            ),
+            CompletionResult(
+                content="0.9",
+                model_id="bonsai-8b",
+                provider="ollama",
+                tokens_used=5,
+            ),
+            CompletionResult(
+                content="success summary",
+                model_id="bonsai-8b",
+                provider="ollama",
+                tokens_used=10,
+            ),
+            CompletionResult(
+                content="ops, build",
+                model_id="bonsai-8b",
+                provider="ollama",
+                tokens_used=10,
+            ),
+            CompletionResult(
+                content="0.7",
+                model_id="bonsai-8b",
+                provider="ollama",
+                tokens_used=5,
+            ),
+        ]
+    )
+    adapter.health_check = AsyncMock(
+        return_value=HealthStatus(provider="ollama", available=True, latency_ms=5)
+    )
+    registry.register("ollama", adapter)
+    router = ModelRouter(
+        registry=registry,
+        system_assignments={CognitiveSystem.SLEEP: RouteStep("ollama", "bonsai-8b")},
+        default_fallback_chain=FallbackChain(steps=(RouteStep("ollama", "bonsai-8b"),)),
+    )
+    ctx = MagicMock(spec=ContextWindowManager)
+    ctx.allocate = MagicMock(
+        return_value=ContextBudget(
+            max_tokens=8192,
+            system_tokens=1000,
+            context_tokens=4000,
+            response_tokens=2000,
+        )
+    )
+    ctx.compress = MagicMock(
+        return_value=CompressedContext(
+            text="compressed",
+            original_tokens=10,
+            compressed_tokens=10,
+            strategy=CompressionStrategy.TRUNCATE,
+        )
+    )
+    ctx.track_usage = MagicMock()
+    return CognitiveEventLoop(model_router=router, context_manager=ctx, strategies={})
 
 
 # ------------------------------------------------------------------ #
@@ -185,7 +272,7 @@ class TestProceduralLifecycle:
 
 @integration
 class TestFullSleepCycle:
-    def test_sleep_consolidates_all(self, tmp_path: Path) -> None:
+    async def test_sleep_consolidates_all(self, tmp_path: Path) -> None:
         mc = _mc(tmp_path)
 
         # Populate STM with failures
@@ -214,21 +301,19 @@ class TestFullSleepCycle:
             created_at=time.time() - 100000 * 3600,
         ))
 
-        sws = SlowWaveSleep(mc)
-        rem = RapidEyeMovement(mc)
         pruner = MemoryPruner(memory_controller=mc)
-        orch = SleepOrchestrator(sws=sws, rem=rem, pruner=pruner)
+        orch = SleepOrchestrator(
+            memory_controller=mc,
+            cognitive_event_loop=_sleep_event_loop(),
+            pruner=pruner,
+        )
 
-        report = orch.run_cycle()
+        report = await orch.run_cycle()
 
-        # Verify constraints in episodic
-        assert report.constraints_extracted >= 2
-        constraints = mc.episodic.query("sws/")
-        assert len(constraints) >= 2
-
-        # Verify skills in procedural
-        assert report.skills_created >= 1
-        assert mc.procedural.size() >= 1
+        # Verify semantic consolidation entries
+        assert report.entries_consolidated >= 2
+        consolidated = mc.semantic.query("sleep/")
+        assert len(consolidated) >= 2
 
         # Verify pruned entries
         assert report.entries_pruned >= 1
@@ -325,12 +410,12 @@ class TestIdleAutoSleep:
             metadata={"status": "error"},
         ))
 
-        sws = SlowWaveSleep(mc)
-        rem = RapidEyeMovement(mc)
         pruner = MemoryPruner(memory_controller=mc)
         phases: list[str] = []
         orch = SleepOrchestrator(
-            sws=sws, rem=rem, pruner=pruner,
+            memory_controller=mc,
+            cognitive_event_loop=_sleep_event_loop(),
+            pruner=pruner,
             idle_threshold_seconds=0.01,
             publish_fn=lambda t, p: phases.append(p.decode()),
         )

--- a/tests/test_sleep_orchestrator.py
+++ b/tests/test_sleep_orchestrator.py
@@ -6,7 +6,23 @@ import asyncio
 import contextlib
 import time
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
+from openbad.cognitive.config import CognitiveSystem
+from openbad.cognitive.context_manager import (
+    CompressedContext,
+    CompressionStrategy,
+    ContextBudget,
+    ContextWindowManager,
+)
+from openbad.cognitive.event_loop import CognitiveEventLoop, CognitiveResponse
+from openbad.cognitive.model_router import FallbackChain, ModelRouter, RouteStep
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ProviderAdapter,
+)
+from openbad.cognitive.providers.registry import ProviderRegistry
 from openbad.memory.base import MemoryEntry, MemoryTier
 from openbad.memory.config import MemoryConfig
 from openbad.memory.controller import MemoryController
@@ -15,17 +31,88 @@ from openbad.memory.sleep.orchestrator import (
     SleepOrchestrator,
     SleepPhase,
     SleepReport,
+    _parse_importance,
+    _parse_tags,
 )
-from openbad.memory.sleep.rem import RapidEyeMovement
-from openbad.memory.sleep.sws import SlowWaveSleep
+
+
+def _mock_sleep_loop() -> CognitiveEventLoop:
+    loop = AsyncMock(spec=CognitiveEventLoop)
+    loop.handle_request = AsyncMock(
+        side_effect=[
+            CognitiveResponse(request_id="1", answer="summary one"),
+            CognitiveResponse(request_id="2", answer="tag1, tag2"),
+            CognitiveResponse(request_id="3", answer="0.8"),
+        ]
+    )
+    return loop
+
+
+def _real_sleep_loop() -> CognitiveEventLoop:
+    registry = ProviderRegistry()
+    adapter = AsyncMock(spec=ProviderAdapter)
+    adapter.complete = AsyncMock(
+        side_effect=[
+            CompletionResult(
+                content="summary one",
+                model_id="bonsai-8b",
+                provider="ollama",
+                tokens_used=10,
+            ),
+            CompletionResult(
+                content="tag1, tag2",
+                model_id="bonsai-8b",
+                provider="ollama",
+                tokens_used=10,
+            ),
+            CompletionResult(
+                content="0.8",
+                model_id="bonsai-8b",
+                provider="ollama",
+                tokens_used=5,
+            ),
+        ]
+    )
+    adapter.health_check = AsyncMock(
+        return_value=HealthStatus(provider="ollama", available=True, latency_ms=5)
+    )
+    registry.register("ollama", adapter)
+    router = ModelRouter(
+        registry=registry,
+        system_assignments={
+            CognitiveSystem.SLEEP: RouteStep("ollama", "bonsai-8b")
+        },
+        default_fallback_chain=FallbackChain(steps=(RouteStep("ollama", "bonsai-8b"),)),
+    )
+    ctx = MagicMock(spec=ContextWindowManager)
+    ctx.allocate = MagicMock(
+        return_value=ContextBudget(
+            max_tokens=8192,
+            system_tokens=1000,
+            context_tokens=4000,
+            response_tokens=2000,
+        )
+    )
+    ctx.compress = MagicMock(
+        return_value=CompressedContext(
+            text="compressed",
+            original_tokens=10,
+            compressed_tokens=10,
+            strategy=CompressionStrategy.TRUNCATE,
+        )
+    )
+    ctx.track_usage = MagicMock()
+    return CognitiveEventLoop(model_router=router, context_manager=ctx, strategies={})
 
 
 def _setup(tmp_path: Path) -> tuple[MemoryController, SleepOrchestrator]:
     mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
-    sws = SlowWaveSleep(mc)
-    rem = RapidEyeMovement(mc)
     pruner = MemoryPruner(memory_controller=mc)
-    orch = SleepOrchestrator(sws=sws, rem=rem, pruner=pruner)
+    orch = SleepOrchestrator(
+        memory_controller=mc,
+        cognitive_event_loop=_mock_sleep_loop(),
+        pruner=pruner,
+    )
     return mc, orch
 
 
@@ -45,11 +132,12 @@ class TestIdleDetection:
 
     def test_custom_threshold(self, tmp_path: Path) -> None:
         mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
-        sws = SlowWaveSleep(mc)
-        rem = RapidEyeMovement(mc)
         pruner = MemoryPruner(memory_controller=mc)
         orch = SleepOrchestrator(
-            sws=sws, rem=rem, pruner=pruner, idle_threshold_seconds=10.0,
+            memory_controller=mc,
+            cognitive_event_loop=_mock_sleep_loop(),
+            pruner=pruner,
+            idle_threshold_seconds=10.0,
         )
         assert not orch.is_idle(time.time() - 5)
         assert orch.is_idle(time.time() - 15)
@@ -65,22 +153,23 @@ class TestPhaseTransitions:
         _, orch = _setup(tmp_path)
         assert orch.phase == SleepPhase.AWAKE
 
-    def test_publishes_phase_transitions(self, tmp_path: Path) -> None:
+    async def test_publishes_phase_transitions(self, tmp_path: Path) -> None:
         mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
-        sws = SlowWaveSleep(mc)
-        rem = RapidEyeMovement(mc)
         pruner = MemoryPruner(memory_controller=mc)
         phases: list[str] = []
         orch = SleepOrchestrator(
-            sws=sws, rem=rem, pruner=pruner,
+            memory_controller=mc,
+            cognitive_event_loop=_mock_sleep_loop(),
+            pruner=pruner,
             publish_fn=lambda t, p: phases.append(p.decode()),
         )
-        orch.run_cycle()
+        mc.stm.write(MemoryEntry(key="s1", value="ok", tier=MemoryTier.STM))
+        await orch.run_cycle()
         assert phases == ["sws", "rem", "pruning", "complete", "awake"]
 
-    def test_returns_to_awake(self, tmp_path: Path) -> None:
+    async def test_returns_to_awake(self, tmp_path: Path) -> None:
         _, orch = _setup(tmp_path)
-        orch.run_cycle()
+        await orch.run_cycle()
         assert orch.phase == SleepPhase.AWAKE
 
 
@@ -90,36 +179,49 @@ class TestPhaseTransitions:
 
 
 class TestRunCycle:
-    def test_empty_cycle(self, tmp_path: Path) -> None:
+    async def test_empty_cycle(self, tmp_path: Path) -> None:
         _, orch = _setup(tmp_path)
-        report = orch.run_cycle()
-        assert report.constraints_extracted == 0
-        assert report.skills_created == 0
+        report = await orch.run_cycle()
+        assert report.entries_consolidated == 0
         assert report.entries_pruned == 0
         assert report.finished_at >= report.started_at
 
-    def test_cycle_with_failures_and_successes(self, tmp_path: Path) -> None:
+    async def test_cycle_with_stm_entries(self, tmp_path: Path) -> None:
         mc, orch = _setup(tmp_path)
-        # Add failures
         mc.stm.write(MemoryEntry(
-            key="f1", value="error: crash", tier=MemoryTier.STM,
-            metadata={"status": "error", "action": "deploy"},
+            key="s1", value="meeting notes", tier=MemoryTier.STM,
+            metadata={"status": "success", "action": "remember"},
         ))
-        # Add successes
-        mc.stm.write(MemoryEntry(
-            key="s1", value="ok", tier=MemoryTier.STM,
-            metadata={"status": "success", "action": "build"},
-        ))
-        report = orch.run_cycle()
-        assert report.constraints_extracted >= 1
-        assert report.skills_created >= 1
+        report = await orch.run_cycle()
+        assert report.entries_consolidated == 1
+        semantic_entries = mc.semantic.query("sleep/")
+        assert len(semantic_entries) == 1
+        assert semantic_entries[0].metadata["tags"] == ["tag1", "tag2"]
+        assert semantic_entries[0].metadata["importance"] == 0.8
 
-    def test_cycle_reports_phase_durations(self, tmp_path: Path) -> None:
+    async def test_cycle_reports_phase_durations(self, tmp_path: Path) -> None:
         _, orch = _setup(tmp_path)
-        report = orch.run_cycle()
+        report = await orch.run_cycle()
         assert "sws" in report.phase_durations
         assert "rem" in report.phase_durations
         assert "pruning" in report.phase_durations
+
+    async def test_cycle_skips_when_provider_unavailable(self, tmp_path: Path) -> None:
+        mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+        loop = AsyncMock(spec=CognitiveEventLoop)
+        loop.handle_request = AsyncMock(side_effect=RuntimeError("provider unavailable"))
+        orch = SleepOrchestrator(
+            memory_controller=mc,
+            cognitive_event_loop=loop,
+            pruner=MemoryPruner(memory_controller=mc),
+        )
+        mc.stm.write(MemoryEntry(key="s1", value="note", tier=MemoryTier.STM))
+
+        report = await orch.run_cycle()
+
+        assert report.skipped is True
+        assert report.entries_consolidated == 0
+        assert report.error == "provider unavailable"
 
 
 # ------------------------------------------------------------------ #
@@ -132,13 +234,12 @@ class TestSleepReport:
         r = SleepReport(
             started_at=100.0,
             finished_at=110.0,
-            constraints_extracted=3,
-            skills_created=1,
+            entries_consolidated=3,
             entries_pruned=5,
         )
         d = r.to_dict()
         assert d["duration_seconds"] == 10.0
-        assert d["constraints_extracted"] == 3
+        assert d["entries_consolidated"] == 3
 
     def test_defaults(self) -> None:
         r = SleepReport()
@@ -217,3 +318,36 @@ class TestSleepPhaseEnum:
         assert SleepPhase.REM.value == "rem"
         assert SleepPhase.PRUNING.value == "pruning"
         assert SleepPhase.COMPLETE.value == "complete"
+
+
+class TestHelpers:
+    def test_parse_tags(self) -> None:
+        assert _parse_tags("one, two\nthree") == ["one", "two", "three"]
+
+    def test_parse_importance(self) -> None:
+        assert _parse_importance("1.4") == 1.0
+        assert _parse_importance("bad") == 0.5
+
+
+class TestIntegration:
+    async def test_stm_entries_consolidate_into_semantic_memory(self, tmp_path: Path) -> None:
+        mc = MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+        mc.stm.write(
+            MemoryEntry(
+                key="entry-1",
+                value="Observed deployment drift",
+                tier=MemoryTier.STM,
+            )
+        )
+        orch = SleepOrchestrator(
+            memory_controller=mc,
+            cognitive_event_loop=_real_sleep_loop(),
+            pruner=MemoryPruner(memory_controller=mc),
+        )
+
+        report = await orch.run_cycle()
+
+        assert report.entries_consolidated == 1
+        entry = mc.semantic.read("sleep/entry-1")
+        assert entry is not None
+        assert entry.metadata["source_stm_key"] == "entry-1"


### PR DESCRIPTION
Closes #220

Summary of changes:
- refactor `SleepOrchestrator` to sequence sleep consolidation passes through `CognitiveEventLoop` using `system=SLEEP`
- convert sleep-cycle reporting to consolidated-entry/pruning outcomes with graceful skip behavior when the sleep provider is unavailable
- update unit and integration coverage for mocked event-loop sleep passes and semantic-memory writes during sleep cycles

How to test:
- . .venv/bin/activate && pytest tests/test_sleep_orchestrator.py tests/test_phase4_e2e.py
- . .venv/bin/activate && ruff check src/openbad/memory/sleep/orchestrator.py tests/test_sleep_orchestrator.py tests/test_phase4_e2e.py