### PR TITLE
#222: Implement LLM keyword/tag extraction pass with retrieval boost

### DIFF
--- a/src/openbad/memory/semantic.py
+++ b/src/openbad/memory/semantic.py
@@ -123,15 +123,29 @@ class SemanticMemory(MemoryStore):
         self,
         query_text: str,
         top_k: int = 5,
+        tags: list[str] | None = None,
+        tag_boost: float = 0.1,
     ) -> list[tuple[MemoryEntry, float]]:
         """Find entries most similar to query_text.
+
+        When *tags* are provided, entries whose ``metadata["tags"]`` overlap
+        with the query tags receive a bonus of *tag_boost* per matching tag
+        (capped so the final score never exceeds 1.0).
 
         Returns list of (entry, similarity_score) sorted by descending score.
         """
         query_vec = self._embed_fn(query_text)
+        tag_set = set(t.lower() for t in tags) if tags else set()
         scored: list[tuple[str, float]] = []
         for key, vec in self._vectors.items():
             sim = cosine_similarity(query_vec, vec)
+            if tag_set:
+                entry_tags = {
+                    t.lower()
+                    for t in self._entries[key].metadata.get("tags", [])
+                }
+                overlap = len(tag_set & entry_tags)
+                sim = min(1.0, sim + overlap * tag_boost)
             if sim >= self._similarity_threshold:
                 scored.append((key, sim))
         scored.sort(key=lambda x: x[1], reverse=True)

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -225,3 +225,77 @@ class TestSemanticPersistence:
         assert not path.exists()
         mem.save()
         assert path.exists()
+
+
+# ------------------------------------------------------------------ #
+# Tag-based retrieval boost
+# ------------------------------------------------------------------ #
+
+
+class TestTagBoost:
+    def test_tags_boost_ranking(self) -> None:
+        """Entries with matching tags should rank higher."""
+        mem = SemanticMemory()
+        mem.write(MemoryEntry(
+            key="a", value="alpha info", tier=MemoryTier.SEMANTIC,
+            metadata={"tags": ["deploy", "error"]},
+        ))
+        mem.write(MemoryEntry(
+            key="b", value="beta info", tier=MemoryTier.SEMANTIC,
+            metadata={"tags": ["network"]},
+        ))
+        results_no_tags = mem.search("info", top_k=2)
+        results_with_tags = mem.search(
+            "info", top_k=2, tags=["deploy"],
+        )
+        # With tag boost, 'a' (matching tag) should be first
+        assert results_with_tags[0][0].key == "a"
+        # Score with tag should be >= score without tag
+        score_a_boosted = results_with_tags[0][1]
+        score_a_plain = next(
+            s for e, s in results_no_tags if e.key == "a"
+        )
+        assert score_a_boosted >= score_a_plain
+
+    def test_tag_boost_capped_at_one(self) -> None:
+        mem = SemanticMemory()
+        mem.write(MemoryEntry(
+            key="a", value="a", tier=MemoryTier.SEMANTIC,
+            metadata={"tags": ["t1", "t2", "t3", "t4", "t5"]},
+        ))
+        results = mem.search(
+            "a", top_k=1, tags=["t1", "t2", "t3", "t4", "t5"],
+            tag_boost=0.5,
+        )
+        assert results[0][1] <= 1.0
+
+    def test_search_without_tags_unchanged(self) -> None:
+        """Backward compatibility: search without tags keyword works."""
+        mem = SemanticMemory()
+        mem.write(MemoryEntry(
+            key="x", value="hello", tier=MemoryTier.SEMANTIC,
+        ))
+        results = mem.search("hello", top_k=1)
+        assert len(results) == 1
+
+    def test_tag_matching_is_case_insensitive(self) -> None:
+        mem = SemanticMemory()
+        mem.write(MemoryEntry(
+            key="a", value="some stored information", tier=MemoryTier.SEMANTIC,
+            metadata={"tags": ["Deploy"]},
+        ))
+        results = mem.search("query text", top_k=1, tags=["deploy"])
+        boosted = results[0][1]
+        results_plain = mem.search("query text", top_k=1)
+        plain = results_plain[0][1]
+        assert boosted > plain
+
+    def test_extracted_tags_reasonable(self) -> None:
+        """Tags extracted by _parse_tags should be usable for retrieval."""
+        from openbad.memory.sleep.orchestrator import _parse_tags
+
+        raw = "deployment, rollback, v2.3.1, production"
+        tags = _parse_tags(raw)
+        assert len(tags) >= 3
+        assert "deployment" in tags
+        assert "rollback" in tags


### PR DESCRIPTION
Closes #222

## Summary
Adds tag-based retrieval boost to semantic memory search, completing the keyword/tag extraction pass for sleep consolidation.

### Changes
- **`src/openbad/memory/semantic.py`**: Extended `search()` with optional `tags` and `tag_boost` params. Entries with matching `metadata["tags"]` get a score bonus per overlap (capped at 1.0). Case-insensitive matching.
- **`tests/test_semantic.py`**: New `TestTagBoost` class with 5 tests: boost ranking, cap at 1.0, backward compat, case-insensitive matching, extracted tags reasonableness.

Tag extraction prompt template and `_parse_tags()` were already implemented in #221. This issue completes the loop by making tags usable for retrieval boost.

### Validation
```bash
pytest tests/test_semantic.py  # 30 passed
ruff check  # All checks passed
```