### PR TITLE
#224: Add configurable raw-episodic retention period before hard delete

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -5,3 +5,4 @@ memory:
   ltm_storage_dir: data/memory
   pruning_interval_seconds: 3600.0
   forgetting_half_life_hours: 168.0
+  episodic_retention_days: 7.0

--- a/src/openbad/memory/config.py
+++ b/src/openbad/memory/config.py
@@ -18,6 +18,7 @@ class MemoryConfig:
     ltm_storage_dir: Path = field(default_factory=lambda: Path("data/memory"))
     pruning_interval_seconds: float = 3600.0
     forgetting_half_life_hours: float = 168.0
+    episodic_retention_days: float = 7.0
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> MemoryConfig:
@@ -32,6 +33,7 @@ class MemoryConfig:
             ltm_storage_dir=Path(mem.get("ltm_storage_dir", "data/memory")),
             pruning_interval_seconds=mem.get("pruning_interval_seconds", 3600.0),
             forgetting_half_life_hours=mem.get("forgetting_half_life_hours", 168.0),
+            episodic_retention_days=mem.get("episodic_retention_days", 7.0),
         )
 
     def to_dict(self) -> dict:
@@ -43,4 +45,5 @@ class MemoryConfig:
             "ltm_storage_dir": str(self.ltm_storage_dir),
             "pruning_interval_seconds": self.pruning_interval_seconds,
             "forgetting_half_life_hours": self.forgetting_half_life_hours,
+            "episodic_retention_days": self.episodic_retention_days,
         }

--- a/src/openbad/memory/forgetting.py
+++ b/src/openbad/memory/forgetting.py
@@ -112,3 +112,41 @@ def rank_by_retention(
 
     scored.sort(key=lambda x: x[1])
     return scored
+
+
+def prune_consolidated_episodic(
+    store: MemoryStore,
+    retention_days: float = 7.0,
+    now: float | None = None,
+) -> list[str]:
+    """Delete consolidated episodic entries older than *retention_days*.
+
+    Only entries with ``metadata["consolidated"] == True`` are considered.
+    Returns a list of pruned keys.
+    """
+    if now is None:
+        now = time.time()
+
+    cutoff = now - (retention_days * 86400.0)
+    pruned: list[str] = []
+
+    for entry in store.query(""):
+        if not entry.metadata.get("consolidated"):
+            continue
+        if entry.created_at < cutoff:
+            store.delete(entry.key)
+            pruned.append(entry.key)
+            logger.debug(
+                "Pruned consolidated episodic %s (age=%.1f days)",
+                entry.key,
+                (now - entry.created_at) / 86400.0,
+            )
+
+    if pruned:
+        logger.info(
+            "Pruned %d consolidated episodic entries (retention=%.1f days)",
+            len(pruned),
+            retention_days,
+        )
+
+    return pruned

--- a/src/openbad/memory/sleep/orchestrator.py
+++ b/src/openbad/memory/sleep/orchestrator.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 from openbad.cognitive.config import CognitiveSystem
 from openbad.cognitive.event_loop import CognitiveEventLoop, CognitiveRequest
 from openbad.cognitive.model_router import Priority
-from openbad.memory.forgetting import prune_store
+from openbad.memory.forgetting import prune_consolidated_episodic, prune_store
 from openbad.memory.sleep.prompts import (
     EXTRACT_TAGS,
     SCORE_IMPORTANCE,
@@ -50,6 +50,7 @@ class MemoryPruner:
     memory_controller: MemoryController
     threshold: float = 0.1
     half_life_hours: float = 168.0
+    episodic_retention_days: float = 7.0
 
     def run(self) -> int:
         """Prune decayed entries from episodic and semantic stores.
@@ -71,6 +72,13 @@ class MemoryPruner:
                 self.memory_controller.semantic,
                 threshold=self.threshold,
                 half_life_hours=self.half_life_hours,
+                now=now,
+            )
+        )
+        total += len(
+            prune_consolidated_episodic(
+                self.memory_controller.episodic,
+                retention_days=self.episodic_retention_days,
                 now=now,
             )
         )

--- a/tests/test_forgetting.py
+++ b/tests/test_forgetting.py
@@ -6,7 +6,13 @@ import math
 import time
 
 from openbad.memory.base import MemoryEntry, MemoryTier
-from openbad.memory.forgetting import prune_store, rank_by_retention, retention_score
+from openbad.memory.episodic import EpisodicMemory
+from openbad.memory.forgetting import (
+    prune_consolidated_episodic,
+    prune_store,
+    rank_by_retention,
+    retention_score,
+)
 from openbad.memory.stm import ShortTermMemory
 
 
@@ -232,6 +238,87 @@ class TestRankByRetention:
         ranked = rank_by_retention(stm, now=now)
         scores = [s for _, s in ranked]
         assert scores == sorted(scores)
+
+
+# ------------------------------------------------------------------ #
+# prune_consolidated_episodic
+# ------------------------------------------------------------------ #
+
+
+class TestPruneConsolidatedEpisodic:
+    def test_consolidated_within_window_survives(self) -> None:
+        store = EpisodicMemory()
+        now = time.time()
+        # 3 days old, consolidated — within default 7-day window
+        store.write(_entry(
+            key="recent",
+            created_at=now - 3 * 86400,
+            metadata={"consolidated": True},
+        ))
+        pruned = prune_consolidated_episodic(store, retention_days=7.0, now=now)
+        assert pruned == []
+        assert store.size() == 1
+
+    def test_consolidated_past_window_deleted(self) -> None:
+        store = EpisodicMemory()
+        now = time.time()
+        # 10 days old, consolidated — past 7-day window
+        store.write(_entry(
+            key="old",
+            created_at=now - 10 * 86400,
+            metadata={"consolidated": True},
+        ))
+        pruned = prune_consolidated_episodic(store, retention_days=7.0, now=now)
+        assert "old" in pruned
+        assert store.size() == 0
+
+    def test_unconsolidated_old_entry_untouched(self) -> None:
+        store = EpisodicMemory()
+        now = time.time()
+        # 10 days old but NOT consolidated — must survive
+        store.write(_entry(
+            key="not_consolidated",
+            created_at=now - 10 * 86400,
+        ))
+        pruned = prune_consolidated_episodic(store, retention_days=7.0, now=now)
+        assert pruned == []
+        assert store.size() == 1
+
+    def test_custom_retention_period(self) -> None:
+        store = EpisodicMemory()
+        now = time.time()
+        # 2 days old, consolidated — survives with 7-day window
+        store.write(_entry(
+            key="a",
+            created_at=now - 2 * 86400,
+            metadata={"consolidated": True},
+        ))
+        assert prune_consolidated_episodic(store, retention_days=7.0, now=now) == []
+        # But NOT with 1-day window
+        pruned = prune_consolidated_episodic(store, retention_days=1.0, now=now)
+        assert "a" in pruned
+
+    def test_mixed_entries(self) -> None:
+        store = EpisodicMemory()
+        now = time.time()
+        old = now - 10 * 86400
+        store.write(_entry(
+            key="old_consolidated",
+            created_at=old,
+            metadata={"consolidated": True},
+        ))
+        store.write(_entry(
+            key="old_raw",
+            created_at=old,
+        ))
+        store.write(_entry(
+            key="fresh_consolidated",
+            created_at=now,
+            metadata={"consolidated": True},
+        ))
+        pruned = prune_consolidated_episodic(store, retention_days=7.0, now=now)
+        assert pruned == ["old_consolidated"]
+        assert store.size() == 2
 
     def test_empty_store_ranks_empty(self) -> None:
         stm = ShortTermMemory(max_tokens=100000, default_ttl=None)

--- a/tests/test_memory_base.py
+++ b/tests/test_memory_base.py
@@ -177,6 +177,7 @@ class TestMemoryConfig:
         assert cfg.ltm_backend == "json"
         assert cfg.pruning_interval_seconds == 3600.0
         assert cfg.forgetting_half_life_hours == 168.0
+        assert cfg.episodic_retention_days == 7.0
 
     def test_from_yaml(self, tmp_path) -> None:
         from openbad.memory.config import MemoryConfig
@@ -211,3 +212,17 @@ class TestMemoryConfig:
         yaml_file.write_text("")
         cfg = MemoryConfig.from_yaml(yaml_file)
         assert cfg.stm_max_tokens == 32768  # defaults
+        assert cfg.episodic_retention_days == 7.0
+
+    def test_episodic_retention_days_from_yaml(self, tmp_path) -> None:
+        from openbad.memory.config import MemoryConfig
+        data = {"memory": {"episodic_retention_days": 14.0}}
+        yaml_file = tmp_path / "ret.yaml"
+        yaml_file.write_text(yaml.dump(data))
+        cfg = MemoryConfig.from_yaml(yaml_file)
+        assert cfg.episodic_retention_days == 14.0
+
+    def test_episodic_retention_days_to_dict(self) -> None:
+        from openbad.memory.config import MemoryConfig
+        cfg = MemoryConfig(episodic_retention_days=3.0)
+        assert cfg.to_dict()["episodic_retention_days"] == 3.0


### PR DESCRIPTION
Closes #224

## Summary
Adds a configurable retention period for consolidated episodic entries before hard-deleting them: a safety net so originals remain recoverable if summarization loses detail.

### Changes
- **`src/openbad/memory/config.py`**: Added `episodic_retention_days: float = 7.0` to `MemoryConfig`, with YAML loading and serialization.
- **`src/openbad/memory/forgetting.py`**: New `prune_consolidated_episodic()` — deletes entries where `consolidated=True` and age exceeds retention window.
- **`src/openbad/memory/sleep/orchestrator.py`**: `MemoryPruner` now accepts `episodic_retention_days` and calls the new pruning function during sleep cycles.
- **`config/memory.yaml`**: Added `episodic_retention_days: 7.0` default.
- **Tests**: 5 new tests for `prune_consolidated_episodic` (within window survives, past window deleted, unconsolidated untouched, custom period, mixed entries) + 3 config tests (default, YAML load, to_dict).

### Validation
```bash
pytest tests/test_forgetting.py tests/test_memory_base.py  # 46 passed
ruff check  # All checks passed
```