### PR TITLE
#225: Default Sleep system to ollama/bonsai-8b and add sleep schedule config

### DIFF
--- a/src/openbad/memory/sleep/schedule.py
+++ b/src/openbad/memory/sleep/schedule.py
@@ -1,0 +1,193 @@
+"""Sleep schedule configuration and scheduler.
+
+Provides a ``SleepScheduleConfig`` dataclass and an async
+``SleepScheduler`` that triggers FSM sleep/wake transitions
+based on a daily time window.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from openbad.cognitive.config import CognitiveSystem
+from openbad.cognitive.event_loop import CognitiveRequest, CognitiveResponse
+
+logger = logging.getLogger(__name__)
+
+# Systems that are blocked during sleep (only SLEEP is allowed).
+_BLOCKED_SYSTEMS = frozenset({
+    CognitiveSystem.CHAT,
+    CognitiveSystem.REASONING,
+    CognitiveSystem.REACTIONS,
+})
+
+
+@dataclass
+class SleepScheduleConfig:
+    """User-configurable sleep schedule."""
+
+    start_hour: int = 2
+    duration_hours: float = 3.0
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.start_hour <= 23:
+            raise ValueError(f"start_hour must be 0–23, got {self.start_hour}")
+        if self.duration_hours <= 0 or self.duration_hours > 24:
+            raise ValueError(
+                f"duration_hours must be in (0, 24], got {self.duration_hours}",
+            )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SleepScheduleConfig:
+        return cls(
+            start_hour=int(data.get("start_hour", 2)),
+            duration_hours=float(data.get("duration_hours", 3.0)),
+            enabled=bool(data.get("enabled", True)),
+        )
+
+    def is_in_window(self, now: datetime | None = None) -> bool:
+        """Check if the given time falls within the sleep window."""
+        if not self.enabled:
+            return False
+        if now is None:
+            now = datetime.now(tz=UTC)
+        current_hour = now.hour + now.minute / 60.0
+        end_hour = self.start_hour + self.duration_hours
+        if end_hour <= 24:
+            return self.start_hour <= current_hour < end_hour
+        # Wraps past midnight: e.g. 23:00 → 02:00
+        return current_hour >= self.start_hour or current_hour < (end_hour - 24)
+
+    def seconds_until_start(self, now: datetime | None = None) -> float:
+        """Seconds until the next sleep window start."""
+        if now is None:
+            now = datetime.now(tz=UTC)
+        current_seconds = now.hour * 3600 + now.minute * 60 + now.second
+        start_seconds = self.start_hour * 3600
+        diff = start_seconds - current_seconds
+        if diff <= 0:
+            diff += 86400
+        return float(diff)
+
+    def window_remaining(self, now: datetime | None = None) -> float:
+        """Seconds remaining in the current sleep window, or 0 if not in window."""
+        if not self.is_in_window(now):
+            return 0.0
+        if now is None:
+            now = datetime.now(tz=UTC)
+        current_seconds = now.hour * 3600 + now.minute * 60 + now.second
+        end_seconds = (self.start_hour * 3600) + (self.duration_hours * 3600)
+        if end_seconds > 86400:
+            # Wraps past midnight
+            if current_seconds >= self.start_hour * 3600:
+                remaining = end_seconds - current_seconds
+            else:
+                remaining = (end_seconds - 86400) - current_seconds
+        else:
+            remaining = end_seconds - current_seconds
+        return max(0.0, remaining)
+
+
+class SleepScheduler:
+    """Async scheduler that triggers FSM sleep/wake transitions on schedule.
+
+    Parameters
+    ----------
+    config:
+        The sleep schedule configuration.
+    fsm:
+        The agent FSM with ``fire("sleep")`` and ``fire("wake")`` methods.
+    orchestrator:
+        Optional SleepOrchestrator to run a consolidation cycle during sleep.
+    """
+
+    def __init__(
+        self,
+        config: SleepScheduleConfig,
+        fsm: Any,
+        orchestrator: Any = None,
+    ) -> None:
+        self._config = config
+        self._fsm = fsm
+        self._orchestrator = orchestrator
+        self._sleeping = False
+        self._task: asyncio.Task[None] | None = None
+        self._manual_wake = False
+
+    @property
+    def sleeping(self) -> bool:
+        return self._sleeping
+
+    def manual_wake(self) -> bool:
+        """Emergency wake override — breaks sleep immediately.
+
+        Returns True if the agent was sleeping and is now waking.
+        """
+        if not self._sleeping:
+            return False
+        self._manual_wake = True
+        self._sleeping = False
+        self._fsm.fire("wake")
+        logger.info("Manual wake override triggered")
+        return True
+
+    async def start(self, check_interval: float = 60.0) -> None:
+        """Run the scheduler loop."""
+        if not self._config.enabled:
+            logger.info("Sleep schedule disabled")
+            return
+
+        try:
+            while True:
+                await asyncio.sleep(check_interval)
+                now = datetime.now(tz=UTC)
+
+                if self._manual_wake:
+                    self._manual_wake = False
+                    continue
+
+                if self._config.is_in_window(now) and not self._sleeping:
+                    self._enter_sleep()
+                elif not self._config.is_in_window(now) and self._sleeping:
+                    self._exit_sleep()
+        except asyncio.CancelledError:
+            if self._sleeping:
+                self._exit_sleep()
+            logger.info("Sleep scheduler cancelled")
+
+    def _enter_sleep(self) -> None:
+        self._sleeping = True
+        self._fsm.fire("sleep")
+        logger.info("Scheduled sleep started (hour=%d)", self._config.start_hour)
+        if self._orchestrator is not None:
+            asyncio.ensure_future(self._orchestrator.run_cycle())
+
+    def _exit_sleep(self) -> None:
+        self._sleeping = False
+        self._fsm.fire("wake")
+        logger.info("Scheduled sleep ended")
+
+
+def sleep_gate(
+    request: CognitiveRequest,
+    scheduler: SleepScheduler,
+) -> CognitiveResponse | None:
+    """Reject non-SLEEP cognitive requests while the agent is sleeping.
+
+    Returns a ``CognitiveResponse`` with an error if the request should be
+    blocked, or ``None`` to allow it through.
+    """
+    if not scheduler.sleeping:
+        return None
+    if request.system not in _BLOCKED_SYSTEMS:
+        return None
+    return CognitiveResponse(
+        request_id=request.request_id,
+        answer="",
+        error="Agent is in scheduled sleep — request rejected",
+    )

--- a/tests/test_sleep_schedule.py
+++ b/tests/test_sleep_schedule.py
@@ -1,0 +1,208 @@
+"""Tests for sleep schedule configuration and scheduler."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from openbad.cognitive.config import CognitiveSystem
+from openbad.cognitive.event_loop import CognitiveRequest
+from openbad.memory.sleep.schedule import (
+    SleepScheduleConfig,
+    SleepScheduler,
+    sleep_gate,
+)
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+
+class FakeFSM:
+    """Minimal FSM stub that records transitions."""
+
+    def __init__(self) -> None:
+        self.state = "IDLE"
+        self.history: list[str] = []
+
+    def fire(self, trigger: str) -> bool:
+        self.history.append(trigger)
+        if trigger == "sleep":
+            self.state = "SLEEP"
+        elif trigger == "wake":
+            self.state = "IDLE"
+        return True
+
+
+def _dt(hour: int, minute: int = 0) -> datetime:
+    return datetime(2025, 6, 15, hour, minute, tzinfo=UTC)
+
+
+# ------------------------------------------------------------------ #
+# SleepScheduleConfig
+# ------------------------------------------------------------------ #
+
+
+class TestSleepScheduleConfig:
+    def test_defaults(self) -> None:
+        cfg = SleepScheduleConfig()
+        assert cfg.start_hour == 2
+        assert cfg.duration_hours == 3.0
+        assert cfg.enabled is True
+
+    def test_from_dict(self) -> None:
+        cfg = SleepScheduleConfig.from_dict({
+            "start_hour": 23,
+            "duration_hours": 4.0,
+            "enabled": False,
+        })
+        assert cfg.start_hour == 23
+        assert cfg.duration_hours == 4.0
+        assert cfg.enabled is False
+
+    def test_invalid_start_hour(self) -> None:
+        with pytest.raises(ValueError, match="start_hour"):
+            SleepScheduleConfig(start_hour=25)
+
+    def test_invalid_duration(self) -> None:
+        with pytest.raises(ValueError, match="duration_hours"):
+            SleepScheduleConfig(duration_hours=0)
+
+    def test_is_in_window_inside(self) -> None:
+        cfg = SleepScheduleConfig(start_hour=2, duration_hours=3.0)
+        assert cfg.is_in_window(_dt(3, 0)) is True
+
+    def test_is_in_window_outside(self) -> None:
+        cfg = SleepScheduleConfig(start_hour=2, duration_hours=3.0)
+        assert cfg.is_in_window(_dt(6, 0)) is False
+
+    def test_is_in_window_at_boundary_start(self) -> None:
+        cfg = SleepScheduleConfig(start_hour=2, duration_hours=3.0)
+        assert cfg.is_in_window(_dt(2, 0)) is True
+
+    def test_is_in_window_at_boundary_end(self) -> None:
+        cfg = SleepScheduleConfig(start_hour=2, duration_hours=3.0)
+        # 05:00 is NOT in the window (end exclusive)
+        assert cfg.is_in_window(_dt(5, 0)) is False
+
+    def test_is_in_window_wrap_midnight(self) -> None:
+        cfg = SleepScheduleConfig(start_hour=23, duration_hours=4.0)
+        assert cfg.is_in_window(_dt(23, 30)) is True
+        assert cfg.is_in_window(_dt(1, 0)) is True
+        assert cfg.is_in_window(_dt(4, 0)) is False
+
+    def test_disabled_never_in_window(self) -> None:
+        cfg = SleepScheduleConfig(start_hour=2, enabled=False)
+        assert cfg.is_in_window(_dt(3, 0)) is False
+
+    def test_seconds_until_start(self) -> None:
+        cfg = SleepScheduleConfig(start_hour=2)
+        # At 01:00, 1 hour until 02:00
+        assert cfg.seconds_until_start(_dt(1, 0)) == 3600.0
+
+    def test_seconds_until_start_wrap(self) -> None:
+        cfg = SleepScheduleConfig(start_hour=2)
+        # At 03:00, ~23 hours until next 02:00
+        assert cfg.seconds_until_start(_dt(3, 0)) == 23 * 3600.0
+
+
+# ------------------------------------------------------------------ #
+# SleepScheduler FSM transitions
+# ------------------------------------------------------------------ #
+
+
+class TestSleepSchedulerTransitions:
+    def test_entering_sleep_fires_fsm(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig(start_hour=2, duration_hours=3.0)
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        scheduler._enter_sleep()
+        assert fsm.state == "SLEEP"
+        assert "sleep" in fsm.history
+        assert scheduler.sleeping is True
+
+    def test_exiting_sleep_fires_wake(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig(start_hour=2, duration_hours=3.0)
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        scheduler._enter_sleep()
+        scheduler._exit_sleep()
+        assert fsm.state == "IDLE"
+        assert "wake" in fsm.history
+        assert scheduler.sleeping is False
+
+    def test_manual_wake_override(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig(start_hour=2, duration_hours=3.0)
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        scheduler._enter_sleep()
+        assert scheduler.manual_wake() is True
+        assert fsm.state == "IDLE"
+        assert scheduler.sleeping is False
+
+    def test_manual_wake_when_not_sleeping(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig(start_hour=2, duration_hours=3.0)
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        assert scheduler.manual_wake() is False
+
+
+# ------------------------------------------------------------------ #
+# sleep_gate
+# ------------------------------------------------------------------ #
+
+
+class TestSleepGate:
+    def _req(self, system: CognitiveSystem) -> CognitiveRequest:
+        return CognitiveRequest(
+            request_id="test",
+            prompt="hello",
+            system=system,
+        )
+
+    def test_allows_when_not_sleeping(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig()
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        assert sleep_gate(self._req(CognitiveSystem.CHAT), scheduler) is None
+
+    def test_blocks_chat_during_sleep(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig()
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        scheduler._enter_sleep()
+        resp = sleep_gate(self._req(CognitiveSystem.CHAT), scheduler)
+        assert resp is not None
+        assert "sleep" in resp.error.lower()
+
+    def test_blocks_reasoning_during_sleep(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig()
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        scheduler._enter_sleep()
+        resp = sleep_gate(self._req(CognitiveSystem.REASONING), scheduler)
+        assert resp is not None
+
+    def test_blocks_reactions_during_sleep(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig()
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        scheduler._enter_sleep()
+        resp = sleep_gate(self._req(CognitiveSystem.REACTIONS), scheduler)
+        assert resp is not None
+
+    def test_allows_sleep_system_during_sleep(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig()
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        scheduler._enter_sleep()
+        assert sleep_gate(self._req(CognitiveSystem.SLEEP), scheduler) is None
+
+    def test_allows_after_manual_wake(self) -> None:
+        fsm = FakeFSM()
+        cfg = SleepScheduleConfig()
+        scheduler = SleepScheduler(config=cfg, fsm=fsm)
+        scheduler._enter_sleep()
+        scheduler.manual_wake()
+        assert sleep_gate(self._req(CognitiveSystem.CHAT), scheduler) is None


### PR DESCRIPTION
Closes #225

## Summary
Adds a configurable daily sleep schedule with FSM-integrated transitions and cognitive request gating.

### Changes
- **`src/openbad/memory/sleep/schedule.py`** (new):
  - `SleepScheduleConfig` dataclass: `start_hour`, `duration_hours`, `enabled` with validation, `from_dict()`, `is_in_window()`, `seconds_until_start()`, `window_remaining()`
  - `SleepScheduler`: async scheduler that triggers FSM `sleep`/`wake` transitions, runs consolidation during sleep, supports `manual_wake()` for emergency override
  - `sleep_gate()`: rejects CHAT/REASONING/REACTIONS requests during sleep, allows SLEEP system through
- **`config/cognitive.yaml`**: Already has `sleep: ollama/bonsai-8b` (AC #1 met)
- **`tests/test_sleep_schedule.py`**: 22 tests covering config parsing, validation, window detection (including midnight wrap), FSM transitions, manual wake, and sleep gate behavior

### Validation
```bash
pytest tests/test_sleep_schedule.py  # 22 passed
ruff check  # All checks passed
```