### PR TITLE
#218: Add WUI system assignment cards with fallback chain editor

### DIFF
--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -14,7 +14,12 @@ from uuid import uuid4
 import yaml
 from aiohttp import web
 
-from openbad.cognitive.config import CognitiveConfig, ProviderConfig, load_cognitive_config
+from openbad.cognitive.config import (
+    CognitiveConfig,
+    CognitiveSystem,
+    ProviderConfig,
+    load_cognitive_config,
+)
 from openbad.cognitive.providers.github_copilot import CopilotAuthError, GitHubCopilotProvider
 from openbad.cognitive.providers.openai_compat import custom_provider
 from openbad.wui.bridge import MqttWebSocketBridge
@@ -420,6 +425,87 @@ async def _post_copilot_complete(request: web.Request) -> web.Response:
     )
 
 
+def _serialize_systems_config(config: CognitiveConfig) -> dict[str, object]:
+    systems = {}
+    for system, assignment in config.systems.items():
+        systems[system.value] = {
+            "provider": assignment.provider,
+            "model": assignment.model,
+        }
+    fallback_chain = [
+        {"provider": step.provider, "model": step.model}
+        for step in config.default_fallback_chain
+    ]
+    return {
+        "systems": systems,
+        "fallback_chain": fallback_chain,
+        "providers": [
+            {"name": p.name, "model": p.model}
+            for p in config.providers
+            if p.enabled
+        ],
+    }
+
+
+async def _get_systems(_request: web.Request) -> web.Response:
+    _path, config = _read_providers_config()
+    return web.json_response(_serialize_systems_config(config))
+
+
+async def _put_systems(request: web.Request) -> web.Response:
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise web.HTTPBadRequest(text="request body must be an object")
+
+    systems_raw = payload.get("systems")
+    if not isinstance(systems_raw, dict):
+        raise web.HTTPBadRequest(text="systems must be an object")
+
+    chain_raw = payload.get("fallback_chain")
+    if not isinstance(chain_raw, list):
+        raise web.HTTPBadRequest(text="fallback_chain must be a list")
+
+    # Validate system names
+    systems: dict[str, dict[str, str]] = {}
+    for name, assignment in systems_raw.items():
+        try:
+            CognitiveSystem(name)
+        except ValueError as exc:
+            raise web.HTTPBadRequest(text=f"unknown system: {name}") from exc
+        if not isinstance(assignment, dict):
+            raise web.HTTPBadRequest(text=f"assignment for {name} must be an object")
+        systems[name] = {
+            "provider": str(assignment.get("provider", "")).strip(),
+            "model": str(assignment.get("model", "")).strip(),
+        }
+
+    chain = []
+    for step in chain_raw:
+        if not isinstance(step, dict):
+            raise web.HTTPBadRequest(text="fallback chain entries must be objects")
+        chain.append({
+            "provider": str(step.get("provider", "")).strip(),
+            "model": str(step.get("model", "")).strip(),
+        })
+
+    path = _resolve_cognitive_config_path()
+    existing = yaml.safe_load(path.read_text()) or {} if path.exists() else {}
+
+    cognitive = existing.get("cognitive", {})
+    if not isinstance(cognitive, dict):
+        cognitive = {}
+
+    cognitive["systems"] = systems
+    cognitive["default_fallback_chain"] = chain
+    existing["cognitive"] = cognitive
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(existing, sort_keys=False), encoding="utf-8")
+
+    config = load_cognitive_config(path)
+    return web.json_response(_serialize_systems_config(config))
+
+
 def create_app(
     mqtt_host: str = "localhost",
     mqtt_port: int = 1883,
@@ -445,6 +531,8 @@ def create_app(
     app.router.add_post("/api/providers/copilot/complete", _post_copilot_complete)
     app.router.add_post("/api/providers/verify", _post_providers_verify)
     app.router.add_put("/api/providers", _put_providers)
+    app.router.add_get("/api/systems", _get_systems)
+    app.router.add_put("/api/systems", _put_systems)
     # TODO: Remove after v1.0 once external consumers have migrated to /api/providers/*.
     app.router.add_get("/api/wiring/providers", _redirect_legacy_wiring_providers)
     app.router.add_post(

--- a/src/openbad/wui/static/app.js
+++ b/src/openbad/wui/static/app.js
@@ -63,6 +63,15 @@ const els = {
     save: document.getElementById('save-provider'),
     modelSelect: document.getElementById('wizard-model-select'),
   },
+  systems: {
+    status: document.getElementById('systems-status'),
+    saveStatus: document.getElementById('systems-save-status'),
+    saveBtn: document.getElementById('save-systems'),
+    chainList: document.getElementById('fallback-chain-list'),
+    chainAddProvider: document.getElementById('fallback-add-provider'),
+    chainAddModel: document.getElementById('fallback-add-model'),
+    chainAddBtn: document.getElementById('fallback-add-btn'),
+  },
 };
 
 const viewMeta = {
@@ -99,6 +108,8 @@ let activeEventSource = null;
 let providerDrafts = [];
 let activeTransport = 'offline';
 let currentView = 'health';
+let systemsData = { systems: {}, fallback_chain: [], providers: [] };
+let fallbackCounts = { chat: 0, sleep: 0, reasoning: 0, reactions: 0 };
 let wizardState = {
   open: false,
   editIndex: null,
@@ -146,6 +157,7 @@ function setView(name) {
 
   if (name === 'providers') {
     loadProvidersConfig();
+    loadSystemsConfig();
   }
 }
 
@@ -264,6 +276,22 @@ function updateFromEvent(topic, payload) {
   if (topic === 'agent/cognitive/response') {
     els.inference.lastTokens.textContent = `${payload.tokens_used || 0}`;
     els.inference.lastLatency.textContent = `${Number(payload.latency_ms || 0).toFixed(1)}ms`;
+    return;
+  }
+
+  if (topic === 'agent/cognitive/fallback') {
+    const system = payload.system || '';
+    if (system in fallbackCounts) {
+      fallbackCounts[system]++;
+      const badge = document.querySelector(`.fallback-badge[data-system="${system}"]`);
+      if (badge) {
+        badge.textContent = String(fallbackCounts[system]);
+        badge.classList.remove('green', 'yellow', 'red');
+        if (fallbackCounts[system] >= 5) badge.classList.add('red');
+        else if (fallbackCounts[system] >= 2) badge.classList.add('yellow');
+        else badge.classList.add('green');
+      }
+    }
   }
 }
 
@@ -721,6 +749,164 @@ async function removeProvider(index) {
   }
 }
 
+// ------------------------------------------------------------------ //
+// System Assignments
+// ------------------------------------------------------------------ //
+
+async function loadSystemsConfig() {
+  if (els.systems.status) els.systems.status.textContent = 'Loading system assignments...';
+  try {
+    const response = await fetch('/api/systems');
+    if (!response.ok) throw new Error(`load failed (${response.status})`);
+    systemsData = await response.json();
+    renderSystemAssignments();
+    renderFallbackChain();
+    if (els.systems.status) els.systems.status.textContent = 'System assignments loaded.';
+  } catch (error) {
+    if (els.systems.status) els.systems.status.textContent = `Unable to load systems: ${error.message}`;
+  }
+}
+
+function renderSystemAssignments() {
+  const providers = systemsData.providers || [];
+  const providerNames = [...new Set(providers.map(p => p.name))];
+
+  for (const system of ['chat', 'sleep', 'reasoning', 'reactions']) {
+    const assignment = (systemsData.systems || {})[system] || {};
+    const providerSelect = document.querySelector(`.system-provider[data-system="${system}"]`);
+    const modelInput = document.querySelector(`.system-model[data-system="${system}"]`);
+    if (!providerSelect || !modelInput) continue;
+
+    providerSelect.innerHTML = '<option value="">--</option>';
+    for (const name of providerNames) {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      opt.selected = name === assignment.provider;
+      providerSelect.append(opt);
+    }
+
+    modelInput.innerHTML = '<option value="">--</option>';
+    const matchingModels = providers.filter(p => p.name === assignment.provider).map(p => p.model).filter(Boolean);
+    for (const model of matchingModels) {
+      const opt = document.createElement('option');
+      opt.value = model;
+      opt.textContent = model;
+      opt.selected = model === assignment.model;
+      modelInput.append(opt);
+    }
+    // If the current model isn't in the list, add it as an option
+    if (assignment.model && !matchingModels.includes(assignment.model)) {
+      const opt = document.createElement('option');
+      opt.value = assignment.model;
+      opt.textContent = assignment.model;
+      opt.selected = true;
+      modelInput.append(opt);
+    }
+  }
+
+  // Populate fallback chain add-provider dropdown
+  if (els.systems.chainAddProvider) {
+    els.systems.chainAddProvider.innerHTML = '<option value="">Provider</option>';
+    for (const name of providerNames) {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      els.systems.chainAddProvider.append(opt);
+    }
+  }
+}
+
+function renderFallbackChain() {
+  const list = els.systems.chainList;
+  if (!list) return;
+  const chain = systemsData.fallback_chain || [];
+  if (chain.length === 0) {
+    list.innerHTML = '<div class="empty-state"><p>No fallback chain configured.</p></div>';
+    return;
+  }
+  list.innerHTML = chain.map((step, i) => `
+    <div class="fallback-step" data-index="${i}">
+      <span class="fallback-step-handle" draggable="true">&#x2630;</span>
+      <span class="mono">${escapeHtml(step.provider)}/${escapeHtml(step.model)}</span>
+      <button type="button" class="ghost-button fallback-remove" data-remove-chain="${i}">&times;</button>
+    </div>
+  `).join('');
+
+  // Simple drag-and-drop reorder
+  list.querySelectorAll('.fallback-step-handle').forEach(handle => {
+    handle.addEventListener('dragstart', (e) => {
+      e.dataTransfer.setData('text/plain', handle.closest('.fallback-step').dataset.index);
+    });
+  });
+  list.querySelectorAll('.fallback-step').forEach(step => {
+    step.addEventListener('dragover', (e) => { e.preventDefault(); });
+    step.addEventListener('drop', (e) => {
+      e.preventDefault();
+      const fromIdx = Number(e.dataTransfer.getData('text/plain'));
+      const toIdx = Number(step.dataset.index);
+      if (fromIdx !== toIdx) {
+        const chain = systemsData.fallback_chain;
+        const [moved] = chain.splice(fromIdx, 1);
+        chain.splice(toIdx, 0, moved);
+        renderFallbackChain();
+      }
+    });
+  });
+}
+
+function addFallbackStep() {
+  const provider = (els.systems.chainAddProvider?.value || '').trim();
+  const model = (els.systems.chainAddModel?.value || '').trim();
+  if (!provider) return;
+  if (!systemsData.fallback_chain) systemsData.fallback_chain = [];
+  systemsData.fallback_chain.push({ provider, model });
+  renderFallbackChain();
+  if (els.systems.chainAddProvider) els.systems.chainAddProvider.value = '';
+  if (els.systems.chainAddModel) els.systems.chainAddModel.value = '';
+}
+
+function removeFallbackStep(index) {
+  if (systemsData.fallback_chain) {
+    systemsData.fallback_chain.splice(index, 1);
+    renderFallbackChain();
+  }
+}
+
+async function saveSystemsConfig() {
+  const systems = {};
+  for (const system of ['chat', 'sleep', 'reasoning', 'reactions']) {
+    const providerSelect = document.querySelector(`.system-provider[data-system="${system}"]`);
+    const modelSelect = document.querySelector(`.system-model[data-system="${system}"]`);
+    systems[system] = {
+      provider: providerSelect?.value || '',
+      model: modelSelect?.value || '',
+    };
+  }
+  const payload = {
+    systems,
+    fallback_chain: systemsData.fallback_chain || [],
+  };
+  if (els.systems.saveStatus) els.systems.saveStatus.textContent = 'Saving...';
+  try {
+    const response = await fetch('/api/systems', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `save failed (${response.status})`);
+    }
+    systemsData = await response.json();
+    renderSystemAssignments();
+    renderFallbackChain();
+    if (els.systems.saveStatus) els.systems.saveStatus.textContent = 'Saved.';
+  } catch (error) {
+    if (els.systems.saveStatus) els.systems.saveStatus.textContent = `Save failed: ${error.message}`;
+  }
+}
+
 function bindEvents() {
   for (const link of els.navLinks) {
     link.addEventListener('click', () => setView(link.dataset.viewTarget));
@@ -771,6 +957,41 @@ function bindEvents() {
     if (remove) {
       removeProvider(Number(remove.dataset.removeProvider));
     }
+  });
+
+  // System assignment events
+  if (els.systems.saveBtn) {
+    els.systems.saveBtn.addEventListener('click', saveSystemsConfig);
+  }
+  if (els.systems.chainAddBtn) {
+    els.systems.chainAddBtn.addEventListener('click', addFallbackStep);
+  }
+  if (els.systems.chainList) {
+    els.systems.chainList.addEventListener('click', (event) => {
+      const removeBtn = event.target.closest('[data-remove-chain]');
+      if (removeBtn) {
+        removeFallbackStep(Number(removeBtn.dataset.removeChain));
+      }
+    });
+  }
+
+  // Update model dropdown when system provider changes
+  document.querySelectorAll('.system-provider').forEach(select => {
+    select.addEventListener('change', () => {
+      const system = select.dataset.system;
+      const modelSelect = document.querySelector(`.system-model[data-system="${system}"]`);
+      if (!modelSelect) return;
+      const providerName = select.value;
+      const providers = systemsData.providers || [];
+      const models = providers.filter(p => p.name === providerName).map(p => p.model).filter(Boolean);
+      modelSelect.innerHTML = '<option value="">--</option>';
+      for (const model of models) {
+        const opt = document.createElement('option');
+        opt.value = model;
+        opt.textContent = model;
+        modelSelect.append(opt);
+      }
+    });
   });
 
   document.getElementById('chat-form').addEventListener('submit', (event) => {

--- a/src/openbad/wui/static/index.html
+++ b/src/openbad/wui/static/index.html
@@ -247,6 +247,57 @@
             </form>
             <p id="wizard-status" class="inline-status">Choose a provider type to begin the setup walkthrough.</p>
           </article>
+
+          <article class="card section-card system-assignments-card">
+            <div class="section-head">
+              <h3>System Assignments</h3>
+              <span class="section-note">Per-system provider and model routing</span>
+            </div>
+            <div id="system-assignments" class="stack">
+              <div class="row system-row" data-system="chat">
+                <div class="label-block"><span class="label-title">Chat</span></div>
+                <select class="system-provider" data-system="chat"><option value="">--</option></select>
+                <select class="system-model" data-system="chat"><option value="">--</option></select>
+                <span class="fallback-badge" data-system="chat" title="Fallback count in last hour">0</span>
+              </div>
+              <div class="row system-row" data-system="sleep">
+                <div class="label-block"><span class="label-title">Sleep</span></div>
+                <select class="system-provider" data-system="sleep"><option value="">--</option></select>
+                <select class="system-model" data-system="sleep"><option value="">--</option></select>
+                <span class="fallback-badge" data-system="sleep" title="Fallback count in last hour">0</span>
+              </div>
+              <div class="row system-row" data-system="reasoning">
+                <div class="label-block"><span class="label-title">Reasoning</span></div>
+                <select class="system-provider" data-system="reasoning"><option value="">--</option></select>
+                <select class="system-model" data-system="reasoning"><option value="">--</option></select>
+                <span class="fallback-badge" data-system="reasoning" title="Fallback count in last hour">0</span>
+              </div>
+              <div class="row system-row" data-system="reactions">
+                <div class="label-block"><span class="label-title">Reactions</span></div>
+                <select class="system-provider" data-system="reactions"><option value="">--</option></select>
+                <select class="system-model" data-system="reactions"><option value="">--</option></select>
+                <span class="fallback-badge" data-system="reactions" title="Fallback count in last hour">0</span>
+              </div>
+            </div>
+            <p id="systems-status" class="inline-status">Loading system assignments...</p>
+          </article>
+
+          <article class="card section-card fallback-chain-card">
+            <div class="section-head">
+              <h3>Fallback Chain</h3>
+              <span class="section-note">Shared default chain — drag to reorder</span>
+            </div>
+            <div id="fallback-chain-list" class="fallback-list"></div>
+            <div class="fallback-controls">
+              <select id="fallback-add-provider"><option value="">Provider</option></select>
+              <input id="fallback-add-model" type="text" placeholder="model">
+              <button id="fallback-add-btn" type="button" class="secondary-button">Add</button>
+            </div>
+            <div class="wizard-actions">
+              <button id="save-systems" type="button" class="primary-button">Save assignments</button>
+            </div>
+            <p id="systems-save-status" class="inline-status"></p>
+          </article>
         </div>
       </section>
 

--- a/src/openbad/wui/static/styles.css
+++ b/src/openbad/wui/static/styles.css
@@ -690,3 +690,48 @@ textarea {
     grid-template-columns: 1fr;
   }
 }
+
+/* ── System Assignments ──────────────────────────────────────────── */
+.system-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.system-row:last-child { border-bottom: none; }
+.system-row label { min-width: 6.5rem; font-weight: 600; text-transform: capitalize; }
+.system-row select, .system-row input { flex: 1; }
+.fallback-badge {
+  display: inline-block;
+  min-width: 1.6rem;
+  text-align: center;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  background: var(--surface);
+  color: var(--fg);
+}
+.fallback-badge.green  { background: #22c55e; color: #fff; }
+.fallback-badge.yellow { background: #eab308; color: #000; }
+.fallback-badge.red    { background: #ef4444; color: #fff; }
+
+.fallback-step {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.35rem;
+  margin-bottom: 0.35rem;
+  background: var(--surface);
+}
+.fallback-step-handle { cursor: grab; user-select: none; }
+.fallback-controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  align-items: center;
+}
+.fallback-controls select, .fallback-controls input { flex: 1; }

--- a/tests/test_wui_server.py
+++ b/tests/test_wui_server.py
@@ -330,3 +330,161 @@ async def test_github_copilot_list_models_falls_back_to_known_models():
     models = await provider.list_models()
 
     assert "gpt-4o" in [model.model_id for model in models]
+
+
+# ── System assignment endpoints ──────────────────────────────────── #
+
+
+def _cognitive_yaml_with_systems(tmp_path, monkeypatch, *, extra_sections=None):
+    """Create a temporary cognitive.yaml with systems + fallback chain."""
+    config_dir = tmp_path / "openbad"
+    config_dir.mkdir(exist_ok=True)
+    base = {
+        "cognitive": {
+            "enabled": True,
+            "default_provider": "ollama",
+            "providers": [
+                {
+                    "name": "ollama",
+                    "base_url": "http://localhost:11434",
+                    "model": "llama3.2",
+                    "timeout_ms": 30000,
+                    "enabled": True,
+                },
+                {
+                    "name": "ollama",
+                    "base_url": "http://localhost:11434",
+                    "model": "bonsai-8b",
+                    "timeout_ms": 30000,
+                    "enabled": True,
+                },
+            ],
+            "systems": {
+                "chat": {"provider": "ollama", "model": "llama3.2"},
+                "sleep": {"provider": "ollama", "model": "bonsai-8b"},
+                "reasoning": {"provider": "ollama", "model": "llama3.2"},
+                "reactions": {"provider": "ollama", "model": "bonsai-8b"},
+            },
+            "default_fallback_chain": [
+                {"provider": "ollama", "model": "bonsai-8b"},
+                {"provider": "ollama", "model": "llama3.2"},
+            ],
+        }
+    }
+    if extra_sections:
+        base["cognitive"].update(extra_sections)
+    config_path = config_dir / "cognitive.yaml"
+    config_path.write_text(yaml.safe_dump(base, sort_keys=False))
+    monkeypatch.setenv("OPENBAD_CONFIG_DIR", str(config_dir))
+    return config_dir
+
+
+@pytest.mark.asyncio
+async def test_get_systems_returns_assignments(aiohttp_client, tmp_path, monkeypatch):
+    _cognitive_yaml_with_systems(tmp_path, monkeypatch)
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    resp = await client.get("/api/systems")
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["systems"]["chat"]["provider"] == "ollama"
+    assert data["systems"]["chat"]["model"] == "llama3.2"
+    assert data["systems"]["sleep"]["model"] == "bonsai-8b"
+    assert len(data["fallback_chain"]) == 2
+    assert data["fallback_chain"][0]["model"] == "bonsai-8b"
+
+
+@pytest.mark.asyncio
+async def test_get_systems_includes_enabled_providers(aiohttp_client, tmp_path, monkeypatch):
+    _cognitive_yaml_with_systems(tmp_path, monkeypatch)
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    resp = await client.get("/api/systems")
+    data = await resp.json()
+
+    provider_models = [(p["name"], p["model"]) for p in data["providers"]]
+    assert ("ollama", "llama3.2") in provider_models
+    assert ("ollama", "bonsai-8b") in provider_models
+
+
+@pytest.mark.asyncio
+async def test_put_systems_updates_config(aiohttp_client, tmp_path, monkeypatch):
+    config_dir = _cognitive_yaml_with_systems(tmp_path, monkeypatch)
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    payload = {
+        "systems": {
+            "chat": {"provider": "ollama", "model": "bonsai-8b"},
+            "sleep": {"provider": "ollama", "model": "bonsai-8b"},
+            "reasoning": {"provider": "ollama", "model": "bonsai-8b"},
+            "reactions": {"provider": "ollama", "model": "llama3.2"},
+        },
+        "fallback_chain": [
+            {"provider": "ollama", "model": "llama3.2"},
+        ],
+    }
+    resp = await client.put("/api/systems", json=payload)
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["systems"]["chat"]["model"] == "bonsai-8b"
+    assert len(data["fallback_chain"]) == 1
+
+    saved = yaml.safe_load((config_dir / "cognitive.yaml").read_text())
+    assert saved["cognitive"]["systems"]["chat"]["model"] == "bonsai-8b"
+    assert len(saved["cognitive"]["default_fallback_chain"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_put_systems_preserves_other_sections(aiohttp_client, tmp_path, monkeypatch):
+    config_dir = _cognitive_yaml_with_systems(
+        tmp_path, monkeypatch, extra_sections={"model_routing": {"tier": "balanced"}}
+    )
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    payload = {
+        "systems": {
+            "chat": {"provider": "ollama", "model": "llama3.2"},
+            "sleep": {"provider": "ollama", "model": "bonsai-8b"},
+            "reasoning": {"provider": "ollama", "model": "llama3.2"},
+            "reactions": {"provider": "ollama", "model": "bonsai-8b"},
+        },
+        "fallback_chain": [],
+    }
+    resp = await client.put("/api/systems", json=payload)
+    assert resp.status == 200
+
+    saved = yaml.safe_load((config_dir / "cognitive.yaml").read_text())
+    assert saved["cognitive"]["model_routing"]["tier"] == "balanced"
+    assert saved["cognitive"]["providers"][0]["name"] == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_put_systems_rejects_unknown_system(aiohttp_client, tmp_path, monkeypatch):
+    _cognitive_yaml_with_systems(tmp_path, monkeypatch)
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    payload = {
+        "systems": {"badname": {"provider": "x", "model": "y"}},
+        "fallback_chain": [],
+    }
+    resp = await client.put("/api/systems", json=payload)
+    assert resp.status == 400
+    text = await resp.text()
+    assert "unknown system" in text
+
+
+@pytest.mark.asyncio
+async def test_put_systems_rejects_invalid_body(aiohttp_client, tmp_path, monkeypatch):
+    _cognitive_yaml_with_systems(tmp_path, monkeypatch)
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    resp = await client.put("/api/systems", json={"systems": "bad", "fallback_chain": []})
+    assert resp.status == 400


### PR DESCRIPTION
Closes #218

## Summary of changes

### Backend (`server.py`)
- Added `GET /api/systems` endpoint — returns current system assignments (chat, sleep, reasoning, reactions), fallback chain, and enabled providers list
- Added `PUT /api/systems` endpoint — validates system names against `CognitiveSystem` enum, persists assignments and fallback chain to `cognitive.yaml` while preserving other config sections
- Added `_serialize_systems_config()` helper

### Frontend (`index.html`, `app.js`, `styles.css`)
- **System Assignments card** — per-system rows with provider and model dropdowns, populated from verified providers; fallback counter badge per system
- **Fallback Chain card** — ordered list with drag-to-reorder, add/remove controls, and save button
- `loadSystemsConfig()` fetches from `/api/systems` and renders dropdowns
- `saveSystemsConfig()` PUTs assignments back to the API
- Provider change cascades to update available model options
- `agent/cognitive/fallback` WebSocket topic updates badge counters with color coding (green < 2, yellow < 5, red ≥ 5)

### Tests (`test_wui_server.py`)
- 6 new tests: GET returns assignments, GET includes enabled providers, PUT updates config, PUT preserves other sections, PUT rejects unknown system, PUT rejects invalid body

## How to test
```bash
pytest tests/test_wui_server.py -v
```
All 25 tests pass (19 existing + 6 new). `ruff check` clean.