### PR TITLE
#226: Unify sensory config into single senses.yaml with per-modality sections

### DIFF
--- a/config/senses.yaml
+++ b/config/senses.yaml
@@ -1,0 +1,38 @@
+# Unified sensory configuration — replaces sensory_audio.yaml + sensory_vision.yaml.
+
+hearing:
+  capture:
+    sample_rate: 16000
+    channels: 1
+    sample_format: "s16le"
+    chunk_duration_ms: 100
+    device: ""
+    passive: true
+  asr:
+    vosk_model_path: ""
+    whisper_model: "base"
+    default_engine: "vosk"
+  wake_word:
+    phrases:
+      - "hey agent"
+    threshold: 0.5
+
+vision:
+  fps_idle: 1.0
+  fps_active: 5.0
+  output_format: jpeg
+  jpeg_quality: 85
+  match_source_resolution: true
+  max_width: 1920
+  max_height: 1080
+  portal_backend: ""
+  attention:
+    ssim_threshold: 0.05
+    cooldown_ms: 500
+    roi_enabled: false
+
+speech:
+  tts:
+    engine: "piper"
+    model_path: ""
+    output_device: ""

--- a/src/openbad/sensory/config.py
+++ b/src/openbad/sensory/config.py
@@ -1,0 +1,158 @@
+"""Unified sensory configuration — loads hearing, vision, speech from senses.yaml."""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from openbad.sensory.audio.config import (
+    ASRConfig,
+    AudioCaptureConfig,
+    AudioConfig,
+    TTSConfig,
+    WakeWordConfig,
+)
+from openbad.sensory.vision.config import AttentionConfig, VisionConfig
+
+# ── Speech section (wraps TTSConfig) ─────────────────────────────── #
+
+
+@dataclass
+class SpeechConfig:
+    """Speech output section of the unified sensory config."""
+
+    tts: TTSConfig = field(default_factory=TTSConfig)
+
+
+# ── Hearing section (mirrors AudioConfig minus TTS) ──────────────── #
+
+
+@dataclass
+class HearingConfig:
+    """Hearing input section of the unified sensory config."""
+
+    capture: AudioCaptureConfig = field(default_factory=AudioCaptureConfig)
+    asr: ASRConfig = field(default_factory=ASRConfig)
+    wake_word: WakeWordConfig = field(default_factory=WakeWordConfig)
+
+
+# ── Top-level unified config ─────────────────────────────────────── #
+
+
+@dataclass
+class SensoryConfig:
+    """Unified sensory configuration covering hearing, vision, and speech."""
+
+    hearing: HearingConfig = field(default_factory=HearingConfig)
+    vision: VisionConfig = field(default_factory=VisionConfig)
+    speech: SpeechConfig = field(default_factory=SpeechConfig)
+
+    def to_audio_config(self) -> AudioConfig:
+        """Return an :class:`AudioConfig` for backward-compat consumers."""
+        return AudioConfig(
+            capture=self.hearing.capture,
+            asr=self.hearing.asr,
+            wake_word=self.hearing.wake_word,
+            tts=self.speech.tts,
+        )
+
+
+# ── Helpers ───────────────────────────────────────────────────────── #
+
+
+def _filter_fields(cls: type, raw: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in raw.items() if k in cls.__dataclass_fields__}
+
+
+def _parse_hearing(raw: dict[str, Any]) -> HearingConfig:
+    capture = AudioCaptureConfig(**_filter_fields(AudioCaptureConfig, raw.get("capture", {})))
+    asr = ASRConfig(**_filter_fields(ASRConfig, raw.get("asr", {})))
+    ww = WakeWordConfig(**_filter_fields(WakeWordConfig, raw.get("wake_word", {})))
+    return HearingConfig(capture=capture, asr=asr, wake_word=ww)
+
+
+def _parse_vision(raw: dict[str, Any]) -> VisionConfig:
+    attention_raw = raw.pop("attention", {})
+    attention = AttentionConfig(**_filter_fields(AttentionConfig, attention_raw))
+    fields = {
+        k: v for k, v in raw.items()
+        if k in VisionConfig.__dataclass_fields__ and k != "attention"
+    }
+    return VisionConfig(**fields, attention=attention)
+
+
+def _parse_speech(raw: dict[str, Any]) -> SpeechConfig:
+    tts = TTSConfig(**_filter_fields(TTSConfig, raw.get("tts", {})))
+    return SpeechConfig(tts=tts)
+
+
+def _merge_legacy(
+    base: dict[str, Any],
+    config_dir: Path,
+) -> dict[str, Any]:
+    """Merge deprecated per-file configs into *base* and emit warnings."""
+    audio_path = config_dir / "sensory_audio.yaml"
+    if audio_path.exists():
+        warnings.warn(
+            "sensory_audio.yaml is deprecated — migrate settings to senses.yaml",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        audio_raw: dict[str, Any] = yaml.safe_load(audio_path.read_text()) or {}
+        audio_section = audio_raw.get("audio", audio_raw)
+        # Map audio sections into hearing + speech
+        hearing = base.setdefault("hearing", {})
+        for key in ("capture", "asr", "wake_word"):
+            if key in audio_section and key not in hearing:
+                hearing[key] = audio_section[key]
+        if "tts" in audio_section:
+            speech = base.setdefault("speech", {})
+            if "tts" not in speech:
+                speech["tts"] = audio_section["tts"]
+
+    vision_path = config_dir / "sensory_vision.yaml"
+    if vision_path.exists():
+        warnings.warn(
+            "sensory_vision.yaml is deprecated — migrate settings to senses.yaml",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        vision_raw: dict[str, Any] = yaml.safe_load(vision_path.read_text()) or {}
+        vision_section = vision_raw.get("vision", vision_raw)
+        if "vision" not in base:
+            base["vision"] = vision_section
+
+    return base
+
+
+# ── Public loader ─────────────────────────────────────────────────── #
+
+
+def load_sensory_config(path: Path | str | None = None) -> SensoryConfig:
+    """Load :class:`SensoryConfig` from a ``senses.yaml`` file.
+
+    When *path* is ``None`` or the file does not exist the function still checks
+    for the deprecated ``sensory_audio.yaml`` / ``sensory_vision.yaml`` in the
+    same directory and merges them with a deprecation warning.  If none are found
+    bare defaults are returned.
+    """
+    p = Path(path) if path is not None else Path("config/senses.yaml")
+
+    if p.exists():
+        raw: dict[str, Any] = yaml.safe_load(p.read_text()) or {}
+    else:
+        raw = {}
+
+    # Backward-compat: merge old per-file configs
+    config_dir = p.parent
+    raw = _merge_legacy(raw, config_dir)
+
+    hearing = _parse_hearing(raw.get("hearing", {}))
+    vision = _parse_vision(dict(raw.get("vision", {})))  # copy — _parse_vision pops
+    speech = _parse_speech(raw.get("speech", {}))
+
+    return SensoryConfig(hearing=hearing, vision=vision, speech=speech)

--- a/tests/test_sensory_config.py
+++ b/tests/test_sensory_config.py
@@ -1,0 +1,178 @@
+"""Tests for unified sensory config — Issue #226."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from openbad.sensory.audio.config import AudioConfig
+from openbad.sensory.config import (
+    SensoryConfig,
+    load_sensory_config,
+)
+
+# ── Defaults ──────────────────────────────────────────────────────── #
+
+
+class TestSensoryConfigDefaults:
+    def test_hearing_defaults(self) -> None:
+        cfg = SensoryConfig()
+        assert cfg.hearing.capture.sample_rate == 16000
+        assert cfg.hearing.asr.default_engine == "vosk"
+        assert cfg.hearing.wake_word.phrases == ["hey agent"]
+
+    def test_vision_defaults(self) -> None:
+        cfg = SensoryConfig()
+        assert cfg.vision.fps_idle == 1.0
+        assert cfg.vision.attention.ssim_threshold == 0.05
+
+    def test_speech_defaults(self) -> None:
+        cfg = SensoryConfig()
+        assert cfg.speech.tts.engine == "piper"
+
+    def test_to_audio_config(self) -> None:
+        cfg = SensoryConfig()
+        audio = cfg.to_audio_config()
+        assert isinstance(audio, AudioConfig)
+        assert audio.capture is cfg.hearing.capture
+        assert audio.tts is cfg.speech.tts
+
+
+# ── Loading ───────────────────────────────────────────────────────── #
+
+
+class TestLoadSensoryConfig:
+    def test_none_returns_defaults(self) -> None:
+        cfg = load_sensory_config(Path("/nonexistent/senses.yaml"))
+        assert cfg.hearing.capture.sample_rate == 16000
+        assert cfg.vision.fps_idle == 1.0
+
+    def test_loads_senses_yaml(self, tmp_path: Path) -> None:
+        senses = tmp_path / "senses.yaml"
+        senses.write_text(
+            "hearing:\n"
+            "  capture:\n"
+            "    sample_rate: 44100\n"
+            "vision:\n"
+            "  fps_idle: 2.0\n"
+            "speech:\n"
+            "  tts:\n"
+            "    engine: espeak\n"
+        )
+        cfg = load_sensory_config(senses)
+        assert cfg.hearing.capture.sample_rate == 44100
+        assert cfg.vision.fps_idle == 2.0
+        assert cfg.speech.tts.engine == "espeak"
+
+    def test_partial_config_preserves_defaults(self, tmp_path: Path) -> None:
+        senses = tmp_path / "senses.yaml"
+        senses.write_text("hearing:\n  capture:\n    sample_rate: 8000\n")
+        cfg = load_sensory_config(senses)
+        assert cfg.hearing.capture.sample_rate == 8000
+        assert cfg.hearing.capture.channels == 1  # default preserved
+        assert cfg.vision.fps_idle == 1.0  # default preserved
+
+    def test_unknown_keys_ignored(self, tmp_path: Path) -> None:
+        senses = tmp_path / "senses.yaml"
+        senses.write_text("hearing:\n  capture:\n    sample_rate: 8000\n    bogus: 42\n")
+        cfg = load_sensory_config(senses)
+        assert cfg.hearing.capture.sample_rate == 8000
+
+    def test_loads_project_senses_yaml(self) -> None:
+        cfg_path = Path(__file__).resolve().parents[1] / "config" / "senses.yaml"
+        if not cfg_path.exists():
+            pytest.skip("config/senses.yaml not found")
+        cfg = load_sensory_config(cfg_path)
+        assert cfg.hearing.capture.sample_rate == 16000
+        assert cfg.vision.fps_idle == 1.0
+        assert cfg.speech.tts.engine == "piper"
+
+    def test_vision_attention_parsed(self, tmp_path: Path) -> None:
+        senses = tmp_path / "senses.yaml"
+        senses.write_text(
+            "vision:\n"
+            "  fps_idle: 3.0\n"
+            "  attention:\n"
+            "    ssim_threshold: 0.1\n"
+            "    cooldown_ms: 250\n"
+        )
+        cfg = load_sensory_config(senses)
+        assert cfg.vision.fps_idle == 3.0
+        assert cfg.vision.attention.ssim_threshold == 0.1
+        assert cfg.vision.attention.cooldown_ms == 250
+
+
+# ── Backward-compat ───────────────────────────────────────────────── #
+
+
+class TestBackwardCompat:
+    def test_merges_legacy_audio(self, tmp_path: Path) -> None:
+        # No senses.yaml exists — only legacy file
+        legacy = tmp_path / "sensory_audio.yaml"
+        legacy.write_text(
+            "audio:\n"
+            "  capture:\n"
+            "    sample_rate: 22050\n"
+            "  tts:\n"
+            "    engine: festival\n"
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cfg = load_sensory_config(tmp_path / "senses.yaml")
+        assert cfg.hearing.capture.sample_rate == 22050
+        assert cfg.speech.tts.engine == "festival"
+        assert any("sensory_audio.yaml is deprecated" in str(x.message) for x in w)
+
+    def test_merges_legacy_vision(self, tmp_path: Path) -> None:
+        legacy = tmp_path / "sensory_vision.yaml"
+        legacy.write_text(
+            "vision:\n"
+            "  fps_idle: 10.0\n"
+            "  attention:\n"
+            "    ssim_threshold: 0.2\n"
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cfg = load_sensory_config(tmp_path / "senses.yaml")
+        assert cfg.vision.fps_idle == 10.0
+        assert cfg.vision.attention.ssim_threshold == 0.2
+        assert any("sensory_vision.yaml is deprecated" in str(x.message) for x in w)
+
+    def test_senses_yaml_takes_precedence_over_legacy(self, tmp_path: Path) -> None:
+        senses = tmp_path / "senses.yaml"
+        senses.write_text("hearing:\n  capture:\n    sample_rate: 48000\n")
+        legacy = tmp_path / "sensory_audio.yaml"
+        legacy.write_text("audio:\n  capture:\n    sample_rate: 8000\n")
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cfg = load_sensory_config(senses)
+        # senses.yaml takes precedence
+        assert cfg.hearing.capture.sample_rate == 48000
+
+    def test_merges_both_legacy_files(self, tmp_path: Path) -> None:
+        (tmp_path / "sensory_audio.yaml").write_text(
+            "audio:\n  capture:\n    sample_rate: 22050\n"
+        )
+        (tmp_path / "sensory_vision.yaml").write_text(
+            "vision:\n  fps_idle: 7.5\n"
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cfg = load_sensory_config(tmp_path / "senses.yaml")
+        assert cfg.hearing.capture.sample_rate == 22050
+        assert cfg.vision.fps_idle == 7.5
+        assert len([x for x in w if issubclass(x.category, DeprecationWarning)]) == 2
+
+
+# ── Validation ────────────────────────────────────────────────────── #
+
+
+class TestValidation:
+    def test_empty_yaml_returns_defaults(self, tmp_path: Path) -> None:
+        senses = tmp_path / "senses.yaml"
+        senses.write_text("")
+        cfg = load_sensory_config(senses)
+        assert cfg.hearing.capture.sample_rate == 16000
+        assert cfg.vision.fps_idle == 1.0


### PR DESCRIPTION
Closes #226

## Summary of changes

- **New `config/senses.yaml`** — unified config with `hearing`, `vision`, `speech` sections replacing `sensory_audio.yaml` and `sensory_vision.yaml`
- **New `src/openbad/sensory/config.py`** — `SensoryConfig`, `HearingConfig`, `SpeechConfig` dataclasses with `load_sensory_config()` loader
  - Reuses existing `AudioCaptureConfig`, `ASRConfig`, `WakeWordConfig`, `TTSConfig`, `VisionConfig`, `AttentionConfig`
  - `to_audio_config()` for backward-compat consumers
  - Backward-compat: if old `sensory_audio.yaml`/`sensory_vision.yaml` exist, merges them with `DeprecationWarning`; senses.yaml values take precedence
- **15 new tests** in `tests/test_sensory_config.py`: defaults, loading, partial configs, unknown keys, project config, legacy merge, precedence, empty YAML
- All 13 existing audio config tests still pass

## How to test
```bash
pytest tests/test_sensory_config.py tests/test_audio_config.py -v
```
28 tests pass. `ruff check` clean.