### PR TITLE
#227: Add vision capture scope parameters (region, interval, resolution)

### DIFF
--- a/config/senses.yaml
+++ b/config/senses.yaml
@@ -26,6 +26,12 @@ vision:
   max_width: 1920
   max_height: 1080
   portal_backend: ""
+  capture_region: active-window
+  capture_interval_s: 1.0
+  max_resolution: [1920, 1080]
+  compression:
+    format: jpeg
+    quality: 85
   attention:
     ssim_threshold: 0.05
     cooldown_ms: 500

--- a/config/sensory_vision.yaml
+++ b/config/sensory_vision.yaml
@@ -10,6 +10,12 @@ vision:
   max_width: 1920
   max_height: 1080
   portal_backend: ""         # wlr | gnome | "" (auto-detect)
+  capture_region: active-window   # full-screen | active-window | custom-rect
+  capture_interval_s: 1.0
+  max_resolution: [1920, 1080]
+  compression:
+    format: jpeg
+    quality: 85
 
   attention:
     ssim_threshold: 0.05     # Minimum SSIM delta to forward a frame

--- a/src/openbad/sensory/config.py
+++ b/src/openbad/sensory/config.py
@@ -16,7 +16,11 @@ from openbad.sensory.audio.config import (
     TTSConfig,
     WakeWordConfig,
 )
-from openbad.sensory.vision.config import AttentionConfig, VisionConfig
+from openbad.sensory.vision.config import (
+    AttentionConfig,
+    CompressionConfig,
+    VisionConfig,
+)
 
 # ── Speech section (wraps TTSConfig) ─────────────────────────────── #
 
@@ -78,11 +82,20 @@ def _parse_hearing(raw: dict[str, Any]) -> HearingConfig:
 def _parse_vision(raw: dict[str, Any]) -> VisionConfig:
     attention_raw = raw.pop("attention", {})
     attention = AttentionConfig(**_filter_fields(AttentionConfig, attention_raw))
+    compression_raw = raw.pop("compression", {})
+    compression = CompressionConfig(**_filter_fields(CompressionConfig, compression_raw))
+    max_res = raw.pop("max_resolution", None)
+    if isinstance(max_res, list) and len(max_res) == 2:
+        max_res = tuple(max_res)
+    skip = {"attention", "compression", "max_resolution"}
     fields = {
         k: v for k, v in raw.items()
-        if k in VisionConfig.__dataclass_fields__ and k != "attention"
+        if k in VisionConfig.__dataclass_fields__ and k not in skip
     }
-    return VisionConfig(**fields, attention=attention)
+    kwargs: dict[str, Any] = {**fields, "attention": attention, "compression": compression}
+    if max_res is not None:
+        kwargs["max_resolution"] = max_res
+    return VisionConfig(**kwargs)
 
 
 def _parse_speech(raw: dict[str, Any]) -> SpeechConfig:

--- a/src/openbad/sensory/vision/capture.py
+++ b/src/openbad/sensory/vision/capture.py
@@ -24,7 +24,7 @@ from typing import Any
 from openbad.nervous_system.schemas import Header, VisionFrame
 from openbad.nervous_system.schemas.sensory_pb2 import FrameFormat
 from openbad.nervous_system.topics import SENSORY_VISION, topic_for
-from openbad.sensory.vision.config import VisionConfig
+from openbad.sensory.vision.config import CaptureRegion, VisionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +117,11 @@ class ScreenCastPortal:
         self._frame_format = _FORMAT_MAP.get(
             self._config.output_format, FrameFormat.JPEG
         )
+        self._capture_region = CaptureRegion(self._config.capture_region)
+        self._capture_interval_s = self._config.capture_interval_s
+        self._max_resolution = self._config.max_resolution
+        self._compression_format = self._config.compression.format
+        self._compression_quality = self._config.compression.quality
 
     @property
     def running(self) -> bool:
@@ -125,6 +130,35 @@ class ScreenCastPortal:
     @property
     def current_fps(self) -> float:
         return self._active_fps
+
+    @property
+    def capture_region(self) -> CaptureRegion:
+        return self._capture_region
+
+    @property
+    def capture_interval_s(self) -> float:
+        return self._capture_interval_s
+
+    @property
+    def max_resolution(self) -> tuple[int, int]:
+        return self._max_resolution
+
+    def reload_config(self, config: VisionConfig) -> None:
+        """Hot-reload configuration without restarting the capture session."""
+        self._config = config
+        was_active = self._active_fps == self._config.fps_active
+        self._active_fps = config.fps_active if was_active else config.fps_idle
+        self._frame_format = _FORMAT_MAP.get(config.output_format, FrameFormat.JPEG)
+        self._capture_region = CaptureRegion(config.capture_region)
+        self._capture_interval_s = config.capture_interval_s
+        self._max_resolution = config.max_resolution
+        self._compression_format = config.compression.format
+        self._compression_quality = config.compression.quality
+        logger.info(
+            "Vision config reloaded: region=%s interval=%ss",
+            self._capture_region.value,
+            self._capture_interval_s,
+        )
 
     def set_active(self, active: bool) -> None:
         """Switch between idle and active FPS."""
@@ -179,11 +213,16 @@ class ScreenCastPortal:
         )
         self._session_handle = session_result
 
-        # SelectSources — request WINDOW only
+        # SelectSources — request based on capture_region
+        source_type = (
+            SOURCE_TYPE_MONITOR
+            if self._capture_region == CaptureRegion.FULL_SCREEN
+            else SOURCE_TYPE_WINDOW
+        )
         await self._portal.call_select_sources(
             self._session_handle,
             {
-                "types": ("u", SOURCE_TYPE_WINDOW),
+                "types": ("u", source_type),
                 "multiple": ("b", False),
             },
         )
@@ -301,9 +340,11 @@ class ScreenCastPortal:
                     topic = frame.mqtt_topic()
                     await self._publish(topic, proto.SerializeToString())
 
-                # Throttle to configured FPS
+                # Throttle to configured interval / FPS
+                interval = self._capture_interval_s
                 if self._active_fps > 0:
-                    await asyncio.sleep(1.0 / self._active_fps)
+                    interval = min(interval, 1.0 / self._active_fps)
+                await asyncio.sleep(interval)
         finally:
             self._running = False
 

--- a/src/openbad/sensory/vision/config.py
+++ b/src/openbad/sensory/vision/config.py
@@ -3,10 +3,43 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+
+class CaptureRegion(StrEnum):
+    """Screen region to capture."""
+
+    FULL_SCREEN = "full-screen"
+    ACTIVE_WINDOW = "active-window"
+    CUSTOM_RECT = "custom-rect"
+
+
+@dataclass
+class CompressionConfig:
+    """Image compression settings.
+
+    Attributes
+    ----------
+    format : str
+        Output format — ``"jpeg"`` or ``"png"`` (default ``"jpeg"``).
+    quality : int
+        Compression quality 1-100 (default 85, used for JPEG only).
+    """
+
+    format: str = "jpeg"
+    quality: int = 85
+
+    def __post_init__(self) -> None:
+        if self.format not in ("jpeg", "png"):
+            msg = f"compression.format must be 'jpeg' or 'png', got '{self.format}'"
+            raise ValueError(msg)
+        if not 1 <= self.quality <= 100:
+            msg = f"compression.quality must be 1-100, got {self.quality}"
+            raise ValueError(msg)
 
 
 @dataclass
@@ -41,9 +74,25 @@ class VisionConfig:
     max_width: int = 1920
     max_height: int = 1080
     portal_backend: str = ""
+    capture_region: str = "active-window"
+    capture_interval_s: float = 1.0
+    max_resolution: tuple[int, int] = (1920, 1080)
+    compression: CompressionConfig = field(default_factory=CompressionConfig)
 
     # Attention filter settings (co-located for convenience)
     attention: AttentionConfig = field(default_factory=lambda: AttentionConfig())
+
+    def __post_init__(self) -> None:
+        # Validate capture_region
+        try:
+            CaptureRegion(self.capture_region)
+        except ValueError:
+            allowed = ", ".join(r.value for r in CaptureRegion)
+            msg = f"capture_region must be one of ({allowed}), got '{self.capture_region}'"
+            raise ValueError(msg) from None
+        if self.capture_interval_s <= 0:
+            msg = f"capture_interval_s must be > 0, got {self.capture_interval_s}"
+            raise ValueError(msg)
 
 
 @dataclass
@@ -65,6 +114,10 @@ class AttentionConfig:
     roi_enabled: bool = False
 
 
+def _filter_fields(cls: type, raw: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in raw.items() if k in cls.__dataclass_fields__}
+
+
 def load_vision_config(path: Path | str | None = None) -> VisionConfig:
     """Load :class:`VisionConfig` from a YAML file.
 
@@ -81,13 +134,27 @@ def load_vision_config(path: Path | str | None = None) -> VisionConfig:
     vision_raw = raw.get("vision", raw)
 
     attention_raw = vision_raw.pop("attention", {})
-    attention = AttentionConfig(**{
-        k: v for k, v in attention_raw.items() if k in AttentionConfig.__dataclass_fields__
-    })
+    attention = AttentionConfig(**_filter_fields(AttentionConfig, attention_raw))
 
+    compression_raw = vision_raw.pop("compression", {})
+    compression = CompressionConfig(**_filter_fields(CompressionConfig, compression_raw))
+
+    # max_resolution may come as a list [w, h]
+    max_res = vision_raw.pop("max_resolution", None)
+    if isinstance(max_res, list) and len(max_res) == 2:
+        max_res = tuple(max_res)
+
+    skip = {"attention", "compression", "max_resolution"}
     fields = {
         k: v
         for k, v in vision_raw.items()
-        if k in VisionConfig.__dataclass_fields__ and k != "attention"
+        if k in VisionConfig.__dataclass_fields__ and k not in skip
     }
-    return VisionConfig(**fields, attention=attention)
+    kwargs: dict[str, Any] = {
+        **fields,
+        "attention": attention,
+        "compression": compression,
+    }
+    if max_res is not None:
+        kwargs["max_resolution"] = max_res
+    return VisionConfig(**kwargs)

--- a/tests/test_vision_capture.py
+++ b/tests/test_vision_capture.py
@@ -14,7 +14,7 @@ from openbad.sensory.vision.capture import (
     CapturedFrame,
     ScreenCastPortal,
 )
-from openbad.sensory.vision.config import VisionConfig
+from openbad.sensory.vision.config import CaptureRegion, CompressionConfig, VisionConfig
 
 # ---------------------------------------------------------------------------
 # CapturedFrame tests
@@ -266,3 +266,51 @@ class TestScreenCastPortalContextManager:
         portal = ScreenCastPortal()
         await portal.stop()
         await portal.stop()  # Should not raise
+
+
+# ── Capture scope properties (#227) ──────────────────────────────── #
+
+
+class TestCaptureScope:
+    def test_capture_region_property(self) -> None:
+        cfg = VisionConfig(capture_region="full-screen")
+        portal = ScreenCastPortal(config=cfg)
+        assert portal.capture_region == CaptureRegion.FULL_SCREEN
+
+    def test_capture_interval_property(self) -> None:
+        cfg = VisionConfig(capture_interval_s=0.5)
+        portal = ScreenCastPortal(config=cfg)
+        assert portal.capture_interval_s == 0.5
+
+    def test_max_resolution_property(self) -> None:
+        cfg = VisionConfig(max_resolution=(1280, 720))
+        portal = ScreenCastPortal(config=cfg)
+        assert portal.max_resolution == (1280, 720)
+
+
+class TestReloadConfig:
+    def test_reload_updates_capture_region(self) -> None:
+        portal = ScreenCastPortal(config=VisionConfig())
+        assert portal.capture_region == CaptureRegion.ACTIVE_WINDOW
+        portal.reload_config(VisionConfig(capture_region="full-screen"))
+        assert portal.capture_region == CaptureRegion.FULL_SCREEN
+
+    def test_reload_updates_interval(self) -> None:
+        portal = ScreenCastPortal(config=VisionConfig())
+        assert portal.capture_interval_s == 1.0
+        portal.reload_config(VisionConfig(capture_interval_s=0.25))
+        assert portal.capture_interval_s == 0.25
+
+    def test_reload_updates_max_resolution(self) -> None:
+        portal = ScreenCastPortal(config=VisionConfig())
+        portal.reload_config(VisionConfig(max_resolution=(640, 480)))
+        assert portal.max_resolution == (640, 480)
+
+    def test_reload_updates_compression(self) -> None:
+        portal = ScreenCastPortal(config=VisionConfig())
+        new_cfg = VisionConfig(
+            compression=CompressionConfig(format="png", quality=100),
+        )
+        portal.reload_config(new_cfg)
+        assert portal._compression_format == "png"
+        assert portal._compression_quality == 100

--- a/tests/test_vision_config.py
+++ b/tests/test_vision_config.py
@@ -1,12 +1,16 @@
-"""Tests for vision configuration — Issue #44."""
+"""Tests for vision configuration — Issue #44, #227."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+
 from openbad.sensory.vision.config import (
     AttentionConfig,
+    CaptureRegion,
+    CompressionConfig,
     VisionConfig,
     load_vision_config,
 )
@@ -142,3 +146,103 @@ class TestLoadVisionConfig:
             cfg = load_vision_config(cfg_path)
             assert cfg.fps_idle == 1.0
             assert cfg.attention.ssim_threshold == 0.05
+
+
+# ── Capture scope fields (#227) ──────────────────────────────────── #
+
+
+class TestCaptureRegionEnum:
+    def test_valid_values(self) -> None:
+        assert CaptureRegion("full-screen") == CaptureRegion.FULL_SCREEN
+        assert CaptureRegion("active-window") == CaptureRegion.ACTIVE_WINDOW
+        assert CaptureRegion("custom-rect") == CaptureRegion.CUSTOM_RECT
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises(ValueError):
+            CaptureRegion("bad-value")
+
+
+class TestCompressionConfig:
+    def test_defaults(self) -> None:
+        c = CompressionConfig()
+        assert c.format == "jpeg"
+        assert c.quality == 85
+
+    def test_png_format(self) -> None:
+        c = CompressionConfig(format="png", quality=100)
+        assert c.format == "png"
+
+    def test_invalid_format_raises(self) -> None:
+        with pytest.raises(ValueError, match="compression.format"):
+            CompressionConfig(format="bmp")
+
+    def test_quality_too_low_raises(self) -> None:
+        with pytest.raises(ValueError, match="compression.quality"):
+            CompressionConfig(quality=0)
+
+    def test_quality_too_high_raises(self) -> None:
+        with pytest.raises(ValueError, match="compression.quality"):
+            CompressionConfig(quality=101)
+
+
+class TestVisionCaptureScope:
+    def test_default_capture_region(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.capture_region == "active-window"
+
+    def test_default_capture_interval(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.capture_interval_s == 1.0
+
+    def test_default_max_resolution(self) -> None:
+        cfg = VisionConfig()
+        assert cfg.max_resolution == (1920, 1080)
+
+    def test_default_compression(self) -> None:
+        cfg = VisionConfig()
+        assert isinstance(cfg.compression, CompressionConfig)
+        assert cfg.compression.format == "jpeg"
+
+    def test_invalid_capture_region_raises(self) -> None:
+        with pytest.raises(ValueError, match="capture_region"):
+            VisionConfig(capture_region="quadrant")
+
+    def test_invalid_capture_interval_raises(self) -> None:
+        with pytest.raises(ValueError, match="capture_interval_s"):
+            VisionConfig(capture_interval_s=0)
+
+    def test_full_screen_region(self) -> None:
+        cfg = VisionConfig(capture_region="full-screen")
+        assert cfg.capture_region == "full-screen"
+
+    def test_custom_rect_region(self) -> None:
+        cfg = VisionConfig(capture_region="custom-rect")
+        assert cfg.capture_region == "custom-rect"
+
+    def test_load_capture_scope_from_yaml(self, tmp_path: Path) -> None:
+        yaml_content = dedent("""\
+            vision:
+              capture_region: full-screen
+              capture_interval_s: 0.5
+              max_resolution: [1280, 720]
+              compression:
+                format: png
+                quality: 100
+        """)
+        cfg_file = tmp_path / "scope.yaml"
+        cfg_file.write_text(yaml_content)
+        cfg = load_vision_config(cfg_file)
+        assert cfg.capture_region == "full-screen"
+        assert cfg.capture_interval_s == 0.5
+        assert cfg.max_resolution == (1280, 720)
+        assert cfg.compression.format == "png"
+        assert cfg.compression.quality == 100
+
+    def test_load_project_config_has_scope(self) -> None:
+        cfg_path = Path(__file__).resolve().parents[1] / "config" / "sensory_vision.yaml"
+        if not cfg_path.exists():
+            pytest.skip("sensory_vision.yaml not found")
+        cfg = load_vision_config(cfg_path)
+        assert cfg.capture_region == "active-window"
+        assert cfg.capture_interval_s == 1.0
+        assert cfg.compression.format == "jpeg"


### PR DESCRIPTION
Closes #227

## Summary of changes

### Config (`vision/config.py`)
- Added `CaptureRegion` StrEnum: `full-screen`, `active-window`, `custom-rect`
- Added `CompressionConfig` dataclass with format (jpeg/png) and quality (1-100) validation
- Extended `VisionConfig` with `capture_region`, `capture_interval_s`, `max_resolution`, `compression` fields
- Added validation in `__post_init__` for invalid region and non-positive interval
- Updated `load_vision_config()` to parse `compression` and `max_resolution` from YAML

### Capture module (`vision/capture.py`)
- `ScreenCastPortal.__init__` reads new scope params: capture_region, capture_interval_s, max_resolution, compression
- Added `capture_region`, `capture_interval_s`, `max_resolution` properties
- Added `reload_config()` for hot-reload without restart (AC #3)
- SelectSources uses MONITOR for full-screen, WINDOW for active-window/custom-rect
- Capture loop throttles by min(capture_interval_s, 1/fps)

### Config files
- Updated `config/senses.yaml` and `config/sensory_vision.yaml` with new fields

### Tests
- 20 new tests across `test_vision_config.py` and `test_vision_capture.py`: CaptureRegion enum, CompressionConfig validation, VisionConfig scope defaults/validation, YAML loading with scope, reload_config behavior

## How to test
```bash
pytest tests/test_vision_config.py tests/test_vision_capture.py tests/test_sensory_config.py -v
```
73 passed, 3 skipped. `ruff check` clean.