### PR TITLE
#229: Add speech/TTS config with engine validation, factory, and disabled mode

### DIFF
--- a/config/senses.yaml
+++ b/config/senses.yaml
@@ -41,5 +41,8 @@ vision:
 speech:
   tts:
     engine: "piper"
+    voice_model: ""
     model_path: ""
+    speaking_rate: 1.0
+    volume: 1.0
     output_device: ""

--- a/config/sensory_audio.yaml
+++ b/config/sensory_audio.yaml
@@ -17,5 +17,8 @@ audio:
     threshold: 0.5
   tts:
     engine: "piper"
+    voice_model: ""
     model_path: ""
+    speaking_rate: 1.0
+    volume: 1.0
     output_device: ""

--- a/src/openbad/sensory/audio/config.py
+++ b/src/openbad/sensory/audio/config.py
@@ -102,6 +102,9 @@ class WakeWordConfig:
             raise ValueError(msg)
 
 
+_VALID_TTS_ENGINES = frozenset({"piper", "espeak", "disabled"})
+
+
 @dataclass
 class TTSConfig:
     """Text-to-speech output settings.
@@ -109,16 +112,37 @@ class TTSConfig:
     Attributes
     ----------
     engine : str
-        TTS backend: ``"piper"`` (default).
+        TTS backend: ``"piper"``, ``"espeak"``, or ``"disabled"`` (default ``"piper"``).
+    voice_model : str
+        Voice model name or path for the selected engine.
     model_path : str
-        Path to TTS voice model.
+        Path to TTS voice model (legacy alias for *voice_model*).
+    speaking_rate : float
+        Speech rate multiplier 0.25–4.0 (default 1.0).
+    volume : float
+        Output volume 0.0–1.0 (default 1.0).
     output_device : str
         PipeWire sink node for TTS output. Empty = default.
     """
 
     engine: str = "piper"
+    voice_model: str = ""
     model_path: str = ""
+    speaking_rate: float = 1.0
+    volume: float = 1.0
     output_device: str = ""
+
+    def __post_init__(self) -> None:
+        if self.engine not in _VALID_TTS_ENGINES:
+            allowed = ", ".join(sorted(_VALID_TTS_ENGINES))
+            msg = f"tts.engine must be one of ({allowed}), got '{self.engine}'"
+            raise ValueError(msg)
+        if not 0.25 <= self.speaking_rate <= 4.0:
+            msg = f"tts.speaking_rate must be 0.25-4.0, got {self.speaking_rate}"
+            raise ValueError(msg)
+        if not 0.0 <= self.volume <= 1.0:
+            msg = f"tts.volume must be 0.0-1.0, got {self.volume}"
+            raise ValueError(msg)
 
 
 @dataclass

--- a/src/openbad/sensory/audio/tts_factory.py
+++ b/src/openbad/sensory/audio/tts_factory.py
@@ -1,0 +1,53 @@
+"""TTS engine factory — selects the right backend from config."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from openbad.sensory.audio.config import TTSConfig
+from openbad.sensory.audio.tts import SynthResult, TTSEngine
+
+logger = logging.getLogger(__name__)
+
+
+class DisabledTTSEngine(TTSEngine):
+    """No-op TTS engine that suppresses all audio output."""
+
+    def __init__(self) -> None:
+        super().__init__(config=TTSConfig(engine="disabled"))
+
+    @property
+    def is_loaded(self) -> bool:
+        return True
+
+    def load_voice(self) -> None:
+        pass
+
+    def synthesize(self, text: str) -> SynthResult:
+        return SynthResult(success=True, audio_bytes=b"", duration_ms=0.0)
+
+    async def synthesize_and_publish(self, text: str) -> SynthResult:
+        return self.synthesize(text)
+
+    def handle_request(self, request: Any) -> SynthResult:
+        return SynthResult(success=True, audio_bytes=b"", duration_ms=0.0)
+
+
+def create_tts_engine(
+    config: TTSConfig | None = None,
+    publish_fn: Any | None = None,
+) -> TTSEngine:
+    """Instantiate the TTS engine specified by *config.engine*.
+
+    Returns a :class:`DisabledTTSEngine` when engine is ``"disabled"``,
+    otherwise a :class:`TTSEngine` for ``"piper"`` or ``"espeak"``.
+    """
+    cfg = config or TTSConfig()
+    engine = cfg.engine
+
+    if engine == "disabled":
+        logger.info("TTS disabled by config — all speech output suppressed")
+        return DisabledTTSEngine()
+
+    return TTSEngine(config=cfg, publish_fn=publish_fn)

--- a/tests/test_sensory_config.py
+++ b/tests/test_sensory_config.py
@@ -116,13 +116,13 @@ class TestBackwardCompat:
             "  capture:\n"
             "    sample_rate: 22050\n"
             "  tts:\n"
-            "    engine: festival\n"
+            "    engine: espeak\n"
         )
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             cfg = load_sensory_config(tmp_path / "senses.yaml")
         assert cfg.hearing.capture.sample_rate == 22050
-        assert cfg.speech.tts.engine == "festival"
+        assert cfg.speech.tts.engine == "espeak"
         assert any("sensory_audio.yaml is deprecated" in str(x.message) for x in w)
 
     def test_merges_legacy_vision(self, tmp_path: Path) -> None:

--- a/tests/test_speech_config.py
+++ b/tests/test_speech_config.py
@@ -1,0 +1,198 @@
+"""Tests for speech/TTS config — Issue #229."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.sensory.audio.config import TTSConfig
+from openbad.sensory.audio.tts_factory import DisabledTTSEngine, create_tts_engine
+
+# ── TTSConfig validation ─────────────────────────────────────────── #
+
+
+class TestTTSConfigValidation:
+    def test_defaults(self) -> None:
+        cfg = TTSConfig()
+        assert cfg.engine == "piper"
+        assert cfg.speaking_rate == 1.0
+        assert cfg.volume == 1.0
+
+    def test_piper_valid(self) -> None:
+        TTSConfig(engine="piper")
+
+    def test_espeak_valid(self) -> None:
+        TTSConfig(engine="espeak")
+
+    def test_disabled_valid(self) -> None:
+        TTSConfig(engine="disabled")
+
+    def test_invalid_engine_raises(self) -> None:
+        with pytest.raises(ValueError, match="tts.engine must be one of"):
+            TTSConfig(engine="festival")
+
+    def test_speaking_rate_bounds(self) -> None:
+        TTSConfig(speaking_rate=0.25)
+        TTSConfig(speaking_rate=4.0)
+
+    def test_speaking_rate_too_low(self) -> None:
+        with pytest.raises(ValueError, match="tts.speaking_rate must be 0.25-4.0"):
+            TTSConfig(speaking_rate=0.1)
+
+    def test_speaking_rate_too_high(self) -> None:
+        with pytest.raises(ValueError, match="tts.speaking_rate must be 0.25-4.0"):
+            TTSConfig(speaking_rate=5.0)
+
+    def test_volume_bounds(self) -> None:
+        TTSConfig(volume=0.0)
+        TTSConfig(volume=1.0)
+
+    def test_volume_too_low(self) -> None:
+        with pytest.raises(ValueError, match="tts.volume must be 0.0-1.0"):
+            TTSConfig(volume=-0.1)
+
+    def test_volume_too_high(self) -> None:
+        with pytest.raises(ValueError, match="tts.volume must be 0.0-1.0"):
+            TTSConfig(volume=1.5)
+
+    def test_voice_model_field(self) -> None:
+        cfg = TTSConfig(voice_model="en_US-lessac-medium")
+        assert cfg.voice_model == "en_US-lessac-medium"
+
+
+# ── TTS engine factory ───────────────────────────────────────────── #
+
+
+class TestCreateTTSEngine:
+    def test_piper_engine(self) -> None:
+        cfg = TTSConfig(engine="piper", model_path="/voice.onnx")
+        engine = create_tts_engine(cfg)
+        assert not isinstance(engine, DisabledTTSEngine)
+        assert engine.config.engine == "piper"
+
+    def test_espeak_engine(self) -> None:
+        cfg = TTSConfig(engine="espeak")
+        engine = create_tts_engine(cfg)
+        assert not isinstance(engine, DisabledTTSEngine)
+        assert engine.config.engine == "espeak"
+
+    def test_disabled_engine(self) -> None:
+        cfg = TTSConfig(engine="disabled")
+        engine = create_tts_engine(cfg)
+        assert isinstance(engine, DisabledTTSEngine)
+
+    def test_default_creates_piper(self) -> None:
+        engine = create_tts_engine()
+        assert engine.config.engine == "piper"
+
+
+# ── Disabled TTS engine ──────────────────────────────────────────── #
+
+
+class TestDisabledTTSEngine:
+    def test_is_loaded(self) -> None:
+        engine = DisabledTTSEngine()
+        assert engine.is_loaded
+
+    def test_load_voice_noop(self) -> None:
+        engine = DisabledTTSEngine()
+        engine.load_voice()  # should not raise
+
+    def test_synthesize_returns_empty(self) -> None:
+        engine = DisabledTTSEngine()
+        result = engine.synthesize("hello world")
+        assert result.success
+        assert result.audio_bytes == b""
+        assert result.duration_ms == 0.0
+
+    @pytest.mark.asyncio
+    async def test_synthesize_and_publish_suppressed(self) -> None:
+        engine = DisabledTTSEngine()
+        result = await engine.synthesize_and_publish("hello")
+        assert result.success
+        assert result.audio_bytes == b""
+
+    def test_handle_request_suppressed(self) -> None:
+        from types import SimpleNamespace
+
+        engine = DisabledTTSEngine()
+        req = SimpleNamespace(text="test", ssml="")
+        result = engine.handle_request(req)
+        assert result.success
+        assert result.audio_bytes == b""
+
+
+# ── Config YAML round-trip ────────────────────────────────────────── #
+
+
+class TestSpeechYAML:
+    def test_load_speech_from_senses(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        from openbad.sensory.config import load_sensory_config
+
+        p = Path(str(tmp_path)) / "senses.yaml"
+        p.write_text(yaml.dump({
+            "speech": {
+                "tts": {
+                    "engine": "espeak",
+                    "voice_model": "en-us",
+                    "speaking_rate": 1.5,
+                    "volume": 0.8,
+                },
+            },
+        }))
+        cfg = load_sensory_config(p)
+        assert cfg.speech.tts.engine == "espeak"
+        assert cfg.speech.tts.voice_model == "en-us"
+        assert cfg.speech.tts.speaking_rate == 1.5
+        assert cfg.speech.tts.volume == 0.8
+
+    def test_disabled_from_yaml(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        from openbad.sensory.config import load_sensory_config
+
+        p = Path(str(tmp_path)) / "senses.yaml"
+        p.write_text(yaml.dump({
+            "speech": {"tts": {"engine": "disabled"}},
+        }))
+        cfg = load_sensory_config(p)
+        assert cfg.speech.tts.engine == "disabled"
+        engine = create_tts_engine(cfg.speech.tts)
+        assert isinstance(engine, DisabledTTSEngine)
+
+    def test_invalid_engine_from_yaml(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        from openbad.sensory.config import load_sensory_config
+
+        p = Path(str(tmp_path)) / "senses.yaml"
+        p.write_text(yaml.dump({
+            "speech": {"tts": {"engine": "festival"}},
+        }))
+        with pytest.raises(ValueError, match="tts.engine must be one of"):
+            load_sensory_config(p)
+
+    def test_to_audio_config_preserves_speech(self) -> None:
+        from openbad.sensory.config import HearingConfig, SensoryConfig, SpeechConfig
+
+        sensory = SensoryConfig(
+            hearing=HearingConfig(),
+            speech=SpeechConfig(
+                tts=TTSConfig(
+                    engine="espeak",
+                    speaking_rate=2.0,
+                    volume=0.5,
+                ),
+            ),
+        )
+        audio = sensory.to_audio_config()
+        assert audio.tts.engine == "espeak"
+        assert audio.tts.speaking_rate == 2.0
+        assert audio.tts.volume == 0.5


### PR DESCRIPTION
Closes #229\n\n## Summary\n- Extended `TTSConfig` with `voice_model`, `speaking_rate` (0.25–4.0), `volume` (0.0–1.0) fields and `__post_init__` validation for engine (piper/espeak/disabled)\n- Created `tts_factory.py` with `create_tts_engine()` factory and `DisabledTTSEngine` that suppresses all audio output\n- Updated `senses.yaml` and `sensory_audio.yaml` with new speech fields\n- Fixed existing test using invalid engine name\n\n## How to test\n```bash\npytest tests/test_speech_config.py -v  # 25 tests\npytest tests/test_tts.py tests/test_audio_config.py tests/test_sensory_config.py tests/test_hearing_config.py -v  # 64 regression tests\nruff check\n```