### PR TITLE
#230: Add WUI Senses panel for configuring vision, hearing, and speech

### DIFF
--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -22,6 +22,7 @@ from openbad.cognitive.config import (
 )
 from openbad.cognitive.providers.github_copilot import CopilotAuthError, GitHubCopilotProvider
 from openbad.cognitive.providers.openai_compat import custom_provider
+from openbad.sensory.config import load_sensory_config
 from openbad.wui.bridge import MqttWebSocketBridge
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
@@ -506,6 +507,95 @@ async def _put_systems(request: web.Request) -> web.Response:
     return web.json_response(_serialize_systems_config(config))
 
 
+# ── Senses config endpoints ──────────────────────────────────────── #
+
+
+def _resolve_senses_config_path() -> Path:
+    config_dir = os.environ.get("OPENBAD_CONFIG_DIR", "").strip()
+    if config_dir:
+        return Path(config_dir) / "senses.yaml"
+    return Path("config/senses.yaml")
+
+
+def _serialize_senses(cfg: object) -> dict:
+    """Convert a SensoryConfig to a JSON-safe dict."""
+    h = cfg.hearing
+    v = cfg.vision
+    s = cfg.speech
+    return {
+        "hearing": {
+            "capture": {
+                "sample_rate": h.capture.sample_rate,
+                "channels": h.capture.channels,
+                "sample_format": h.capture.sample_format,
+                "chunk_duration_ms": h.capture.chunk_duration_ms,
+                "device": h.capture.device,
+                "passive": h.capture.passive,
+            },
+            "asr": {
+                "default_engine": h.asr.default_engine,
+                "vosk_model_path": h.asr.vosk_model_path,
+                "whisper_model": h.asr.whisper_model,
+                "vad_sensitivity": h.asr.vad_sensitivity,
+            },
+            "wake_word": {
+                "phrases": list(h.wake_word.phrases),
+                "threshold": h.wake_word.threshold,
+            },
+        },
+        "vision": {
+            "fps_idle": v.fps_idle,
+            "fps_active": v.fps_active,
+            "capture_region": str(v.capture_region),
+            "capture_interval_s": v.capture_interval_s,
+            "max_resolution": list(v.max_resolution) if v.max_resolution else None,
+            "compression": {
+                "format": v.compression.format,
+                "quality": v.compression.quality,
+            },
+            "attention": {
+                "ssim_threshold": v.attention.ssim_threshold,
+                "cooldown_ms": v.attention.cooldown_ms,
+                "roi_enabled": v.attention.roi_enabled,
+            },
+        },
+        "speech": {
+            "tts": {
+                "engine": s.tts.engine,
+                "voice_model": s.tts.voice_model,
+                "model_path": s.tts.model_path,
+                "speaking_rate": s.tts.speaking_rate,
+                "volume": s.tts.volume,
+                "output_device": s.tts.output_device,
+            },
+        },
+    }
+
+
+async def _get_senses(_request: web.Request) -> web.Response:
+    path = _resolve_senses_config_path()
+    cfg = load_sensory_config(path)
+    return web.json_response(_serialize_senses(cfg))
+
+
+async def _put_senses(request: web.Request) -> web.Response:
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise web.HTTPBadRequest(text="request body must be an object")
+
+    # Write the raw payload as YAML — validation happens via load_sensory_config
+    path = _resolve_senses_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+        cfg = load_sensory_config(path)
+    except (ValueError, TypeError) as exc:
+        raise web.HTTPBadRequest(text=str(exc)) from exc
+
+    return web.json_response(_serialize_senses(cfg))
+
+
 def create_app(
     mqtt_host: str = "localhost",
     mqtt_port: int = 1883,
@@ -533,6 +623,8 @@ def create_app(
     app.router.add_put("/api/providers", _put_providers)
     app.router.add_get("/api/systems", _get_systems)
     app.router.add_put("/api/systems", _put_systems)
+    app.router.add_get("/api/senses", _get_senses)
+    app.router.add_put("/api/senses", _put_senses)
     # TODO: Remove after v1.0 once external consumers have migrated to /api/providers/*.
     app.router.add_get("/api/wiring/providers", _redirect_legacy_wiring_providers)
     app.router.add_post(

--- a/src/openbad/wui/static/app.js
+++ b/src/openbad/wui/static/app.js
@@ -72,6 +72,45 @@ const els = {
     chainAddModel: document.getElementById('fallback-add-model'),
     chainAddBtn: document.getElementById('fallback-add-btn'),
   },
+  senses: {
+    saveBtn: document.getElementById('senses-save-btn'),
+    saveStatus: document.getElementById('senses-save-status'),
+    // Vision
+    vFpsIdle: document.getElementById('sens-vision-fps-idle'),
+    vFpsActive: document.getElementById('sens-vision-fps-active'),
+    vRegion: document.getElementById('sens-vision-capture-region'),
+    vInterval: document.getElementById('sens-vision-interval'),
+    vMaxW: document.getElementById('sens-vision-max-w'),
+    vMaxH: document.getElementById('sens-vision-max-h'),
+    vCompFmt: document.getElementById('sens-vision-comp-format'),
+    vCompQual: document.getElementById('sens-vision-comp-quality'),
+    vSsim: document.getElementById('sens-vision-ssim'),
+    vCooldown: document.getElementById('sens-vision-cooldown'),
+    vRoi: document.getElementById('sens-vision-roi'),
+    vError: document.getElementById('sens-vision-error'),
+    // Hearing
+    hSampleRate: document.getElementById('sens-hearing-sample-rate'),
+    hChannels: document.getElementById('sens-hearing-channels'),
+    hFormat: document.getElementById('sens-hearing-format'),
+    hChunkMs: document.getElementById('sens-hearing-chunk-ms'),
+    hDevice: document.getElementById('sens-hearing-device'),
+    hPassive: document.getElementById('sens-hearing-passive'),
+    hAsrEngine: document.getElementById('sens-hearing-asr-engine'),
+    hVoskPath: document.getElementById('sens-hearing-vosk-path'),
+    hWhisperModel: document.getElementById('sens-hearing-whisper-model'),
+    hVad: document.getElementById('sens-hearing-vad'),
+    hPhrases: document.getElementById('sens-hearing-phrases'),
+    hThreshold: document.getElementById('sens-hearing-threshold'),
+    hError: document.getElementById('sens-hearing-error'),
+    // Speech
+    sEngine: document.getElementById('sens-speech-engine'),
+    sVoiceModel: document.getElementById('sens-speech-voice-model'),
+    sModelPath: document.getElementById('sens-speech-model-path'),
+    sRate: document.getElementById('sens-speech-rate'),
+    sVolume: document.getElementById('sens-speech-volume'),
+    sOutputDevice: document.getElementById('sens-speech-output-device'),
+    sError: document.getElementById('sens-speech-error'),
+  },
 };
 
 const viewMeta = {
@@ -86,6 +125,10 @@ const viewMeta = {
   providers: {
     title: 'Providers',
     subtitle: 'Verified providers and model access for the runtime.',
+  },
+  senses: {
+    title: 'Senses',
+    subtitle: 'Configure vision, hearing, and speech modalities.',
   },
   models: {
     title: 'Models',
@@ -158,6 +201,9 @@ function setView(name) {
   if (name === 'providers') {
     loadProvidersConfig();
     loadSystemsConfig();
+  }
+  if (name === 'senses') {
+    loadSensesConfig();
   }
 }
 
@@ -907,6 +953,172 @@ async function saveSystemsConfig() {
   }
 }
 
+// ── Senses config ──────────────────────────────────────────────── //
+
+let sensesData = null;
+
+async function loadSensesConfig() {
+  try {
+    const res = await fetch('/api/senses');
+    sensesData = await res.json();
+    populateSensesForm(sensesData);
+  } catch (err) {
+    if (els.senses.saveStatus) els.senses.saveStatus.textContent = `Load failed: ${err.message}`;
+  }
+}
+
+function populateSensesForm(d) {
+  const s = els.senses;
+  // Vision
+  const v = d.hearing ? d : d;
+  const vis = d.vision || {};
+  if (s.vFpsIdle) s.vFpsIdle.value = vis.fps_idle ?? '';
+  if (s.vFpsActive) s.vFpsActive.value = vis.fps_active ?? '';
+  if (s.vRegion) s.vRegion.value = vis.capture_region || 'active-window';
+  if (s.vInterval) s.vInterval.value = vis.capture_interval_s ?? '';
+  const maxRes = vis.max_resolution || [];
+  if (s.vMaxW) s.vMaxW.value = maxRes[0] ?? '';
+  if (s.vMaxH) s.vMaxH.value = maxRes[1] ?? '';
+  const comp = vis.compression || {};
+  if (s.vCompFmt) s.vCompFmt.value = comp.format || 'jpeg';
+  if (s.vCompQual) s.vCompQual.value = comp.quality ?? '';
+  const att = vis.attention || {};
+  if (s.vSsim) s.vSsim.value = att.ssim_threshold ?? '';
+  if (s.vCooldown) s.vCooldown.value = att.cooldown_ms ?? '';
+  if (s.vRoi) s.vRoi.checked = att.roi_enabled ?? false;
+  // Hearing
+  const h = d.hearing || {};
+  const cap = h.capture || {};
+  if (s.hSampleRate) s.hSampleRate.value = cap.sample_rate ?? '';
+  if (s.hChannels) s.hChannels.value = cap.channels ?? '';
+  if (s.hFormat) s.hFormat.value = cap.sample_format || '';
+  if (s.hChunkMs) s.hChunkMs.value = cap.chunk_duration_ms ?? '';
+  if (s.hDevice) s.hDevice.value = cap.device || '';
+  if (s.hPassive) s.hPassive.checked = cap.passive ?? true;
+  const asr = h.asr || {};
+  if (s.hAsrEngine) s.hAsrEngine.value = asr.default_engine || 'vosk';
+  if (s.hVoskPath) s.hVoskPath.value = asr.vosk_model_path || '';
+  if (s.hWhisperModel) s.hWhisperModel.value = asr.whisper_model || '';
+  if (s.hVad) s.hVad.value = asr.vad_sensitivity ?? '';
+  const ww = h.wake_word || {};
+  if (s.hPhrases) s.hPhrases.value = (ww.phrases || []).join(', ');
+  if (s.hThreshold) s.hThreshold.value = ww.threshold ?? '';
+  // Speech
+  const sp = d.speech || {};
+  const tts = sp.tts || {};
+  if (s.sEngine) s.sEngine.value = tts.engine || 'piper';
+  if (s.sVoiceModel) s.sVoiceModel.value = tts.voice_model || '';
+  if (s.sModelPath) s.sModelPath.value = tts.model_path || '';
+  if (s.sRate) s.sRate.value = tts.speaking_rate ?? '';
+  if (s.sVolume) s.sVolume.value = tts.volume ?? '';
+  if (s.sOutputDevice) s.sOutputDevice.value = tts.output_device || '';
+}
+
+function validateSensesForm() {
+  const s = els.senses;
+  let valid = true;
+  // Vision validation
+  const fpsIdle = parseFloat(s.vFpsIdle?.value);
+  if (isNaN(fpsIdle) || fpsIdle < 0.1 || fpsIdle > 30) {
+    if (s.vError) s.vError.textContent = 'FPS idle must be 0.1–30';
+    valid = false;
+  } else if (s.vError) {
+    s.vError.textContent = '';
+  }
+  // Hearing validation
+  const phrases = (s.hPhrases?.value || '').split(',').map(p => p.trim()).filter(Boolean);
+  if (phrases.length === 0) {
+    if (s.hError) s.hError.textContent = 'Wake phrases must not be empty';
+    valid = false;
+  } else if (s.hError) {
+    s.hError.textContent = '';
+  }
+  // Speech validation
+  const rate = parseFloat(s.sRate?.value);
+  if (isNaN(rate) || rate < 0.25 || rate > 4.0) {
+    if (s.sError) s.sError.textContent = 'Speaking rate must be 0.25–4.0';
+    valid = false;
+  } else if (s.sError) {
+    s.sError.textContent = '';
+  }
+  return valid;
+}
+
+function collectSensesPayload() {
+  const s = els.senses;
+  const phrases = (s.hPhrases?.value || '').split(',').map(p => p.trim()).filter(Boolean);
+  return {
+    hearing: {
+      capture: {
+        sample_rate: parseInt(s.hSampleRate?.value) || 16000,
+        channels: parseInt(s.hChannels?.value) || 1,
+        sample_format: s.hFormat?.value || 's16le',
+        chunk_duration_ms: parseInt(s.hChunkMs?.value) || 100,
+        device: s.hDevice?.value || '',
+        passive: s.hPassive?.checked ?? true,
+      },
+      asr: {
+        default_engine: s.hAsrEngine?.value || 'vosk',
+        vosk_model_path: s.hVoskPath?.value || '',
+        whisper_model: s.hWhisperModel?.value || 'base',
+        vad_sensitivity: parseFloat(s.hVad?.value) || 0.5,
+      },
+      wake_word: {
+        phrases: phrases,
+        threshold: parseFloat(s.hThreshold?.value) || 0.5,
+      },
+    },
+    vision: {
+      fps_idle: parseFloat(s.vFpsIdle?.value) || 1.0,
+      fps_active: parseFloat(s.vFpsActive?.value) || 5.0,
+      capture_region: s.vRegion?.value || 'active-window',
+      capture_interval_s: parseFloat(s.vInterval?.value) || 1.0,
+      max_resolution: [parseInt(s.vMaxW?.value) || 1920, parseInt(s.vMaxH?.value) || 1080],
+      compression: {
+        format: s.vCompFmt?.value || 'jpeg',
+        quality: parseInt(s.vCompQual?.value) || 85,
+      },
+      attention: {
+        ssim_threshold: parseFloat(s.vSsim?.value) || 0.05,
+        cooldown_ms: parseInt(s.vCooldown?.value) || 500,
+        roi_enabled: s.vRoi?.checked ?? false,
+      },
+    },
+    speech: {
+      tts: {
+        engine: s.sEngine?.value || 'piper',
+        voice_model: s.sVoiceModel?.value || '',
+        model_path: s.sModelPath?.value || '',
+        speaking_rate: parseFloat(s.sRate?.value) || 1.0,
+        volume: parseFloat(s.sVolume?.value) || 1.0,
+        output_device: s.sOutputDevice?.value || '',
+      },
+    },
+  };
+}
+
+async function saveSensesConfig() {
+  if (!validateSensesForm()) return;
+  const payload = collectSensesPayload();
+  if (els.senses.saveStatus) els.senses.saveStatus.textContent = 'Saving...';
+  try {
+    const res = await fetch('/api/senses', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || `save failed (${res.status})`);
+    }
+    sensesData = await res.json();
+    populateSensesForm(sensesData);
+    if (els.senses.saveStatus) els.senses.saveStatus.textContent = 'Saved.';
+  } catch (err) {
+    if (els.senses.saveStatus) els.senses.saveStatus.textContent = `Save failed: ${err.message}`;
+  }
+}
+
 function bindEvents() {
   for (const link of els.navLinks) {
     link.addEventListener('click', () => setView(link.dataset.viewTarget));
@@ -974,6 +1186,20 @@ function bindEvents() {
       }
     });
   }
+
+  // Senses events
+  if (els.senses.saveBtn) {
+    els.senses.saveBtn.addEventListener('click', saveSensesConfig);
+  }
+  // Collapsible sections
+  document.querySelectorAll('[data-collapse-toggle]').forEach(toggle => {
+    toggle.addEventListener('click', () => {
+      const target = document.getElementById(toggle.dataset.collapseToggle);
+      if (target) target.classList.toggle('collapsed');
+      const icon = toggle.querySelector('.collapse-icon');
+      if (icon) icon.textContent = target?.classList.contains('collapsed') ? '▸' : '▾';
+    });
+  });
 
   // Update model dropdown when system provider changes
   document.querySelectorAll('.system-provider').forEach(select => {

--- a/src/openbad/wui/static/index.html
+++ b/src/openbad/wui/static/index.html
@@ -22,6 +22,7 @@
         <button type="button" class="nav-link active" data-view-target="health">Health</button>
         <button type="button" class="nav-link" data-view-target="chat">Chat</button>
         <button type="button" class="nav-link" data-view-target="providers">Providers</button>
+        <button type="button" class="nav-link" data-view-target="senses">Senses</button>
         <button type="button" class="nav-link" data-view-target="models">Models <span class="nav-chip">next</span></button>
       </nav>
       <div class="nav-status">
@@ -297,6 +298,100 @@
               <button id="save-systems" type="button" class="primary-button">Save assignments</button>
             </div>
             <p id="systems-save-status" class="inline-status"></p>
+          </article>
+        </div>
+      </section>
+
+      <section id="view-senses" class="view-panel reveal hidden" data-view="senses">
+        <div class="panel-grid single-column">
+          <!-- Vision -->
+          <article class="card section-card collapsible" id="senses-vision-card">
+            <div class="section-head" data-collapse-toggle="senses-vision-body">
+              <h3>Vision</h3>
+              <span class="collapse-icon">▾</span>
+            </div>
+            <div id="senses-vision-body" class="collapse-body">
+              <label>FPS (idle) <input type="number" id="sens-vision-fps-idle" min="0.1" max="30" step="0.1"></label>
+              <label>FPS (active) <input type="number" id="sens-vision-fps-active" min="0.1" max="60" step="0.1"></label>
+              <label>Capture region
+                <select id="sens-vision-capture-region">
+                  <option value="full-screen">full-screen</option>
+                  <option value="active-window">active-window</option>
+                  <option value="custom-rect">custom-rect</option>
+                </select>
+              </label>
+              <label>Capture interval (s) <input type="number" id="sens-vision-interval" min="0.1" max="60" step="0.1"></label>
+              <label>Max width <input type="number" id="sens-vision-max-w" min="1" max="7680"></label>
+              <label>Max height <input type="number" id="sens-vision-max-h" min="1" max="4320"></label>
+              <label>Compression format
+                <select id="sens-vision-comp-format">
+                  <option value="jpeg">jpeg</option>
+                  <option value="png">png</option>
+                </select>
+              </label>
+              <label>Compression quality <input type="number" id="sens-vision-comp-quality" min="1" max="100"></label>
+              <label>SSIM threshold <input type="number" id="sens-vision-ssim" min="0" max="1" step="0.01"></label>
+              <label>Cooldown (ms) <input type="number" id="sens-vision-cooldown" min="0" max="10000"></label>
+              <label>ROI enabled <input type="checkbox" id="sens-vision-roi"></label>
+              <p id="sens-vision-error" class="inline-error"></p>
+            </div>
+          </article>
+
+          <!-- Hearing -->
+          <article class="card section-card collapsible" id="senses-hearing-card">
+            <div class="section-head" data-collapse-toggle="senses-hearing-body">
+              <h3>Hearing</h3>
+              <span class="collapse-icon">▾</span>
+            </div>
+            <div id="senses-hearing-body" class="collapse-body">
+              <label>Sample rate <input type="number" id="sens-hearing-sample-rate" min="8000" max="48000"></label>
+              <label>Channels <input type="number" id="sens-hearing-channels" min="1" max="2"></label>
+              <label>Sample format <input type="text" id="sens-hearing-format" placeholder="s16le"></label>
+              <label>Chunk duration (ms) <input type="number" id="sens-hearing-chunk-ms" min="10" max="1000"></label>
+              <label>Device <input type="text" id="sens-hearing-device" placeholder="default"></label>
+              <label>Passive <input type="checkbox" id="sens-hearing-passive"></label>
+              <label>ASR engine
+                <select id="sens-hearing-asr-engine">
+                  <option value="vosk">vosk</option>
+                  <option value="whisper">whisper</option>
+                </select>
+              </label>
+              <label>Vosk model path <input type="text" id="sens-hearing-vosk-path"></label>
+              <label>Whisper model <input type="text" id="sens-hearing-whisper-model" placeholder="base"></label>
+              <label>VAD sensitivity <input type="number" id="sens-hearing-vad" min="0" max="1" step="0.1"></label>
+              <label>Wake phrases <input type="text" id="sens-hearing-phrases" placeholder="hey agent"></label>
+              <label>Wake threshold <input type="number" id="sens-hearing-threshold" min="0" max="1" step="0.05"></label>
+              <p id="sens-hearing-error" class="inline-error"></p>
+            </div>
+          </article>
+
+          <!-- Speech -->
+          <article class="card section-card collapsible" id="senses-speech-card">
+            <div class="section-head" data-collapse-toggle="senses-speech-body">
+              <h3>Speech</h3>
+              <span class="collapse-icon">▾</span>
+            </div>
+            <div id="senses-speech-body" class="collapse-body">
+              <label>TTS engine
+                <select id="sens-speech-engine">
+                  <option value="piper">piper</option>
+                  <option value="espeak">espeak</option>
+                  <option value="disabled">disabled</option>
+                </select>
+              </label>
+              <label>Voice model <input type="text" id="sens-speech-voice-model"></label>
+              <label>Model path <input type="text" id="sens-speech-model-path"></label>
+              <label>Speaking rate <input type="number" id="sens-speech-rate" min="0.25" max="4" step="0.05"></label>
+              <label>Volume <input type="number" id="sens-speech-volume" min="0" max="1" step="0.05"></label>
+              <label>Output device <input type="text" id="sens-speech-output-device" placeholder="default"></label>
+              <p id="sens-speech-error" class="inline-error"></p>
+            </div>
+          </article>
+
+          <!-- Save -->
+          <article class="card section-card">
+            <button type="button" id="senses-save-btn" class="btn primary">Save Senses</button>
+            <p id="senses-save-status" class="inline-status"></p>
           </article>
         </div>
       </section>

--- a/src/openbad/wui/static/styles.css
+++ b/src/openbad/wui/static/styles.css
@@ -734,4 +734,29 @@ textarea {
   margin-top: 0.5rem;
   align-items: center;
 }
+
+/* ── Senses panel ──────────────────────────────────────────────── */
+.collapsible .section-head { cursor: pointer; user-select: none; }
+.collapse-icon { float: right; font-size: 0.9rem; }
+.collapse-body { padding: 0.5rem 0; }
+.collapse-body.collapsed { display: none; }
+.collapse-body label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+}
+.collapse-body input[type="number"],
+.collapse-body input[type="text"],
+.collapse-body select {
+  width: 180px;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+  background: var(--surface);
+  color: var(--fg);
+}
+.collapse-body input[type="checkbox"] { width: auto; }
+.inline-error { color: var(--red); font-size: 0.85rem; min-height: 1.2em; }
 .fallback-controls select, .fallback-controls input { flex: 1; }

--- a/tests/test_wui_server.py
+++ b/tests/test_wui_server.py
@@ -488,3 +488,115 @@ async def test_put_systems_rejects_invalid_body(aiohttp_client, tmp_path, monkey
 
     resp = await client.put("/api/systems", json={"systems": "bad", "fallback_chain": []})
     assert resp.status == 400
+
+
+# ── Senses endpoint tests ──────────────────────────────────────── #
+
+
+def _senses_yaml(tmp_path, monkeypatch):
+    """Create a temporary senses.yaml and point env there."""
+    config_dir = tmp_path / "openbad"
+    config_dir.mkdir(exist_ok=True)
+    data = {
+        "hearing": {
+            "capture": {"sample_rate": 16000},
+            "asr": {"default_engine": "vosk", "vad_sensitivity": 0.5},
+            "wake_word": {"phrases": ["hey agent"], "threshold": 0.5},
+        },
+        "vision": {
+            "fps_idle": 1.0,
+            "fps_active": 5.0,
+            "capture_region": "active-window",
+            "capture_interval_s": 1.0,
+            "max_resolution": [1920, 1080],
+            "compression": {"format": "jpeg", "quality": 85},
+            "attention": {"ssim_threshold": 0.05, "cooldown_ms": 500, "roi_enabled": False},
+        },
+        "speech": {
+            "tts": {"engine": "piper", "speaking_rate": 1.0, "volume": 1.0},
+        },
+    }
+    (config_dir / "senses.yaml").write_text(yaml.safe_dump(data, sort_keys=False))
+    monkeypatch.setenv("OPENBAD_CONFIG_DIR", str(config_dir))
+    return config_dir
+
+
+@pytest.mark.asyncio
+async def test_get_senses(aiohttp_client, tmp_path, monkeypatch):
+    _senses_yaml(tmp_path, monkeypatch)
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+    resp = await client.get("/api/senses")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "hearing" in data
+    assert "vision" in data
+    assert "speech" in data
+    assert data["hearing"]["asr"]["default_engine"] == "vosk"
+    assert data["vision"]["capture_region"] == "active-window"
+    assert data["speech"]["tts"]["engine"] == "piper"
+
+
+@pytest.mark.asyncio
+async def test_put_senses_valid(aiohttp_client, tmp_path, monkeypatch):
+    config_dir = _senses_yaml(tmp_path, monkeypatch)
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    payload = {
+        "hearing": {
+            "capture": {"sample_rate": 22050},
+            "asr": {"default_engine": "whisper", "vad_sensitivity": 0.7},
+            "wake_word": {"phrases": ["computer"], "threshold": 0.6},
+        },
+        "vision": {
+            "fps_idle": 2.0,
+            "fps_active": 10.0,
+            "capture_region": "full-screen",
+            "capture_interval_s": 0.5,
+            "max_resolution": [3840, 2160],
+            "compression": {"format": "png", "quality": 100},
+            "attention": {"ssim_threshold": 0.1, "cooldown_ms": 1000, "roi_enabled": True},
+        },
+        "speech": {
+            "tts": {"engine": "espeak", "speaking_rate": 1.5, "volume": 0.8},
+        },
+    }
+    resp = await client.put("/api/senses", json=payload)
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["hearing"]["asr"]["default_engine"] == "whisper"
+    assert data["vision"]["capture_region"] == "full-screen"
+    assert data["speech"]["tts"]["engine"] == "espeak"
+
+    # Verify file was written
+    saved = yaml.safe_load((config_dir / "senses.yaml").read_text())
+    assert saved["hearing"]["asr"]["default_engine"] == "whisper"
+
+
+@pytest.mark.asyncio
+async def test_put_senses_validation_error(aiohttp_client, tmp_path, monkeypatch):
+    _senses_yaml(tmp_path, monkeypatch)
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    payload = {
+        "hearing": {
+            "asr": {"default_engine": "invalid-engine"},
+            "wake_word": {"phrases": ["hey"], "threshold": 0.5},
+        },
+    }
+    resp = await client.put("/api/senses", json=payload)
+    assert resp.status == 400
+    text = await resp.text()
+    assert "default_engine" in text
+
+
+@pytest.mark.asyncio
+async def test_put_senses_rejects_non_object(aiohttp_client, tmp_path, monkeypatch):
+    _senses_yaml(tmp_path, monkeypatch)
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+
+    resp = await client.put("/api/senses", json="bad")
+    assert resp.status == 400


### PR DESCRIPTION
Closes #230\n\n## Summary\n- Added Senses nav tab and view panel with three collapsible sections (Vision, Hearing, Speech)\n- Form controls for all VisionConfig, HearingConfig, SpeechConfig fields\n- Client-side validation (FPS range, non-empty wake phrases, speaking rate bounds)\n- REST endpoints: `GET /api/senses` returns serialized SensoryConfig, `PUT /api/senses` validates and writes to senses.yaml\n- Toast-style status messages on save success/failure\n- CSS for collapsible cards, form layout, inline error messages\n- 4 new tests: GET senses, PUT valid payload, PUT validation error, PUT non-object rejection\n\n## How to test\n```bash\npytest tests/test_wui_server.py -v  # 29 tests\nruff check\n```