### PR TITLE
#231: Integrate sensory health checks into proprioception heartbeat

### DIFF
--- a/src/openbad/endocrine/hooks/cortisol.py
+++ b/src/openbad/endocrine/hooks/cortisol.py
@@ -55,6 +55,11 @@ class CortisolHooks:
         amount *= min(float(error_count), 3.0)
         return self._controller.trigger("cortisol", amount)
 
+    def on_tool_degraded(self, tool_name: str, reason: str = "") -> float:
+        """Fire cortisol when a sensory tool transitions to DEGRADED."""
+        amount = self._controller._config.cortisol.increment  # noqa: SLF001
+        return self._controller.trigger("cortisol", amount)
+
     def fire(self, event: CortisolEvent) -> float:
         """Generic cortisol trigger from a ``CortisolEvent``."""
         amount = (

--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -24,6 +24,7 @@ TELEMETRY_MEMORY = "agent/telemetry/memory"
 TELEMETRY_DISK = "agent/telemetry/disk"
 TELEMETRY_NETWORK = "agent/telemetry/network"
 TELEMETRY_TOKENS = "agent/telemetry/tokens"
+TELEMETRY_SENSORY_HEALTH = "agent/telemetry/sensory_health"
 
 # Wildcard: subscribe to all telemetry
 TELEMETRY_ALL = "agent/telemetry/+"

--- a/src/openbad/proprioception/registry.py
+++ b/src/openbad/proprioception/registry.py
@@ -30,6 +30,7 @@ STATE_TOPIC = "agent/proprioception/state"
 
 class HealthStatus(Enum):
     AVAILABLE = "AVAILABLE"
+    DEGRADED = "DEGRADED"
     UNAVAILABLE = "UNAVAILABLE"
 
 
@@ -41,6 +42,7 @@ class ToolStatus:
     status: HealthStatus = HealthStatus.AVAILABLE
     last_heartbeat: float = field(default_factory=time.time)
     metadata: dict[str, str] = field(default_factory=dict)
+    health_check: Callable[[], bool] | None = field(default=None, repr=False)
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +78,7 @@ class ToolRegistry:
         self,
         name: str,
         metadata: dict[str, str] | None = None,
+        health_check: Callable[[], bool] | None = None,
     ) -> ToolStatus:
         """Register a tool/subsystem.  Idempotent for the same *name*."""
         with self._lock:
@@ -85,10 +88,13 @@ class ToolRegistry:
                 entry.last_heartbeat = time.time()
                 if metadata:
                     entry.metadata.update(metadata)
+                if health_check is not None:
+                    entry.health_check = health_check
             else:
                 entry = ToolStatus(
                     name=name,
                     metadata=metadata or {},
+                    health_check=health_check,
                 )
                 self._tools[name] = entry
         self._emit_snapshot()
@@ -121,6 +127,59 @@ class ToolRegistry:
                 changed = True
         if changed:
             self._emit_snapshot()
+
+    def mark_degraded(self, name: str, reason: str = "") -> bool:
+        """Transition a tool to DEGRADED status.
+
+        Returns ``True`` if the status actually changed.
+        """
+        changed = False
+        with self._lock:
+            entry = self._tools.get(name)
+            if entry is None:
+                return False
+            if entry.status is not HealthStatus.DEGRADED:
+                entry.status = HealthStatus.DEGRADED
+                if reason:
+                    entry.metadata["degraded_reason"] = reason
+                changed = True
+        if changed:
+            self._emit_snapshot()
+        return changed
+
+    def run_health_checks(self) -> list[str]:
+        """Run registered health checks and mark failing tools DEGRADED.
+
+        Returns list of tool names that transitioned to DEGRADED.
+        """
+        degraded: list[str] = []
+        with self._lock:
+            tools_to_check = [
+                (t.name, t.health_check)
+                for t in self._tools.values()
+                if t.health_check is not None and t.status is not HealthStatus.UNAVAILABLE
+            ]
+        for name, check in tools_to_check:
+            try:
+                healthy = check()
+            except Exception:
+                logger.exception("Health check failed for %s", name)
+                healthy = False
+            if not healthy:
+                if self.mark_degraded(name, reason="health check failed"):
+                    degraded.append(name)
+            else:
+                # Recover from DEGRADED if check passes
+                with self._lock:
+                    entry = self._tools.get(name)
+                    if entry and entry.status is HealthStatus.DEGRADED:
+                        entry.status = HealthStatus.AVAILABLE
+                        degraded_cleared = True
+                    else:
+                        degraded_cleared = False
+                if degraded_cleared:
+                    self._emit_snapshot()
+        return degraded
 
     # -- querying -----------------------------------------------------------
 

--- a/src/openbad/sensory/health.py
+++ b/src/openbad/sensory/health.py
@@ -1,0 +1,107 @@
+"""Sensory health integration — registers modalities with proprioception.
+
+Each enabled sensory modality (vision, hearing, speech) registers as a tool
+in the :class:`ToolRegistry` with a health-check callback.  When a health
+check fails, the tool transitions to DEGRADED and a telemetry event is
+published on ``agent/telemetry/sensory_health``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from openbad.nervous_system.topics import TELEMETRY_SENSORY_HEALTH
+from openbad.proprioception.registry import HealthStatus, ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+SENSORY_TOOLS = ("sensory.vision", "sensory.hearing", "sensory.speech")
+
+
+@dataclass
+class SensoryHealthEvent:
+    """Published when a sensory modality health status changes."""
+
+    modality: str
+    status: str
+    reason: str = ""
+    timestamp: float = 0.0
+
+    def to_bytes(self) -> bytes:
+        if self.timestamp == 0.0:
+            self.timestamp = time.time()
+        return json.dumps({
+            "modality": self.modality,
+            "status": self.status,
+            "reason": self.reason,
+            "timestamp": self.timestamp,
+        }).encode()
+
+
+def register_sensory_tools(
+    registry: ToolRegistry,
+    *,
+    vision_check: Callable[[], bool] | None = None,
+    hearing_check: Callable[[], bool] | None = None,
+    speech_check: Callable[[], bool] | None = None,
+) -> None:
+    """Register vision, hearing, and speech as proprioception tools."""
+    registry.register(
+        "sensory.vision",
+        metadata={"modality": "vision"},
+        health_check=vision_check,
+    )
+    registry.register(
+        "sensory.hearing",
+        metadata={"modality": "hearing"},
+        health_check=hearing_check,
+    )
+    registry.register(
+        "sensory.speech",
+        metadata={"modality": "speech"},
+        health_check=speech_check,
+    )
+
+
+def check_sensory_health(
+    registry: ToolRegistry,
+    publish_fn: Callable[[str, bytes], None] | None = None,
+    cortisol_hook: Callable[[str, str], float] | None = None,
+) -> list[str]:
+    """Run health checks on sensory tools, publish events for degraded ones.
+
+    Returns list of modality names that transitioned to DEGRADED.
+    """
+    degraded = registry.run_health_checks()
+    sensory_degraded = [n for n in degraded if n in SENSORY_TOOLS]
+
+    for name in sensory_degraded:
+        modality = name.split(".")[-1]
+        tool = next(
+            (t for t in registry.get_all_tools() if t.name == name),
+            None,
+        )
+        reason = (tool.metadata.get("degraded_reason", "") if tool else "")
+
+        event = SensoryHealthEvent(
+            modality=modality,
+            status=HealthStatus.DEGRADED.value,
+            reason=reason,
+        )
+        if publish_fn is not None:
+            try:
+                publish_fn(TELEMETRY_SENSORY_HEALTH, event.to_bytes())
+            except Exception:
+                logger.exception("Failed to publish sensory health event")
+
+        if cortisol_hook is not None:
+            try:
+                cortisol_hook(name, reason)
+            except Exception:
+                logger.exception("Cortisol hook failed for %s", name)
+
+    return sensory_degraded

--- a/tests/test_sensory_health.py
+++ b/tests/test_sensory_health.py
@@ -1,0 +1,204 @@
+"""Tests for sensory health integration — Issue #231."""
+
+from __future__ import annotations
+
+import json
+
+from openbad.proprioception.registry import HealthStatus, ToolRegistry
+from openbad.sensory.health import (
+    SensoryHealthEvent,
+    check_sensory_health,
+    register_sensory_tools,
+)
+
+# ── Registration ──────────────────────────────────────────────────── #
+
+
+class TestRegistration:
+    def test_registers_three_tools(self) -> None:
+        registry = ToolRegistry()
+        register_sensory_tools(registry)
+        names = {t.name for t in registry.get_all_tools()}
+        assert names == {"sensory.vision", "sensory.hearing", "sensory.speech"}
+
+    def test_all_available_after_registration(self) -> None:
+        registry = ToolRegistry()
+        register_sensory_tools(registry)
+        for tool in registry.get_all_tools():
+            assert tool.status is HealthStatus.AVAILABLE
+
+    def test_health_checks_attached(self) -> None:
+        registry = ToolRegistry()
+        register_sensory_tools(
+            registry,
+            vision_check=lambda: True,
+            hearing_check=lambda: True,
+            speech_check=lambda: True,
+        )
+        for tool in registry.get_all_tools():
+            assert tool.health_check is not None
+
+
+# ── Heartbeat ─────────────────────────────────────────────────────── #
+
+
+class TestHeartbeat:
+    def test_heartbeat_updates_timestamp(self) -> None:
+        import time
+
+        registry = ToolRegistry()
+        register_sensory_tools(registry)
+        old_ts = registry.get_all_tools()[0].last_heartbeat
+        time.sleep(0.01)
+        registry.heartbeat("sensory.vision")
+        new_ts = next(t for t in registry.get_all_tools() if t.name == "sensory.vision")
+        assert new_ts.last_heartbeat > old_ts
+
+    def test_heartbeat_revives_degraded(self) -> None:
+        registry = ToolRegistry()
+        register_sensory_tools(registry)
+        registry.mark_degraded("sensory.vision", "test")
+        assert next(
+            t for t in registry.get_all_tools() if t.name == "sensory.vision"
+        ).status is HealthStatus.DEGRADED
+        registry.heartbeat("sensory.vision")
+        assert next(
+            t for t in registry.get_all_tools() if t.name == "sensory.vision"
+        ).status is HealthStatus.AVAILABLE
+
+
+# ── Degradation ───────────────────────────────────────────────────── #
+
+
+class TestDegradation:
+    def test_mark_degraded(self) -> None:
+        registry = ToolRegistry()
+        register_sensory_tools(registry)
+        changed = registry.mark_degraded("sensory.hearing", "model missing")
+        assert changed
+        tool = next(t for t in registry.get_all_tools() if t.name == "sensory.hearing")
+        assert tool.status is HealthStatus.DEGRADED
+        assert tool.metadata["degraded_reason"] == "model missing"
+
+    def test_mark_degraded_idempotent(self) -> None:
+        registry = ToolRegistry()
+        register_sensory_tools(registry)
+        registry.mark_degraded("sensory.hearing", "reason")
+        changed = registry.mark_degraded("sensory.hearing", "reason")
+        assert not changed
+
+    def test_mark_degraded_nonexistent(self) -> None:
+        registry = ToolRegistry()
+        assert not registry.mark_degraded("nonexistent", "reason")
+
+    def test_health_check_failure_marks_degraded(self) -> None:
+        registry = ToolRegistry()
+        register_sensory_tools(
+            registry,
+            vision_check=lambda: False,
+            hearing_check=lambda: True,
+            speech_check=lambda: True,
+        )
+        degraded = registry.run_health_checks()
+        assert "sensory.vision" in degraded
+        tool = next(t for t in registry.get_all_tools() if t.name == "sensory.vision")
+        assert tool.status is HealthStatus.DEGRADED
+
+    def test_health_check_recovery(self) -> None:
+        healthy = [False]
+        registry = ToolRegistry()
+        register_sensory_tools(registry, vision_check=lambda: healthy[0])
+        registry.run_health_checks()
+        tool = next(t for t in registry.get_all_tools() if t.name == "sensory.vision")
+        assert tool.status is HealthStatus.DEGRADED
+        healthy[0] = True
+        registry.run_health_checks()
+        tool = next(t for t in registry.get_all_tools() if t.name == "sensory.vision")
+        assert tool.status is HealthStatus.AVAILABLE
+
+    def test_health_check_exception_marks_degraded(self) -> None:
+        def bad_check() -> bool:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        registry = ToolRegistry()
+        register_sensory_tools(registry, vision_check=bad_check)
+        degraded = registry.run_health_checks()
+        assert "sensory.vision" in degraded
+
+
+# ── Sensory health event publishing ──────────────────────────────── #
+
+
+class TestSensoryHealthEvent:
+    def test_event_serialization(self) -> None:
+        evt = SensoryHealthEvent(modality="vision", status="DEGRADED", reason="test")
+        data = json.loads(evt.to_bytes())
+        assert data["modality"] == "vision"
+        assert data["status"] == "DEGRADED"
+        assert data["timestamp"] > 0
+
+    def test_check_publishes_event(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        def pub(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        registry = ToolRegistry(publish_fn=pub)
+        register_sensory_tools(registry, vision_check=lambda: False)
+        degraded = check_sensory_health(registry, publish_fn=pub)
+        assert "sensory.vision" in degraded
+        sensory_pubs = [
+            (t, p) for t, p in published if "sensory_health" in t
+        ]
+        assert len(sensory_pubs) >= 1
+        data = json.loads(sensory_pubs[0][1])
+        assert data["modality"] == "vision"
+        assert data["status"] == "DEGRADED"
+
+
+# ── Cortisol response ────────────────────────────────────────────── #
+
+
+class TestCortisolResponse:
+    def test_cortisol_hook_called_on_degradation(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def hook(name: str, reason: str) -> float:
+            calls.append((name, reason))
+            return 0.1
+
+        registry = ToolRegistry()
+        register_sensory_tools(registry, speech_check=lambda: False)
+        check_sensory_health(registry, cortisol_hook=hook)
+        assert len(calls) == 1
+        assert calls[0][0] == "sensory.speech"
+
+    def test_cortisol_hook_not_called_when_healthy(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def hook(name: str, reason: str) -> float:
+            calls.append((name, reason))
+            return 0.1
+
+        registry = ToolRegistry()
+        register_sensory_tools(
+            registry,
+            vision_check=lambda: True,
+            hearing_check=lambda: True,
+            speech_check=lambda: True,
+        )
+        check_sensory_health(registry, cortisol_hook=hook)
+        assert len(calls) == 0
+
+    def test_cortisol_hooks_integration(self) -> None:
+        from unittest.mock import MagicMock
+
+        from openbad.endocrine.hooks.cortisol import CortisolHooks
+
+        controller = MagicMock()
+        controller._config.cortisol.increment = 0.1
+        hooks = CortisolHooks(controller)
+        result = hooks.on_tool_degraded("sensory.vision", "PipeWire disconnected")
+        controller.trigger.assert_called_once_with("cortisol", 0.1)
+        assert result == controller.trigger.return_value


### PR DESCRIPTION
Closes #231

## Summary of changes

- **DEGRADED health status**: Added `HealthStatus.DEGRADED` to the proprioception registry enum, sitting between AVAILABLE and UNAVAILABLE.
- **Health check callbacks**: Extended `ToolRegistry.register()` to accept an optional `health_check` callable. Added `mark_degraded()` and `run_health_checks()` methods that transition tools to DEGRADED when their health check fails, with automatic recovery when checks pass again.
- **Sensory health topic**: Added `TELEMETRY_SENSORY_HEALTH = "agent/telemetry/sensory_health"` to topics.py.
- **Sensory health module** (`sensory/health.py`): `register_sensory_tools()` registers vision, hearing, and speech as proprioception tools with optional health-check callbacks. `check_sensory_health()` runs health checks, publishes `SensoryHealthEvent` on the telemetry topic, and fires the cortisol hook for degraded modalities.
- **Cortisol hook**: Added `on_tool_degraded(tool_name, reason)` to `CortisolHooks` for stress response when sensory modalities degrade.
- **16 tests** covering registration, heartbeat reviving, degradation transitions, health check recovery, event publishing, and cortisol integration.

## How to test

```bash
pytest tests/test_sensory_health.py -v
pytest tests/test_registry.py tests/test_cortisol_hooks.py tests/test_proprioceptive.py -v
ruff check
```