### PR TITLE
#232: Add ToolRole enum and role metadata to ToolRegistry

### DIFF
--- a/src/openbad/proprioception/registry.py
+++ b/src/openbad/proprioception/registry.py
@@ -34,11 +34,24 @@ class HealthStatus(Enum):
     UNAVAILABLE = "UNAVAILABLE"
 
 
+class ToolRole(Enum):
+    """Functional role for a registered tool / subsystem."""
+
+    CLI = "CLI"
+    WEB_SEARCH = "WEB_SEARCH"
+    MEMORY = "MEMORY"
+    MEDIA = "MEDIA"
+    CODE = "CODE"
+    FILE_SYSTEM = "FILE_SYSTEM"
+    COMMUNICATION = "COMMUNICATION"
+
+
 @dataclass
 class ToolStatus:
     """Live status entry for a single tool / subsystem."""
 
     name: str
+    role: ToolRole | None = None
     status: HealthStatus = HealthStatus.AVAILABLE
     last_heartbeat: float = field(default_factory=time.time)
     metadata: dict[str, str] = field(default_factory=dict)
@@ -79,6 +92,7 @@ class ToolRegistry:
         name: str,
         metadata: dict[str, str] | None = None,
         health_check: Callable[[], bool] | None = None,
+        role: ToolRole | None = None,
     ) -> ToolStatus:
         """Register a tool/subsystem.  Idempotent for the same *name*."""
         with self._lock:
@@ -90,9 +104,12 @@ class ToolRegistry:
                     entry.metadata.update(metadata)
                 if health_check is not None:
                     entry.health_check = health_check
+                if role is not None:
+                    entry.role = role
             else:
                 entry = ToolStatus(
                     name=name,
+                    role=role,
                     metadata=metadata or {},
                     health_check=health_check,
                 )
@@ -259,6 +276,7 @@ class ToolRegistry:
             return [
                 {
                     "name": t.name,
+                    "role": t.role.value if t.role else None,
                     "status": t.status.value,
                     "last_heartbeat": t.last_heartbeat,
                     "metadata": t.metadata,

--- a/src/openbad/sensory/health.py
+++ b/src/openbad/sensory/health.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from openbad.nervous_system.topics import TELEMETRY_SENSORY_HEALTH
-from openbad.proprioception.registry import HealthStatus, ToolRegistry
+from openbad.proprioception.registry import HealthStatus, ToolRegistry, ToolRole
 
 logger = logging.getLogger(__name__)
 
@@ -54,16 +54,19 @@ def register_sensory_tools(
         "sensory.vision",
         metadata={"modality": "vision"},
         health_check=vision_check,
+        role=ToolRole.MEDIA,
     )
     registry.register(
         "sensory.hearing",
         metadata={"modality": "hearing"},
         health_check=hearing_check,
+        role=ToolRole.MEDIA,
     )
     registry.register(
         "sensory.speech",
         metadata={"modality": "speech"},
         health_check=speech_check,
+        role=ToolRole.MEDIA,
     )
 
 

--- a/tests/test_tool_role.py
+++ b/tests/test_tool_role.py
@@ -1,0 +1,80 @@
+"""Tests for ToolRole enum and role metadata — Issue #232."""
+
+from __future__ import annotations
+
+from openbad.proprioception.registry import (
+    ToolRegistry,
+    ToolRole,
+    ToolStatus,
+)
+
+
+class TestToolRoleEnum:
+    def test_all_values(self) -> None:
+        expected = {"CLI", "WEB_SEARCH", "MEMORY", "MEDIA", "CODE", "FILE_SYSTEM", "COMMUNICATION"}
+        assert {r.value for r in ToolRole} == expected
+
+    def test_enum_from_string(self) -> None:
+        assert ToolRole("CLI") is ToolRole.CLI
+        assert ToolRole("WEB_SEARCH") is ToolRole.WEB_SEARCH
+
+
+class TestToolStatusWithRole:
+    def test_default_role_is_none(self) -> None:
+        ts = ToolStatus(name="test-tool")
+        assert ts.role is None
+
+    def test_role_assigned(self) -> None:
+        ts = ToolStatus(name="test-tool", role=ToolRole.CODE)
+        assert ts.role is ToolRole.CODE
+
+    def test_all_roles_assignable(self) -> None:
+        for role in ToolRole:
+            ts = ToolStatus(name=f"tool-{role.value}", role=role)
+            assert ts.role is role
+
+
+class TestRegistryWithRole:
+    def test_register_with_role(self) -> None:
+        reg = ToolRegistry()
+        entry = reg.register("cli-tool", role=ToolRole.CLI)
+        assert entry.role is ToolRole.CLI
+
+    def test_register_without_role(self) -> None:
+        reg = ToolRegistry()
+        entry = reg.register("generic-tool")
+        assert entry.role is None
+
+    def test_re_register_updates_role(self) -> None:
+        reg = ToolRegistry()
+        reg.register("tool", role=ToolRole.MEMORY)
+        entry = reg.register("tool", role=ToolRole.FILE_SYSTEM)
+        assert entry.role is ToolRole.FILE_SYSTEM
+
+    def test_re_register_preserves_role_if_none(self) -> None:
+        reg = ToolRegistry()
+        reg.register("tool", role=ToolRole.CODE)
+        entry = reg.register("tool")
+        assert entry.role is ToolRole.CODE
+
+    def test_snapshot_includes_role(self) -> None:
+        reg = ToolRegistry()
+        reg.register("web", role=ToolRole.WEB_SEARCH)
+        snap = reg.snapshot()
+        assert snap[0]["role"] == "WEB_SEARCH"
+
+    def test_snapshot_role_none(self) -> None:
+        reg = ToolRegistry()
+        reg.register("plain")
+        snap = reg.snapshot()
+        assert snap[0]["role"] is None
+
+
+class TestSensoryToolsHaveRole:
+    def test_sensory_tools_have_media_role(self) -> None:
+        from openbad.sensory.health import register_sensory_tools
+
+        reg = ToolRegistry()
+        register_sensory_tools(reg)
+        for tool in reg.get_all_tools():
+            assert tool.role is ToolRole.MEDIA, f"{tool.name} missing MEDIA role"


### PR DESCRIPTION
Closes #232

## Summary of changes

- Added `ToolRole` enum with 7 values: `CLI`, `WEB_SEARCH`, `MEMORY`, `MEDIA`, `CODE`, `FILE_SYSTEM`, `COMMUNICATION`
- Extended `ToolStatus` dataclass with `role: ToolRole | None` field (defaults to `None` for backward compatibility)
- Updated `ToolRegistry.register()` to accept optional `role` parameter, preserved on re-registration
- Updated `snapshot()` serialization to include role
- Updated sensory tool registrations in `sensory/health.py` to use `ToolRole.MEDIA`
- 12 tests covering enum values, ToolStatus construction, registry role handling, snapshot serialization, sensory integration

## How to test

```bash
pytest tests/test_tool_role.py tests/test_registry.py tests/test_sensory_health.py -v
ruff check
```