### PR TITLE
#233: Implement cabinet + belt registry (many installed, one equipped per role)

### DIFF
--- a/src/openbad/proprioception/registry.py
+++ b/src/openbad/proprioception/registry.py
@@ -83,6 +83,7 @@ class ToolRegistry:
         self._publish_fn = publish_fn
         self._lock = threading.Lock()
         self._tools: dict[str, ToolStatus] = {}
+        self._belt: dict[ToolRole, str] = {}
         self._reaper: _ReaperThread | None = None
 
     # -- registration -------------------------------------------------------
@@ -209,6 +210,58 @@ class ToolRegistry:
         """Return all registered tools regardless of status."""
         with self._lock:
             return list(self._tools.values())
+
+    # -- cabinet / belt -----------------------------------------------------
+
+    @property
+    def cabinet(self) -> dict[ToolRole, list[ToolStatus]]:
+        """All registered tools grouped by role."""
+        result: dict[ToolRole, list[ToolStatus]] = {}
+        with self._lock:
+            for t in self._tools.values():
+                if t.role is not None:
+                    result.setdefault(t.role, []).append(t)
+        return result
+
+    @property
+    def belt(self) -> dict[ToolRole, ToolStatus]:
+        """Currently equipped tool per role."""
+        with self._lock:
+            result: dict[ToolRole, ToolStatus] = {}
+            for role, name in self._belt.items():
+                entry = self._tools.get(name)
+                if entry is not None:
+                    result[role] = entry
+            return result
+
+    def equip(self, role: ToolRole, tool_name: str) -> ToolStatus:
+        """Equip a cabinet tool onto the belt for *role*.
+
+        Raises ``KeyError`` if *tool_name* is not registered or its role
+        does not match *role*.
+        """
+        with self._lock:
+            entry = self._tools.get(tool_name)
+            if entry is None:
+                msg = f"Tool {tool_name!r} not found in cabinet"
+                raise KeyError(msg)
+            if entry.role is not role:
+                msg = f"Tool {tool_name!r} has role {entry.role}, expected {role}"
+                raise KeyError(msg)
+            self._belt[role] = tool_name
+        self._emit_snapshot()
+        return entry
+
+    def unequip(self, role: ToolRole) -> None:
+        """Remove the belt entry for *role* (no error if empty)."""
+        with self._lock:
+            removed = self._belt.pop(role, None) is not None
+        if removed:
+            self._emit_snapshot()
+
+    def get_belt(self) -> dict[ToolRole, ToolStatus]:
+        """Return the active tool set for prompt injection."""
+        return self.belt
 
     # -- staleness reaper ---------------------------------------------------
 

--- a/tests/test_cabinet_belt.py
+++ b/tests/test_cabinet_belt.py
@@ -1,0 +1,96 @@
+"""Tests for cabinet/belt registry — Issue #233."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.proprioception.registry import (
+    ToolRegistry,
+    ToolRole,
+)
+
+
+@pytest.fixture()
+def reg() -> ToolRegistry:
+    r = ToolRegistry()
+    r.register("grep-tool", role=ToolRole.CLI)
+    r.register("find-tool", role=ToolRole.CLI)
+    r.register("web-search", role=ToolRole.WEB_SEARCH)
+    r.register("memory-store", role=ToolRole.MEMORY)
+    return r
+
+
+class TestCabinet:
+    def test_groups_by_role(self, reg: ToolRegistry) -> None:
+        cab = reg.cabinet
+        assert len(cab[ToolRole.CLI]) == 2
+        assert len(cab[ToolRole.WEB_SEARCH]) == 1
+        assert len(cab[ToolRole.MEMORY]) == 1
+
+    def test_excludes_tools_without_role(self) -> None:
+        r = ToolRegistry()
+        r.register("no-role-tool")
+        r.register("cli-tool", role=ToolRole.CLI)
+        cab = r.cabinet
+        assert ToolRole.CLI in cab
+        names = {t.name for tools in cab.values() for t in tools}
+        assert "no-role-tool" not in names
+
+    def test_empty_cabinet(self) -> None:
+        r = ToolRegistry()
+        assert r.cabinet == {}
+
+
+class TestEquip:
+    def test_equip_tool(self, reg: ToolRegistry) -> None:
+        entry = reg.equip(ToolRole.CLI, "grep-tool")
+        assert entry.name == "grep-tool"
+        assert reg.belt[ToolRole.CLI].name == "grep-tool"
+
+    def test_equip_replaces_previous(self, reg: ToolRegistry) -> None:
+        reg.equip(ToolRole.CLI, "grep-tool")
+        reg.equip(ToolRole.CLI, "find-tool")
+        assert reg.belt[ToolRole.CLI].name == "find-tool"
+
+    def test_equip_nonexistent_raises(self, reg: ToolRegistry) -> None:
+        with pytest.raises(KeyError, match="not found"):
+            reg.equip(ToolRole.CLI, "nonexistent")
+
+    def test_equip_wrong_role_raises(self, reg: ToolRegistry) -> None:
+        with pytest.raises(KeyError, match="has role"):
+            reg.equip(ToolRole.WEB_SEARCH, "grep-tool")
+
+    def test_only_one_per_role(self, reg: ToolRegistry) -> None:
+        reg.equip(ToolRole.CLI, "grep-tool")
+        reg.equip(ToolRole.WEB_SEARCH, "web-search")
+        belt = reg.get_belt()
+        assert len(belt) == 2
+        assert belt[ToolRole.CLI].name == "grep-tool"
+        assert belt[ToolRole.WEB_SEARCH].name == "web-search"
+
+
+class TestUnequip:
+    def test_unequip_removes_belt_entry(self, reg: ToolRegistry) -> None:
+        reg.equip(ToolRole.CLI, "grep-tool")
+        reg.unequip(ToolRole.CLI)
+        assert ToolRole.CLI not in reg.belt
+
+    def test_unequip_empty_is_noop(self, reg: ToolRegistry) -> None:
+        reg.unequip(ToolRole.CODE)  # never equipped — no error
+        assert ToolRole.CODE not in reg.belt
+
+
+class TestGetBelt:
+    def test_empty_belt(self) -> None:
+        r = ToolRegistry()
+        assert r.get_belt() == {}
+
+    def test_belt_reflects_equipped(self, reg: ToolRegistry) -> None:
+        reg.equip(ToolRole.MEMORY, "memory-store")
+        belt = reg.get_belt()
+        assert belt[ToolRole.MEMORY].name == "memory-store"
+
+    def test_belt_excludes_unregistered(self, reg: ToolRegistry) -> None:
+        reg.equip(ToolRole.CLI, "grep-tool")
+        reg.unregister("grep-tool")
+        assert ToolRole.CLI not in reg.get_belt()


### PR DESCRIPTION
Closes #233

## Summary of changes

- **Cabinet**: `cabinet` property on `ToolRegistry` returns `dict[ToolRole, list[ToolStatus]]` grouping all registered tools by role
- **Belt**: `belt` property returns `dict[ToolRole, ToolStatus]` — the single equipped tool per role
- **`equip(role, tool_name)`**: moves a cabinet tool to the belt; validates existence and role match (raises `KeyError` otherwise)
- **`unequip(role)`**: removes belt entry for a role (no-op if empty)
- **`get_belt()`**: returns the active tool set for prompt injection
- Only one tool per role on the belt at a time; re-equipping replaces the previous
- Belt entries auto-clear when the underlying tool is unregistered
- 13 tests: cabinet grouping, equip, re-equip, equip-nonexistent, equip-wrong-role, unequip, get_belt

## How to test

```bash
pytest tests/test_cabinet_belt.py tests/test_registry.py tests/test_tool_role.py -v
ruff check
```