### PR TITLE
#234: Auto-equip fallback with cortisol escalation on tool failure

### DIFF
--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -25,6 +25,7 @@ TELEMETRY_DISK = "agent/telemetry/disk"
 TELEMETRY_NETWORK = "agent/telemetry/network"
 TELEMETRY_TOKENS = "agent/telemetry/tokens"
 TELEMETRY_SENSORY_HEALTH = "agent/telemetry/sensory_health"
+TELEMETRY_TOOLBELT = "agent/telemetry/toolbelt"
 
 # Wildcard: subscribe to all telemetry
 TELEMETRY_ALL = "agent/telemetry/+"

--- a/src/openbad/proprioception/registry.py
+++ b/src/openbad/proprioception/registry.py
@@ -78,13 +78,28 @@ class ToolRegistry:
         self,
         timeout: float = 10.0,
         publish_fn: Callable[[str, bytes], None] | None = None,
+        *,
+        auto_reequip_on_recovery: bool = True,
+        swap_cortisol_increment: float = 0.15,
+        empty_role_cortisol_spike: float = 0.4,
     ) -> None:
         self._timeout = timeout
         self._publish_fn = publish_fn
+        self._auto_reequip = auto_reequip_on_recovery
+        self._swap_cortisol = swap_cortisol_increment
+        self._empty_cortisol = empty_role_cortisol_spike
         self._lock = threading.Lock()
         self._tools: dict[str, ToolStatus] = {}
         self._belt: dict[ToolRole, str] = {}
+        self._original_belt: dict[ToolRole, str] = {}
+        self._cortisol_hook: Callable[[str, str, float], None] | None = None
         self._reaper: _ReaperThread | None = None
+
+    def set_cortisol_hook(
+        self, hook: Callable[[str, str, float], None] | None
+    ) -> None:
+        """Set a cortisol callback ``(tool_name, reason, delta)``."""
+        self._cortisol_hook = hook
 
     # -- registration -------------------------------------------------------
 
@@ -262,6 +277,116 @@ class ToolRegistry:
     def get_belt(self) -> dict[ToolRole, ToolStatus]:
         """Return the active tool set for prompt injection."""
         return self.belt
+
+    def handle_tool_failure(self, tool_name: str, reason: str = "") -> str | None:
+        """Auto-swap to the next healthy tool when *tool_name* fails.
+
+        Returns the name of the replacement tool, or ``None`` if the role
+        went empty.
+        """
+        with self._lock:
+            entry = self._tools.get(tool_name)
+            if entry is None or entry.role is None:
+                return None
+            role = entry.role
+            current = self._belt.get(role)
+            if current != tool_name:
+                return None  # not the equipped tool
+
+            # Remember original for potential recovery
+            if role not in self._original_belt:
+                self._original_belt[role] = tool_name
+
+            # Find next healthy tool in cabinet for same role
+            candidates = [
+                t for t in self._tools.values()
+                if t.role is role
+                and t.name != tool_name
+                and t.status is HealthStatus.AVAILABLE
+            ]
+
+        replacement: str | None = None
+        if candidates:
+            replacement = candidates[0].name
+            with self._lock:
+                self._belt[role] = replacement
+            self._fire_cortisol(
+                replacement, f"auto-swap from {tool_name}", self._swap_cortisol
+            )
+            self._publish_toolbelt_event(
+                "swap", role, tool_name, replacement, reason
+            )
+        else:
+            with self._lock:
+                self._belt.pop(role, None)
+            self._fire_cortisol(
+                tool_name, f"no fallback for role {role.value}", self._empty_cortisol
+            )
+            self._publish_toolbelt_event(
+                "empty", role, tool_name, None, reason
+            )
+
+        self._emit_snapshot()
+        return replacement
+
+    def try_reequip_on_recovery(self, tool_name: str) -> bool:
+        """Re-equip the original tool for its role if it has recovered.
+
+        Only acts if ``auto_reequip_on_recovery`` is enabled and the tool
+        was previously swapped out.  Returns ``True`` if re-equipped.
+        """
+        if not self._auto_reequip:
+            return False
+        with self._lock:
+            entry = self._tools.get(tool_name)
+            if entry is None or entry.role is None:
+                return False
+            if entry.status is not HealthStatus.AVAILABLE:
+                return False
+            role = entry.role
+            original = self._original_belt.get(role)
+            if original != tool_name:
+                return False
+            self._belt[role] = tool_name
+            del self._original_belt[role]
+        self._publish_toolbelt_event(
+            "recovery", role, tool_name, tool_name, "original tool recovered"
+        )
+        self._emit_snapshot()
+        return True
+
+    def _fire_cortisol(
+        self, tool_name: str, reason: str, delta: float
+    ) -> None:
+        if self._cortisol_hook is not None:
+            try:
+                self._cortisol_hook(tool_name, reason, delta)
+            except Exception:
+                logger.exception("Cortisol hook failed for %s", tool_name)
+
+    def _publish_toolbelt_event(
+        self,
+        event_type: str,
+        role: ToolRole,
+        old_tool: str,
+        new_tool: str | None,
+        reason: str,
+    ) -> None:
+        if self._publish_fn is None:
+            return
+        from openbad.nervous_system.topics import TELEMETRY_TOOLBELT
+
+        payload = json.dumps({
+            "event": event_type,
+            "role": role.value,
+            "old_tool": old_tool,
+            "new_tool": new_tool,
+            "reason": reason,
+        }).encode()
+        try:
+            self._publish_fn(TELEMETRY_TOOLBELT, payload)
+        except Exception:
+            logger.exception("Failed to publish toolbelt event")
 
     # -- staleness reaper ---------------------------------------------------
 

--- a/tests/test_auto_equip.py
+++ b/tests/test_auto_equip.py
@@ -1,0 +1,167 @@
+"""Tests for auto-equip fallback with cortisol escalation — Issue #234."""
+
+from __future__ import annotations
+
+import json
+
+from openbad.proprioception.registry import (
+    ToolRegistry,
+    ToolRole,
+)
+
+
+def _make_registry(
+    **kwargs: object,
+) -> tuple[ToolRegistry, list[tuple[str, bytes]], list[tuple[str, str, float]]]:
+    published: list[tuple[str, bytes]] = []
+    cortisol_calls: list[tuple[str, str, float]] = []
+
+    def pub(topic: str, payload: bytes) -> None:
+        published.append((topic, payload))
+
+    def cortisol(name: str, reason: str, delta: float) -> None:
+        cortisol_calls.append((name, reason, delta))
+
+    reg = ToolRegistry(publish_fn=pub, **kwargs)
+    reg.set_cortisol_hook(cortisol)
+    return reg, published, cortisol_calls
+
+
+class TestFailureSwap:
+    def test_swap_to_next_healthy(self) -> None:
+        reg, published, cortisol_calls = _make_registry()
+        reg.register("tool-a", role=ToolRole.CLI)
+        reg.register("tool-b", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "tool-a")
+
+        replacement = reg.handle_tool_failure("tool-a", "timeout")
+        assert replacement == "tool-b"
+        assert reg.belt[ToolRole.CLI].name == "tool-b"
+
+    def test_cortisol_on_swap(self) -> None:
+        reg, published, cortisol_calls = _make_registry(swap_cortisol_increment=0.2)
+        reg.register("tool-a", role=ToolRole.CLI)
+        reg.register("tool-b", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "tool-a")
+
+        reg.handle_tool_failure("tool-a", "error")
+        assert len(cortisol_calls) == 1
+        assert cortisol_calls[0][2] == 0.2
+
+    def test_swap_event_published(self) -> None:
+        reg, published, _ = _make_registry()
+        reg.register("tool-a", role=ToolRole.CLI)
+        reg.register("tool-b", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "tool-a")
+
+        reg.handle_tool_failure("tool-a", "timeout")
+        toolbelt_events = [
+            json.loads(p) for t, p in published if "toolbelt" in t
+        ]
+        assert any(e["event"] == "swap" for e in toolbelt_events)
+        swap_event = next(e for e in toolbelt_events if e["event"] == "swap")
+        assert swap_event["old_tool"] == "tool-a"
+        assert swap_event["new_tool"] == "tool-b"
+        assert swap_event["role"] == "CLI"
+
+    def test_skips_unavailable_candidates(self) -> None:
+        reg, _, _ = _make_registry()
+        reg.register("a", role=ToolRole.CLI)
+        reg.register("b", role=ToolRole.CLI)
+        reg.register("c", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "a")
+        reg.mark_degraded("b", "broken")
+
+        replacement = reg.handle_tool_failure("a", "fail")
+        assert replacement == "c"
+
+
+class TestNoFallbackSpike:
+    def test_empty_role_no_healthy_fallback(self) -> None:
+        reg, _, cortisol_calls = _make_registry(empty_role_cortisol_spike=0.5)
+        reg.register("only-tool", role=ToolRole.WEB_SEARCH)
+        reg.equip(ToolRole.WEB_SEARCH, "only-tool")
+
+        replacement = reg.handle_tool_failure("only-tool", "crash")
+        assert replacement is None
+        assert ToolRole.WEB_SEARCH not in reg.belt
+        assert len(cortisol_calls) == 1
+        assert cortisol_calls[0][2] == 0.5
+
+    def test_empty_event_published(self) -> None:
+        reg, published, _ = _make_registry()
+        reg.register("solo", role=ToolRole.MEMORY)
+        reg.equip(ToolRole.MEMORY, "solo")
+
+        reg.handle_tool_failure("solo", "oom")
+        toolbelt_events = [
+            json.loads(p) for t, p in published if "toolbelt" in t
+        ]
+        assert any(e["event"] == "empty" for e in toolbelt_events)
+
+
+class TestRecoveryReequip:
+    def test_reequip_on_recovery(self) -> None:
+        reg, published, _ = _make_registry()
+        reg.register("a", role=ToolRole.CLI)
+        reg.register("b", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "a")
+        reg.handle_tool_failure("a", "timeout")
+        assert reg.belt[ToolRole.CLI].name == "b"
+
+        # Simulate recovery
+        reg.heartbeat("a")
+        reequipped = reg.try_reequip_on_recovery("a")
+        assert reequipped
+        assert reg.belt[ToolRole.CLI].name == "a"
+
+    def test_recovery_event_published(self) -> None:
+        reg, published, _ = _make_registry()
+        reg.register("a", role=ToolRole.CLI)
+        reg.register("b", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "a")
+        reg.handle_tool_failure("a", "timeout")
+        reg.heartbeat("a")
+        reg.try_reequip_on_recovery("a")
+        toolbelt_events = [
+            json.loads(p) for t, p in published if "toolbelt" in t
+        ]
+        assert any(e["event"] == "recovery" for e in toolbelt_events)
+
+    def test_no_reequip_when_disabled(self) -> None:
+        reg, _, _ = _make_registry(auto_reequip_on_recovery=False)
+        reg.register("a", role=ToolRole.CLI)
+        reg.register("b", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "a")
+        reg.handle_tool_failure("a", "timeout")
+        reg.heartbeat("a")
+        assert not reg.try_reequip_on_recovery("a")
+        assert reg.belt[ToolRole.CLI].name == "b"
+
+    def test_no_reequip_if_not_original(self) -> None:
+        reg, _, _ = _make_registry()
+        reg.register("a", role=ToolRole.CLI)
+        reg.register("b", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "a")
+        # b was never the original equipped tool
+        assert not reg.try_reequip_on_recovery("b")
+
+
+class TestEdgeCases:
+    def test_failure_nonequipped_noop(self) -> None:
+        reg, _, cortisol_calls = _make_registry()
+        reg.register("a", role=ToolRole.CLI)
+        reg.register("b", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "a")
+        result = reg.handle_tool_failure("b", "error")
+        assert result is None
+        assert len(cortisol_calls) == 0
+
+    def test_failure_unknown_tool_noop(self) -> None:
+        reg, _, _ = _make_registry()
+        assert reg.handle_tool_failure("ghost", "poof") is None
+
+    def test_failure_no_role_noop(self) -> None:
+        reg, _, _ = _make_registry()
+        reg.register("norole")
+        assert reg.handle_tool_failure("norole", "err") is None


### PR DESCRIPTION
Closes #234

## Summary of changes

- **Auto-equip on failure**: `handle_tool_failure(tool_name, reason)` swaps the equipped tool to the next healthy candidate in the same role's cabinet
- **Cortisol escalation**: Configurable `swap_cortisol_increment` (default 0.15) per swap, `empty_role_cortisol_spike` (default 0.4) when no fallback exists
- **Toolbelt telemetry**: Swap/empty/recovery events published to `agent/telemetry/toolbelt` topic
- **Recovery re-equip**: `try_reequip_on_recovery(tool_name)` re-equips the original tool when it comes back healthy; controlled by `auto_reequip_on_recovery` flag (default `True`)
- **`set_cortisol_hook()`**: Register a `(name, reason, delta)` callback for cortisol integration
- **14 tests** covering swap, cortisol on swap, empty role spike, event publishing, recovery, disabled recovery, edge cases

## How to test

```bash
pytest tests/test_auto_equip.py tests/test_cabinet_belt.py tests/test_registry.py -v
ruff check
```