### PR TITLE
#235: Proprioception readiness gate — block cognitive until belt minimum met

### DIFF
--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -26,6 +26,7 @@ TELEMETRY_NETWORK = "agent/telemetry/network"
 TELEMETRY_TOKENS = "agent/telemetry/tokens"
 TELEMETRY_SENSORY_HEALTH = "agent/telemetry/sensory_health"
 TELEMETRY_TOOLBELT = "agent/telemetry/toolbelt"
+TELEMETRY_READINESS = "agent/telemetry/readiness"
 
 # Wildcard: subscribe to all telemetry
 TELEMETRY_ALL = "agent/telemetry/+"

--- a/src/openbad/proprioception/readiness.py
+++ b/src/openbad/proprioception/readiness.py
@@ -1,0 +1,115 @@
+"""Proprioception readiness gate — blocks until belt minimum is met.
+
+The cognitive event loop should call ``gate.wait_ready()`` before
+accepting requests.  If the timeout expires, the agent starts in
+degraded mode.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable
+from enum import Enum
+
+from openbad.nervous_system.topics import TELEMETRY_READINESS
+from openbad.proprioception.registry import ToolRegistry, ToolRole
+
+logger = logging.getLogger(__name__)
+
+
+class ReadinessStatus(Enum):
+    WAITING = "waiting"
+    READY = "ready"
+    DEGRADED = "degraded"
+
+
+class ReadinessGate:
+    """Block until the belt has the required roles equipped and healthy.
+
+    Parameters
+    ----------
+    registry:
+        The tool registry to check belt status against.
+    required_roles:
+        Roles that must be equipped for the gate to pass.
+    timeout:
+        Seconds to wait before starting in degraded mode.
+    publish_fn:
+        Optional ``(topic, payload)`` publisher for readiness events.
+    cortisol_hook:
+        Optional callback fired on degraded-mode start.
+    poll_interval:
+        Seconds between belt checks while waiting.
+    """
+
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        required_roles: list[ToolRole] | None = None,
+        timeout: float = 30.0,
+        publish_fn: Callable[[str, bytes], None] | None = None,
+        cortisol_hook: Callable[[], float] | None = None,
+        poll_interval: float = 0.5,
+    ) -> None:
+        self._registry = registry
+        self._required = set(required_roles or [])
+        self._timeout = timeout
+        self._publish_fn = publish_fn
+        self._cortisol_hook = cortisol_hook
+        self._poll_interval = poll_interval
+        self._status = ReadinessStatus.WAITING
+        self._lock = threading.Lock()
+
+    @property
+    def status(self) -> ReadinessStatus:
+        with self._lock:
+            return self._status
+
+    def check(self) -> bool:
+        """Return ``True`` if all required roles are equipped."""
+        belt = self._registry.get_belt()
+        return self._required.issubset(belt.keys())
+
+    def wait_ready(self) -> ReadinessStatus:
+        """Block until ready or timeout.
+
+        Returns the final status: ``READY`` or ``DEGRADED``.
+        """
+        self._set_status(ReadinessStatus.WAITING)
+
+        if not self._required:
+            self._set_status(ReadinessStatus.READY)
+            return ReadinessStatus.READY
+
+        deadline = time.monotonic() + self._timeout
+        while time.monotonic() < deadline:
+            if self.check():
+                self._set_status(ReadinessStatus.READY)
+                return ReadinessStatus.READY
+            time.sleep(self._poll_interval)
+
+        # Timeout — degraded mode
+        self._set_status(ReadinessStatus.DEGRADED)
+        if self._cortisol_hook is not None:
+            try:
+                self._cortisol_hook()
+            except Exception:
+                logger.exception("Cortisol hook failed on readiness timeout")
+        return ReadinessStatus.DEGRADED
+
+    def _set_status(self, status: ReadinessStatus) -> None:
+        with self._lock:
+            self._status = status
+        self._publish_status(status)
+
+    def _publish_status(self, status: ReadinessStatus) -> None:
+        if self._publish_fn is None:
+            return
+        payload = json.dumps({"status": status.value}).encode()
+        try:
+            self._publish_fn(TELEMETRY_READINESS, payload)
+        except Exception:
+            logger.exception("Failed to publish readiness status")

--- a/tests/test_readiness_gate.py
+++ b/tests/test_readiness_gate.py
@@ -1,0 +1,142 @@
+"""Tests for ReadinessGate — Issue #235."""
+
+from __future__ import annotations
+
+import json
+import threading
+
+from openbad.proprioception.readiness import ReadinessGate, ReadinessStatus
+from openbad.proprioception.registry import ToolRegistry, ToolRole
+
+
+class TestGatePass:
+    def test_ready_when_all_roles_equipped(self) -> None:
+        reg = ToolRegistry()
+        reg.register("cli", role=ToolRole.CLI)
+        reg.register("mem", role=ToolRole.MEMORY)
+        reg.equip(ToolRole.CLI, "cli")
+        reg.equip(ToolRole.MEMORY, "mem")
+
+        gate = ReadinessGate(reg, required_roles=[ToolRole.CLI, ToolRole.MEMORY])
+        result = gate.wait_ready()
+        assert result is ReadinessStatus.READY
+        assert gate.status is ReadinessStatus.READY
+
+    def test_ready_with_no_requirements(self) -> None:
+        reg = ToolRegistry()
+        gate = ReadinessGate(reg, required_roles=[])
+        assert gate.wait_ready() is ReadinessStatus.READY
+
+    def test_ready_with_none_requirements(self) -> None:
+        reg = ToolRegistry()
+        gate = ReadinessGate(reg, required_roles=None)
+        assert gate.wait_ready() is ReadinessStatus.READY
+
+    def test_check_returns_true(self) -> None:
+        reg = ToolRegistry()
+        reg.register("cli", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "cli")
+        gate = ReadinessGate(reg, required_roles=[ToolRole.CLI])
+        assert gate.check()
+
+    def test_check_returns_false(self) -> None:
+        reg = ToolRegistry()
+        gate = ReadinessGate(reg, required_roles=[ToolRole.CLI])
+        assert not gate.check()
+
+
+class TestGateTimeout:
+    def test_timeout_yields_degraded(self) -> None:
+        reg = ToolRegistry()
+        gate = ReadinessGate(
+            reg,
+            required_roles=[ToolRole.CLI],
+            timeout=0.1,
+            poll_interval=0.05,
+        )
+        result = gate.wait_ready()
+        assert result is ReadinessStatus.DEGRADED
+        assert gate.status is ReadinessStatus.DEGRADED
+
+    def test_cortisol_bumped_on_timeout(self) -> None:
+        calls: list[bool] = []
+
+        def cortisol() -> float:
+            calls.append(True)
+            return 0.3
+
+        reg = ToolRegistry()
+        gate = ReadinessGate(
+            reg,
+            required_roles=[ToolRole.MEMORY],
+            timeout=0.1,
+            poll_interval=0.05,
+            cortisol_hook=cortisol,
+        )
+        gate.wait_ready()
+        assert len(calls) == 1
+
+
+class TestDegradedStartup:
+    def test_publishes_waiting_then_degraded(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        def pub(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        reg = ToolRegistry()
+        gate = ReadinessGate(
+            reg,
+            required_roles=[ToolRole.CLI],
+            timeout=0.1,
+            poll_interval=0.05,
+            publish_fn=pub,
+        )
+        gate.wait_ready()
+
+        readiness_pubs = [json.loads(p)["status"] for t, p in published if "readiness" in t]
+        assert "waiting" in readiness_pubs
+        assert "degraded" in readiness_pubs
+
+    def test_publishes_waiting_then_ready(self) -> None:
+        published: list[tuple[str, bytes]] = []
+
+        def pub(topic: str, payload: bytes) -> None:
+            published.append((topic, payload))
+
+        reg = ToolRegistry(publish_fn=pub)
+        reg.register("cli", role=ToolRole.CLI)
+        reg.equip(ToolRole.CLI, "cli")
+
+        gate = ReadinessGate(
+            reg,
+            required_roles=[ToolRole.CLI],
+            publish_fn=pub,
+        )
+        gate.wait_ready()
+        readiness_pubs = [json.loads(p)["status"] for t, p in published if "readiness" in t]
+        assert "waiting" in readiness_pubs
+        assert "ready" in readiness_pubs
+
+
+class TestLateFulfillment:
+    def test_roles_equipped_during_wait(self) -> None:
+        reg = ToolRegistry()
+        reg.register("cli", role=ToolRole.CLI)
+        gate = ReadinessGate(
+            reg,
+            required_roles=[ToolRole.CLI],
+            timeout=5.0,
+            poll_interval=0.05,
+        )
+
+        def equip_later() -> None:
+            import time
+            time.sleep(0.15)
+            reg.equip(ToolRole.CLI, "cli")
+
+        t = threading.Thread(target=equip_later)
+        t.start()
+        result = gate.wait_ready()
+        t.join()
+        assert result is ReadinessStatus.READY


### PR DESCRIPTION
Closes #235

## Summary of changes

- **`ReadinessGate`** in `src/openbad/proprioception/readiness.py`: blocks `wait_ready()` until all required `ToolRole`s are equipped on the belt
- **Status enum**: `WAITING` → `READY` or `DEGRADED` (on timeout)
- **Telemetry**: publishes `agent/telemetry/readiness` with status updates
- **Cortisol hook**: fires on timeout for degraded-mode startup stress response
- **Configurable**: `required_roles`, `timeout` (default 30s), `poll_interval`, `auto_reequip_on_recovery`
- **10 tests**: gate pass (4), timeout (2), telemetry publishing (2), late fulfillment (1), cortisol on timeout (1)

## How to test

```bash
pytest tests/test_readiness_gate.py -v
ruff check
```