### PR TITLE
#239: Add media tool adapter with permission checks

### DIFF
--- a/src/openbad/toolbelt/media_tool.py
+++ b/src/openbad/toolbelt/media_tool.py
@@ -1,0 +1,187 @@
+"""Media tool adapter — screenshot, audio clip, file read/write.
+
+Registers under ``ToolRole.MEDIA`` and wraps vision capture, audio
+capture, and sandboxed file I/O behind permission checks.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from openbad.identity.permissions import (
+    ActionTier,
+    PermissionClassifier,
+    PermissionResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MediaConfig:
+    """Configuration for the media tool adapter."""
+
+    allowed_paths: list[str] = field(default_factory=lambda: ["/tmp"])  # noqa: S108
+    max_file_bytes: int = 10 * 1024 * 1024  # 10 MB
+    audio_clip_max_seconds: float = 30.0
+
+
+@dataclass
+class CaptureResult:
+    """Result of a screenshot or audio clip capture."""
+
+    data: bytes
+    format: str
+    source: str
+    metadata: dict = field(default_factory=dict)
+
+
+class MediaToolAdapter:
+    """Cognitive-callable media tool with permission checks.
+
+    Parameters
+    ----------
+    permission_classifier:
+        Used to check permissions before executing actions.
+    config:
+        Optional media configuration.
+    vision_capture_fn:
+        Async callable returning ``(image_bytes, format_str)`` or ``None``.
+    audio_capture_fn:
+        Async callable ``(duration_s) -> (audio_bytes, format_str)`` or ``None``.
+    """
+
+    def __init__(
+        self,
+        permission_classifier: PermissionClassifier | None = None,
+        config: MediaConfig | None = None,
+        vision_capture_fn=None,
+        audio_capture_fn=None,
+    ) -> None:
+        self._perms = permission_classifier
+        self._config = config or MediaConfig()
+        self._vision_capture_fn = vision_capture_fn
+        self._audio_capture_fn = audio_capture_fn
+
+    def _check(self, action: str) -> PermissionResult | None:
+        """Return a denial PermissionResult, or None if allowed."""
+        if self._perms is None:
+            return None
+        result = self._perms.classify(action)
+        if result.tier is ActionTier.READ:
+            return None
+        # For non-READ tiers without a session manager, deny
+        return PermissionResult(
+            allowed=False,
+            action=action,
+            tier=result.tier,
+            reason="No active session for elevated action",
+        )
+
+    def _path_allowed(self, path: str) -> bool:
+        """Check path is within allowed directories."""
+        resolved = Path(path).resolve()
+        for allowed in self._config.allowed_paths:
+            if str(resolved).startswith(str(Path(allowed).resolve())):
+                return True
+        return False
+
+    async def screenshot(self) -> CaptureResult | None:
+        """Capture a screenshot via the vision subsystem."""
+        denial = self._check("media.screenshot")
+        if denial and not denial.allowed:
+            logger.warning("Permission denied: %s", denial.reason)
+            return None
+
+        if self._vision_capture_fn is None:
+            logger.warning("No vision capture backend configured")
+            return None
+
+        try:
+            image_bytes, fmt = await self._vision_capture_fn()
+            return CaptureResult(
+                data=image_bytes,
+                format=fmt,
+                source="vision",
+            )
+        except Exception:
+            logger.exception("Screenshot capture failed")
+            return None
+
+    async def audio_clip(self, duration_s: float = 5.0) -> CaptureResult | None:
+        """Record a short audio clip."""
+        denial = self._check("media.audio_clip")
+        if denial and not denial.allowed:
+            logger.warning("Permission denied: %s", denial.reason)
+            return None
+
+        if self._audio_capture_fn is None:
+            logger.warning("No audio capture backend configured")
+            return None
+
+        clamped = min(duration_s, self._config.audio_clip_max_seconds)
+        try:
+            audio_bytes, fmt = await self._audio_capture_fn(clamped)
+            return CaptureResult(
+                data=audio_bytes,
+                format=fmt,
+                source="audio",
+                metadata={"duration_s": clamped},
+            )
+        except Exception:
+            logger.exception("Audio clip capture failed")
+            return None
+
+    def read_file(self, path: str) -> bytes | None:
+        """Read a file within allowed paths."""
+        denial = self._check("media.read_file")
+        if denial and not denial.allowed:
+            logger.warning("Permission denied: %s", denial.reason)
+            return None
+
+        if not self._path_allowed(path):
+            logger.warning("Path not in allowed directories: %s", path)
+            return None
+
+        try:
+            data = Path(path).read_bytes()
+            if len(data) > self._config.max_file_bytes:
+                logger.warning("File too large: %d bytes", len(data))
+                return None
+            return data
+        except Exception:
+            logger.exception("Failed to read file: %s", path)
+            return None
+
+    def write_file(self, path: str, content: bytes) -> bool:
+        """Write content to a file within allowed paths."""
+        denial = self._check("media.write_file")
+        if denial and not denial.allowed:
+            logger.warning("Permission denied: %s", denial.reason)
+            return False
+
+        if not self._path_allowed(path):
+            logger.warning("Path not in allowed directories: %s", path)
+            return False
+
+        if len(content) > self._config.max_file_bytes:
+            logger.warning("Content too large: %d bytes", len(content))
+            return False
+
+        try:
+            target = Path(path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+            return True
+        except Exception:
+            logger.exception("Failed to write file: %s", path)
+            return False
+
+    def health_check(self) -> bool:
+        """Verify at least one media capability is available."""
+        return (
+            self._vision_capture_fn is not None
+            or self._audio_capture_fn is not None
+        )

--- a/tests/test_media_tool.py
+++ b/tests/test_media_tool.py
@@ -1,0 +1,225 @@
+"""Tests for the media tool adapter (MediaToolAdapter)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from openbad.identity.permissions import (
+    ActionTier,
+    PermissionClassifier,
+)
+from openbad.proprioception.registry import ToolRegistry, ToolRole
+from openbad.toolbelt.media_tool import (
+    CaptureResult,
+    MediaConfig,
+    MediaToolAdapter,
+)
+
+# --------------- helpers ---------------
+
+async def _fake_vision():
+    return (b"\x89PNG-fake", "png")
+
+
+async def _fake_audio(duration_s: float):
+    return (b"PCM-fake-audio", "wav")
+
+
+def _read_tier_classifier() -> PermissionClassifier:
+    """Classifier that maps all media actions to READ tier."""
+    return PermissionClassifier(
+        action_mappings={
+            "media.screenshot": ActionTier.READ,
+            "media.audio_clip": ActionTier.READ,
+            "media.read_file": ActionTier.READ,
+            "media.write_file": ActionTier.READ,
+        },
+    )
+
+
+def _write_tier_classifier() -> PermissionClassifier:
+    """Classifier that maps all media actions to WRITE tier."""
+    return PermissionClassifier(
+        action_mappings={
+            "media.screenshot": ActionTier.WRITE,
+            "media.audio_clip": ActionTier.WRITE,
+            "media.read_file": ActionTier.WRITE,
+            "media.write_file": ActionTier.WRITE,
+        },
+    )
+
+
+# --------------- screenshot ---------------
+
+class TestScreenshot:
+    def test_screenshot_returns_capture_result(self) -> None:
+        adapter = MediaToolAdapter(vision_capture_fn=_fake_vision)
+        result = asyncio.get_event_loop().run_until_complete(adapter.screenshot())
+        assert result is not None
+        assert isinstance(result, CaptureResult)
+        assert result.data == b"\x89PNG-fake"
+        assert result.format == "png"
+        assert result.source == "vision"
+
+    def test_screenshot_no_backend_returns_none(self) -> None:
+        adapter = MediaToolAdapter()
+        result = asyncio.get_event_loop().run_until_complete(adapter.screenshot())
+        assert result is None
+
+    def test_screenshot_permission_denied(self) -> None:
+        adapter = MediaToolAdapter(
+            permission_classifier=_write_tier_classifier(),
+            vision_capture_fn=_fake_vision,
+        )
+        result = asyncio.get_event_loop().run_until_complete(adapter.screenshot())
+        assert result is None
+
+    def test_screenshot_permission_allowed(self) -> None:
+        adapter = MediaToolAdapter(
+            permission_classifier=_read_tier_classifier(),
+            vision_capture_fn=_fake_vision,
+        )
+        result = asyncio.get_event_loop().run_until_complete(adapter.screenshot())
+        assert result is not None
+
+
+# --------------- audio_clip ---------------
+
+class TestAudioClip:
+    def test_audio_clip_returns_capture_result(self) -> None:
+        adapter = MediaToolAdapter(audio_capture_fn=_fake_audio)
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.audio_clip(3.0),
+        )
+        assert result is not None
+        assert result.data == b"PCM-fake-audio"
+        assert result.format == "wav"
+        assert result.metadata["duration_s"] == 3.0
+
+    def test_audio_clip_clamps_duration(self) -> None:
+        cfg = MediaConfig(audio_clip_max_seconds=5.0)
+        adapter = MediaToolAdapter(config=cfg, audio_capture_fn=_fake_audio)
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.audio_clip(100.0),
+        )
+        assert result is not None
+        assert result.metadata["duration_s"] == 5.0
+
+    def test_audio_clip_no_backend(self) -> None:
+        adapter = MediaToolAdapter()
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.audio_clip(1.0),
+        )
+        assert result is None
+
+    def test_audio_clip_permission_denied(self) -> None:
+        adapter = MediaToolAdapter(
+            permission_classifier=_write_tier_classifier(),
+            audio_capture_fn=_fake_audio,
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.audio_clip(1.0),
+        )
+        assert result is None
+
+
+# --------------- read_file ---------------
+
+class TestReadFile:
+    def test_read_file_success(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.txt"
+        target.write_bytes(b"hello")
+        cfg = MediaConfig(allowed_paths=[str(tmp_path)])
+        adapter = MediaToolAdapter(config=cfg)
+        data = adapter.read_file(str(target))
+        assert data == b"hello"
+
+    def test_read_file_outside_allowed(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.txt"
+        target.write_bytes(b"secret")
+        cfg = MediaConfig(allowed_paths=["/nonexistent"])
+        adapter = MediaToolAdapter(config=cfg)
+        assert adapter.read_file(str(target)) is None
+
+    def test_read_file_too_large(self, tmp_path: Path) -> None:
+        target = tmp_path / "big.bin"
+        target.write_bytes(b"x" * 200)
+        cfg = MediaConfig(allowed_paths=[str(tmp_path)], max_file_bytes=100)
+        adapter = MediaToolAdapter(config=cfg)
+        assert adapter.read_file(str(target)) is None
+
+    def test_read_file_permission_denied(self, tmp_path: Path) -> None:
+        target = tmp_path / "data.txt"
+        target.write_bytes(b"hello")
+        cfg = MediaConfig(allowed_paths=[str(tmp_path)])
+        adapter = MediaToolAdapter(
+            permission_classifier=_write_tier_classifier(),
+            config=cfg,
+        )
+        assert adapter.read_file(str(target)) is None
+
+
+# --------------- write_file ---------------
+
+class TestWriteFile:
+    def test_write_file_success(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        cfg = MediaConfig(allowed_paths=[str(tmp_path)])
+        adapter = MediaToolAdapter(config=cfg)
+        assert adapter.write_file(str(target), b"world") is True
+        assert target.read_bytes() == b"world"
+
+    def test_write_file_outside_allowed(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        cfg = MediaConfig(allowed_paths=["/nonexistent"])
+        adapter = MediaToolAdapter(config=cfg)
+        assert adapter.write_file(str(target), b"hack") is False
+        assert not target.exists()
+
+    def test_write_file_too_large(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.bin"
+        cfg = MediaConfig(allowed_paths=[str(tmp_path)], max_file_bytes=10)
+        adapter = MediaToolAdapter(config=cfg)
+        assert adapter.write_file(str(target), b"x" * 100) is False
+
+    def test_write_file_permission_denied(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        cfg = MediaConfig(allowed_paths=[str(tmp_path)])
+        adapter = MediaToolAdapter(
+            permission_classifier=_write_tier_classifier(),
+            config=cfg,
+        )
+        assert adapter.write_file(str(target), b"no") is False
+
+
+# --------------- health_check ---------------
+
+class TestHealthCheck:
+    def test_healthy_with_vision(self) -> None:
+        adapter = MediaToolAdapter(vision_capture_fn=_fake_vision)
+        assert adapter.health_check() is True
+
+    def test_healthy_with_audio(self) -> None:
+        adapter = MediaToolAdapter(audio_capture_fn=_fake_audio)
+        assert adapter.health_check() is True
+
+    def test_unhealthy_no_backends(self) -> None:
+        adapter = MediaToolAdapter()
+        assert adapter.health_check() is False
+
+
+# --------------- registration ---------------
+
+class TestRegistration:
+    def test_registers_under_media_role(self) -> None:
+        adapter = MediaToolAdapter(vision_capture_fn=_fake_vision)
+        registry = ToolRegistry(timeout=30.0)
+        registry.register(
+            "media",
+            role=ToolRole.MEDIA,
+            health_check=adapter.health_check,
+        )
+        cabinet = registry.cabinet
+        assert ToolRole.MEDIA in cabinet
+        assert any(t.name == "media" for t in cabinet[ToolRole.MEDIA])


### PR DESCRIPTION
Closes #239

## Summary
Adds `MediaToolAdapter` in `src/openbad/toolbelt/media_tool.py` — a media tool that registers under `ToolRole.MEDIA` with permission-gated actions:

- **`screenshot()`** — delegates to injected vision capture function, returns `CaptureResult`
- **`audio_clip(duration_s)`** — delegates to injected audio capture function, clamps to max duration
- **`read_file(path)`** — reads files within allowed path boundaries, enforces size limits
- **`write_file(path, content)`** — writes files within allowed paths with size checks
- **`health_check()`** — returns True if at least one media backend is configured

All actions check `PermissionClassifier` before executing — READ tier actions are always allowed, higher tiers are denied without an active session.

## Tests
20 unit tests in `tests/test_media_tool.py`:
- Screenshot: success, no backend, permission denied, permission allowed
- Audio clip: success, duration clamping, no backend, permission denied
- Read file: success, path denial, too large, permission denied
- Write file: success, path denial, too large, permission denied
- Health check: healthy with vision/audio, unhealthy with no backends
- Registration: registers under `ToolRole.MEDIA`

## How to test
```bash
pytest tests/test_media_tool.py -v
ruff check src/openbad/toolbelt/media_tool.py tests/test_media_tool.py
```