### PR TITLE
#240: Add WUI toolbelt panel with REST endpoints

### DIFF
--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -596,6 +596,92 @@ async def _put_senses(request: web.Request) -> web.Response:
     return web.json_response(_serialize_senses(cfg))
 
 
+# ---------------------------------------------------------------------------
+# Toolbelt API — GET / PUT / DELETE on in-memory ToolRegistry
+# ---------------------------------------------------------------------------
+
+
+def _serialize_toolbelt(registry) -> dict:
+    """Serialize ToolRegistry state for JSON response."""
+    cabinet: dict[str, list[dict]] = {}
+    for role, tools in registry.cabinet.items():
+        role_name = role.value.lower() if hasattr(role, "value") else str(role).lower()
+        cabinet[role_name] = [
+            {
+                "name": t.name,
+                "status": (
+                    t.status.value.lower()
+                    if hasattr(t.status, "value")
+                    else str(t.status).lower()
+                ),
+                "role": role_name,
+            }
+            for t in tools
+        ]
+
+    belt: dict[str, str | None] = {}
+    for role, tool in registry.get_belt().items():
+        role_name = role.value.lower() if hasattr(role, "value") else str(role).lower()
+        belt[role_name] = tool.name if tool else None
+
+    return {"cabinet": cabinet, "belt": belt}
+
+
+async def _get_toolbelt(request: web.Request) -> web.Response:
+    registry = request.app.get("registry")
+    if registry is None:
+        return web.json_response({"cabinet": {}, "belt": {}})
+    return web.json_response(_serialize_toolbelt(registry))
+
+
+async def _put_toolbelt_role(request: web.Request) -> web.Response:
+    registry = request.app.get("registry")
+    if registry is None:
+        raise web.HTTPServiceUnavailable(text="ToolRegistry not available")
+
+    role_str = request.match_info["role"].upper()
+
+    # Resolve ToolRole enum from string
+    from openbad.proprioception.registry import ToolRole
+    try:
+        role = ToolRole(role_str)
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text=f"Unknown role: {role_str}") from exc
+
+    payload = await request.json()
+    tool_name = payload.get("tool") if isinstance(payload, dict) else None
+    if not tool_name:
+        raise web.HTTPBadRequest(text="'tool' field required")
+
+    try:
+        registry.equip(role, tool_name)
+    except (KeyError, ValueError) as exc:
+        raise web.HTTPBadRequest(text=str(exc)) from exc
+
+    return web.json_response(_serialize_toolbelt(registry))
+
+
+async def _delete_toolbelt_role(request: web.Request) -> web.Response:
+    registry = request.app.get("registry")
+    if registry is None:
+        raise web.HTTPServiceUnavailable(text="ToolRegistry not available")
+
+    role_str = request.match_info["role"].upper()
+
+    from openbad.proprioception.registry import ToolRole
+    try:
+        role = ToolRole(role_str)
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text=f"Unknown role: {role_str}") from exc
+
+    try:
+        registry.unequip(role)
+    except (KeyError, ValueError) as exc:
+        raise web.HTTPBadRequest(text=str(exc)) from exc
+
+    return web.json_response(_serialize_toolbelt(registry))
+
+
 def create_app(
     mqtt_host: str = "localhost",
     mqtt_port: int = 1883,
@@ -625,6 +711,9 @@ def create_app(
     app.router.add_put("/api/systems", _put_systems)
     app.router.add_get("/api/senses", _get_senses)
     app.router.add_put("/api/senses", _put_senses)
+    app.router.add_get("/api/toolbelt", _get_toolbelt)
+    app.router.add_put("/api/toolbelt/{role}", _put_toolbelt_role)
+    app.router.add_delete("/api/toolbelt/{role}", _delete_toolbelt_role)
     # TODO: Remove after v1.0 once external consumers have migrated to /api/providers/*.
     app.router.add_get("/api/wiring/providers", _redirect_legacy_wiring_providers)
     app.router.add_post(

--- a/src/openbad/wui/static/app.js
+++ b/src/openbad/wui/static/app.js
@@ -130,6 +130,10 @@ const viewMeta = {
     title: 'Senses',
     subtitle: 'Configure vision, hearing, and speech modalities.',
   },
+  toolbelt: {
+    title: 'Toolbelt',
+    subtitle: 'Cabinet inventory, equipped tools, and health status.',
+  },
   models: {
     title: 'Models',
     subtitle: 'Reserved for the upcoming model surface.',
@@ -204,6 +208,9 @@ function setView(name) {
   }
   if (name === 'senses') {
     loadSensesConfig();
+  }
+  if (name === 'toolbelt') {
+    loadToolbelt();
   }
 }
 
@@ -338,6 +345,11 @@ function updateFromEvent(topic, payload) {
         else badge.classList.add('green');
       }
     }
+  }
+
+  if (topic === 'agent/telemetry/toolbelt') {
+    renderToolbeltFromEvent(payload);
+    return;
   }
 }
 
@@ -1116,6 +1128,110 @@ async function saveSensesConfig() {
     if (els.senses.saveStatus) els.senses.saveStatus.textContent = 'Saved.';
   } catch (err) {
     if (els.senses.saveStatus) els.senses.saveStatus.textContent = `Save failed: ${err.message}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Toolbelt panel
+// ---------------------------------------------------------------------------
+
+const swapLog = [];
+const MAX_SWAP_LOG = 50;
+
+async function loadToolbelt() {
+  try {
+    const resp = await fetch('/api/toolbelt');
+    const data = await resp.json();
+    renderToolbeltCabinet(data);
+  } catch (err) {
+    logLine(`toolbelt load failed: ${err.message}`);
+  }
+}
+
+function renderToolbeltCabinet(data) {
+  const container = document.getElementById('toolbelt-cabinet-list');
+  if (!container) return;
+  const cabinet = data.cabinet || {};
+  const belt = data.belt || {};
+  let html = '';
+  for (const [role, tools] of Object.entries(cabinet)) {
+    const equipped = belt[role] || null;
+    html += `<div class="toolbelt-role-group" data-role="${escapeHtml(role)}">`;
+    html += `<h4 class="role-heading">${escapeHtml(role)}</h4>`;
+    for (const tool of tools) {
+      const isEquipped = tool.name === equipped;
+      const healthClass = tool.status === 'available' ? 'green' : tool.status === 'degraded' ? 'yellow' : 'red';
+      html += `<div class="tool-row${isEquipped ? ' equipped' : ''}" data-tool="${escapeHtml(tool.name)}">`;
+      html += `<span class="health-dot ${healthClass}"></span>`;
+      html += `<span class="tool-name">${escapeHtml(tool.name)}</span>`;
+      if (isEquipped) {
+        html += `<button type="button" class="btn small unequip-btn" data-role="${escapeHtml(role)}">Unequip</button>`;
+      } else {
+        html += `<button type="button" class="btn small equip-btn" data-role="${escapeHtml(role)}" data-tool="${escapeHtml(tool.name)}">Equip</button>`;
+      }
+      html += '</div>';
+    }
+    html += '</div>';
+  }
+  container.innerHTML = html || '<p>No tools registered.</p>';
+  bindToolbeltButtons();
+}
+
+function renderToolbeltFromEvent(payload) {
+  renderToolbeltCabinet(payload);
+  if (payload.swap_event) {
+    addSwapLogEntry(payload.swap_event);
+  }
+}
+
+function addSwapLogEntry(evt) {
+  const ts = new Date().toLocaleTimeString();
+  const reason = evt.reason || 'unknown';
+  const from = evt.from || '—';
+  const to = evt.to || '—';
+  const role = evt.role || '?';
+  swapLog.unshift({ts, role, from, to, reason});
+  if (swapLog.length > MAX_SWAP_LOG) swapLog.length = MAX_SWAP_LOG;
+  renderSwapLog();
+}
+
+function renderSwapLog() {
+  const ul = document.getElementById('toolbelt-swap-log');
+  if (!ul) return;
+  ul.innerHTML = swapLog.map(e =>
+    `<li><code>${escapeHtml(e.ts)}</code> <strong>${escapeHtml(e.role)}</strong>: ${escapeHtml(e.from)} → ${escapeHtml(e.to)} (${escapeHtml(e.reason)})</li>`
+  ).join('');
+}
+
+function bindToolbeltButtons() {
+  for (const btn of document.querySelectorAll('.equip-btn')) {
+    btn.addEventListener('click', async () => {
+      const role = btn.dataset.role;
+      const tool = btn.dataset.tool;
+      try {
+        const resp = await fetch(`/api/toolbelt/${encodeURIComponent(role)}`, {
+          method: 'PUT',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({tool}),
+        });
+        const data = await resp.json();
+        renderToolbeltCabinet(data);
+      } catch (err) {
+        logLine(`equip failed: ${err.message}`);
+      }
+    });
+  }
+  for (const btn of document.querySelectorAll('.unequip-btn')) {
+    btn.addEventListener('click', async () => {
+      const role = btn.dataset.role;
+      try {
+        const resp = await fetch(`/api/toolbelt/${encodeURIComponent(role)}`, {method: 'DELETE'});
+        const data = await resp.json();
+        renderToolbeltCabinet(data);
+      } catch (err) {
+        logLine(`unequip failed: ${err.message}`);
+      }
+    });
   }
 }
 

--- a/src/openbad/wui/static/index.html
+++ b/src/openbad/wui/static/index.html
@@ -23,6 +23,7 @@
         <button type="button" class="nav-link" data-view-target="chat">Chat</button>
         <button type="button" class="nav-link" data-view-target="providers">Providers</button>
         <button type="button" class="nav-link" data-view-target="senses">Senses</button>
+        <button type="button" class="nav-link" data-view-target="toolbelt">Toolbelt</button>
         <button type="button" class="nav-link" data-view-target="models">Models <span class="nav-chip">next</span></button>
       </nav>
       <div class="nav-status">
@@ -392,6 +393,32 @@
           <article class="card section-card">
             <button type="button" id="senses-save-btn" class="btn primary">Save Senses</button>
             <p id="senses-save-status" class="inline-status"></p>
+          </article>
+        </div>
+      </section>
+
+      <section id="view-toolbelt" class="view-panel reveal hidden" data-view="toolbelt">
+        <div class="panel-grid single-column">
+          <!-- Cabinet Inventory -->
+          <article class="card section-card collapsible" id="toolbelt-cabinet-card">
+            <div class="section-head" data-collapse-toggle="toolbelt-cabinet-body">
+              <h3>Cabinet</h3>
+              <span class="collapse-icon">▾</span>
+            </div>
+            <div id="toolbelt-cabinet-body" class="collapse-body">
+              <div id="toolbelt-cabinet-list"></div>
+            </div>
+          </article>
+
+          <!-- Auto-swap Log -->
+          <article class="card section-card collapsible" id="toolbelt-swap-card">
+            <div class="section-head" data-collapse-toggle="toolbelt-swap-body">
+              <h3>Auto-swap Log</h3>
+              <span class="collapse-icon">▾</span>
+            </div>
+            <div id="toolbelt-swap-body" class="collapse-body">
+              <ul id="toolbelt-swap-log" class="swap-log"></ul>
+            </div>
           </article>
         </div>
       </section>

--- a/tests/test_wui_server.py
+++ b/tests/test_wui_server.py
@@ -600,3 +600,94 @@ async def test_put_senses_rejects_non_object(aiohttp_client, tmp_path, monkeypat
 
     resp = await client.put("/api/senses", json="bad")
     assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# Toolbelt API tests
+# ---------------------------------------------------------------------------
+
+
+def _app_with_registry():
+    """Create an app with an in-memory ToolRegistry attached."""
+    from openbad.proprioception.registry import ToolRegistry, ToolRole
+
+    app = create_app(enable_mqtt=False)
+    registry = ToolRegistry(timeout=30.0)
+    registry.register("cli-tool", role=ToolRole.CLI)
+    registry.register("web-search", role=ToolRole.WEB_SEARCH)
+    registry.register("alt-search", role=ToolRole.WEB_SEARCH)
+    app["registry"] = registry
+    return app
+
+
+@pytest.mark.asyncio
+async def test_get_toolbelt_no_registry(aiohttp_client):
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+    resp = await client.get("/api/toolbelt")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == {"cabinet": {}, "belt": {}}
+
+
+@pytest.mark.asyncio
+async def test_get_toolbelt_with_registry(aiohttp_client):
+    app = _app_with_registry()
+    client = await aiohttp_client(app)
+    resp = await client.get("/api/toolbelt")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "cabinet" in data
+    assert "belt" in data
+    assert "cli" in data["cabinet"]
+    assert "web_search" in data["cabinet"]
+
+
+@pytest.mark.asyncio
+async def test_put_toolbelt_equip(aiohttp_client):
+    app = _app_with_registry()
+    client = await aiohttp_client(app)
+    resp = await client.put(
+        "/api/toolbelt/cli",
+        json={"tool": "cli-tool"},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["belt"].get("cli") == "cli-tool"
+
+
+@pytest.mark.asyncio
+async def test_put_toolbelt_bad_role(aiohttp_client):
+    app = _app_with_registry()
+    client = await aiohttp_client(app)
+    resp = await client.put(
+        "/api/toolbelt/nonexistent_role",
+        json={"tool": "cli-tool"},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_put_toolbelt_missing_tool_field(aiohttp_client):
+    app = _app_with_registry()
+    client = await aiohttp_client(app)
+    resp = await client.put(
+        "/api/toolbelt/cli",
+        json={},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_toolbelt_unequip(aiohttp_client):
+    app = _app_with_registry()
+    # First equip
+    registry = app["registry"]
+    from openbad.proprioception.registry import ToolRole
+    registry.equip(ToolRole.CLI, "cli-tool")
+
+    client = await aiohttp_client(app)
+    resp = await client.delete("/api/toolbelt/cli")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["belt"].get("cli") is None


### PR DESCRIPTION
Closes #240

## Summary
Adds a Toolbelt panel to the WUI with REST endpoints for managing the ToolRegistry:

### REST Endpoints
- **`GET /api/toolbelt`** — returns cabinet grouped by role and current belt state
- **`PUT /api/toolbelt/{role}`** — equip a tool for a role (body: `{"tool": "name"}`)
- **`DELETE /api/toolbelt/{role}`** — unequip the tool from a role's belt slot

### WUI Panel
- Nav button "Toolbelt" in sidebar
- Cabinet view grouped by ToolRole with equipped tool highlighted
- Equip/Unequip buttons per tool calling the REST API
- Health indicator dots (green/yellow/red) per tool status
- Auto-swap event log showing last N swaps with timestamp and reason
- Real-time updates via `agent/telemetry/toolbelt` WebSocket topic

### Tests
6 new endpoint tests in `tests/test_wui_server.py`:
- GET with no registry returns empty
- GET with registry returns grouped cabinet
- PUT equip succeeds and returns updated belt
- PUT invalid role returns 400
- PUT missing tool field returns 400
- DELETE unequip succeeds

## How to test
```bash
pytest tests/test_wui_server.py -v -k toolbelt
ruff check src/openbad/wui/server.py tests/test_wui_server.py
```