### PR TITLE
#241: Add UserProfile schema and config-seeded loader

### DIFF
--- a/config/identity.yaml
+++ b/config/identity.yaml
@@ -12,3 +12,11 @@ identity:
 
   # Path prefix for persisted marker files
   marker_path: "data/markers"
+
+# User profile — layer 1 (config-seeded)
+user:
+  name: "User"
+  preferred_name: ""
+  communication_style: "casual"
+  expertise_domains: []
+  interaction_history_summary: ""

--- a/src/openbad/identity/user_profile.py
+++ b/src/openbad/identity/user_profile.py
@@ -1,0 +1,76 @@
+"""UserProfile schema and config-seeded loader.
+
+Defines the layer-1 user entity loaded from ``config/identity.yaml``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class CommunicationStyle(Enum):
+    """Supported communication style presets."""
+
+    FORMAL = "formal"
+    CASUAL = "casual"
+    TERSE = "terse"
+
+
+@dataclass
+class UserProfile:
+    """Core user entity — layer 1 (config-seeded).
+
+    Fields are seeded from ``config/identity.yaml`` under the ``user:`` key.
+    Layer 2 (episodic LTM evolution) is handled elsewhere.
+    """
+
+    name: str
+    preferred_name: str = ""
+    communication_style: CommunicationStyle = CommunicationStyle.CASUAL
+    expertise_domains: list[str] = field(default_factory=list)
+    interaction_history_summary: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            msg = "UserProfile.name is required"
+            raise ValueError(msg)
+        if isinstance(self.communication_style, str):
+            self.communication_style = CommunicationStyle(
+                self.communication_style.lower(),
+            )
+
+
+def load_user_profile(path: str | Path) -> UserProfile:
+    """Load a :class:`UserProfile` from a YAML file.
+
+    Expects a ``user:`` top-level key with profile fields.
+    """
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    user_data = raw.get("user")
+    if not isinstance(user_data, dict):
+        msg = "identity.yaml must contain a 'user' mapping"
+        raise ValueError(msg)
+
+    style_raw = user_data.get("communication_style", "casual")
+    try:
+        style = CommunicationStyle(style_raw.lower())
+    except (ValueError, AttributeError) as exc:
+        msg = f"Invalid communication_style: {style_raw!r}"
+        raise ValueError(msg) from exc
+
+    return UserProfile(
+        name=user_data.get("name", ""),
+        preferred_name=user_data.get("preferred_name", ""),
+        communication_style=style,
+        expertise_domains=user_data.get("expertise_domains", []),
+        interaction_history_summary=user_data.get(
+            "interaction_history_summary", "",
+        ),
+    )

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -1,0 +1,104 @@
+"""Tests for UserProfile schema and loader (#241)."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from openbad.identity.user_profile import (
+    CommunicationStyle,
+    UserProfile,
+    load_user_profile,
+)
+
+
+class TestUserProfile:
+    def test_valid_construction(self) -> None:
+        p = UserProfile(name="Alice")
+        assert p.name == "Alice"
+        assert p.preferred_name == ""
+        assert p.communication_style is CommunicationStyle.CASUAL
+        assert p.expertise_domains == []
+        assert p.interaction_history_summary == ""
+
+    def test_all_fields(self) -> None:
+        p = UserProfile(
+            name="Bob",
+            preferred_name="Bobby",
+            communication_style=CommunicationStyle.FORMAL,
+            expertise_domains=["python", "ML"],
+            interaction_history_summary="Long-time user",
+        )
+        assert p.preferred_name == "Bobby"
+        assert p.communication_style is CommunicationStyle.FORMAL
+        assert p.expertise_domains == ["python", "ML"]
+
+    def test_name_required(self) -> None:
+        with pytest.raises(ValueError, match="name is required"):
+            UserProfile(name="")
+
+    def test_style_from_string(self) -> None:
+        p = UserProfile(name="X", communication_style="terse")  # type: ignore[arg-type]
+        assert p.communication_style is CommunicationStyle.TERSE
+
+    def test_style_from_string_case_insensitive(self) -> None:
+        p = UserProfile(name="X", communication_style="FORMAL")  # type: ignore[arg-type]
+        assert p.communication_style is CommunicationStyle.FORMAL
+
+
+class TestCommunicationStyle:
+    def test_enum_values(self) -> None:
+        assert CommunicationStyle.FORMAL.value == "formal"
+        assert CommunicationStyle.CASUAL.value == "casual"
+        assert CommunicationStyle.TERSE.value == "terse"
+
+
+class TestLoadUserProfile:
+    def test_load_valid(self, tmp_path) -> None:
+        cfg = tmp_path / "identity.yaml"
+        cfg.write_text(yaml.safe_dump({
+            "user": {
+                "name": "Jane",
+                "preferred_name": "J",
+                "communication_style": "formal",
+                "expertise_domains": ["devops"],
+                "interaction_history_summary": "New user",
+            },
+        }))
+        p = load_user_profile(cfg)
+        assert p.name == "Jane"
+        assert p.preferred_name == "J"
+        assert p.communication_style is CommunicationStyle.FORMAL
+        assert p.expertise_domains == ["devops"]
+
+    def test_load_defaults(self, tmp_path) -> None:
+        cfg = tmp_path / "identity.yaml"
+        cfg.write_text(yaml.safe_dump({"user": {"name": "Min"}}))
+        p = load_user_profile(cfg)
+        assert p.name == "Min"
+        assert p.communication_style is CommunicationStyle.CASUAL
+
+    def test_load_missing_user_section(self, tmp_path) -> None:
+        cfg = tmp_path / "identity.yaml"
+        cfg.write_text(yaml.safe_dump({"identity": {}}))
+        with pytest.raises(ValueError, match="user"):
+            load_user_profile(cfg)
+
+    def test_load_invalid_style(self, tmp_path) -> None:
+        cfg = tmp_path / "identity.yaml"
+        cfg.write_text(yaml.safe_dump({
+            "user": {"name": "X", "communication_style": "aggressive"},
+        }))
+        with pytest.raises(ValueError, match="Invalid communication_style"):
+            load_user_profile(cfg)
+
+    def test_load_empty_name(self, tmp_path) -> None:
+        cfg = tmp_path / "identity.yaml"
+        cfg.write_text(yaml.safe_dump({"user": {"name": ""}}))
+        with pytest.raises(ValueError, match="name is required"):
+            load_user_profile(cfg)
+
+    def test_load_from_real_config(self) -> None:
+        p = load_user_profile("config/identity.yaml")
+        assert p.name == "User"
+        assert p.communication_style is CommunicationStyle.CASUAL


### PR DESCRIPTION
Closes #241

## Summary
Adds `UserProfile` dataclass and `load_user_profile()` loader in `src/openbad/identity/user_profile.py`:

- **`UserProfile`**: `name` (required), `preferred_name`, `communication_style` (enum: formal/casual/terse), `expertise_domains`, `interaction_history_summary`
- **`CommunicationStyle`** enum: FORMAL, CASUAL, TERSE
- **`load_user_profile(path)`**: loads from YAML `user:` section with validation
- Config seed added to `config/identity.yaml` with `user:` section

## Tests
12 tests in `tests/test_user_profile.py`:
- Dataclass: valid construction, all fields, name required, style from string, case-insensitive
- Enum values
- Loader: valid, defaults, missing section, invalid style, empty name, real config

## How to test
```bash
pytest tests/test_user_profile.py -v
ruff check src/openbad/identity/user_profile.py tests/test_user_profile.py
```