### PR TITLE
#242: Add AssistantProfile with OCEAN personality sliders

### DIFF
--- a/config/identity.yaml
+++ b/config/identity.yaml
@@ -20,3 +20,15 @@ user:
   communication_style: "casual"
   expertise_domains: []
   interaction_history_summary: ""
+
+# Assistant profile — OCEAN personality sliders
+assistant:
+  name: "OpenBaD"
+  persona_summary: "A self-aware Linux agent with biological metaphors"
+  learning_focus: []
+  ocean:
+    openness: 0.7
+    conscientiousness: 0.8
+    extraversion: 0.5
+    agreeableness: 0.4
+    stability: 0.6

--- a/src/openbad/identity/assistant_profile.py
+++ b/src/openbad/identity/assistant_profile.py
@@ -1,0 +1,74 @@
+"""AssistantProfile with OCEAN personality sliders and config seed.
+
+The OCEAN model maps to agent behaviours:
+- **Openness** → Exploration Drive
+- **Conscientiousness** → Research Rigor
+- **Extraversion** → Engagement Style
+- **Agreeableness** → Challenge Posture
+- **Stability** → Stress Tolerance
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+@dataclass
+class AssistantProfile:
+    """Agent personality and identity — seeded from config.
+
+    Each OCEAN slider is clamped to [0.0, 1.0].
+    """
+
+    name: str = "OpenBaD"
+    persona_summary: str = ""
+    learning_focus: list[str] = field(default_factory=list)
+    openness: float = 0.7
+    conscientiousness: float = 0.8
+    extraversion: float = 0.5
+    agreeableness: float = 0.4
+    stability: float = 0.6
+
+    def __post_init__(self) -> None:
+        self.openness = _clamp(self.openness)
+        self.conscientiousness = _clamp(self.conscientiousness)
+        self.extraversion = _clamp(self.extraversion)
+        self.agreeableness = _clamp(self.agreeableness)
+        self.stability = _clamp(self.stability)
+
+
+def load_assistant_profile(path: str | Path) -> AssistantProfile:
+    """Load an :class:`AssistantProfile` from a YAML file.
+
+    Expects an ``assistant:`` top-level key.
+    """
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    data = raw.get("assistant")
+    if not isinstance(data, dict):
+        msg = "identity.yaml must contain an 'assistant' mapping"
+        raise ValueError(msg)
+
+    ocean = data.get("ocean", {})
+    if not isinstance(ocean, dict):
+        ocean = {}
+
+    return AssistantProfile(
+        name=data.get("name", "OpenBaD"),
+        persona_summary=data.get("persona_summary", ""),
+        learning_focus=data.get("learning_focus", []),
+        openness=ocean.get("openness", 0.7),
+        conscientiousness=ocean.get("conscientiousness", 0.8),
+        extraversion=ocean.get("extraversion", 0.5),
+        agreeableness=ocean.get("agreeableness", 0.4),
+        stability=ocean.get("stability", 0.6),
+    )

--- a/tests/test_assistant_profile.py
+++ b/tests/test_assistant_profile.py
@@ -1,0 +1,101 @@
+"""Tests for AssistantProfile schema and loader (#242)."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from openbad.identity.assistant_profile import (
+    AssistantProfile,
+    load_assistant_profile,
+)
+
+
+class TestAssistantProfile:
+    def test_defaults(self) -> None:
+        p = AssistantProfile()
+        assert p.name == "OpenBaD"
+        assert p.openness == 0.7
+        assert p.conscientiousness == 0.8
+        assert p.extraversion == 0.5
+        assert p.agreeableness == 0.4
+        assert p.stability == 0.6
+        assert p.learning_focus == []
+
+    def test_custom_values(self) -> None:
+        p = AssistantProfile(
+            name="Agent",
+            openness=0.9,
+            conscientiousness=0.1,
+            stability=1.0,
+            learning_focus=["rust", "eBPF"],
+        )
+        assert p.name == "Agent"
+        assert p.openness == 0.9
+        assert p.conscientiousness == 0.1
+        assert p.learning_focus == ["rust", "eBPF"]
+
+    def test_clamping_high(self) -> None:
+        p = AssistantProfile(openness=1.5, stability=99.0)
+        assert p.openness == 1.0
+        assert p.stability == 1.0
+
+    def test_clamping_low(self) -> None:
+        p = AssistantProfile(agreeableness=-0.5, extraversion=-100.0)
+        assert p.agreeableness == 0.0
+        assert p.extraversion == 0.0
+
+
+class TestLoadAssistantProfile:
+    def test_load_valid(self, tmp_path) -> None:
+        cfg = tmp_path / "identity.yaml"
+        cfg.write_text(yaml.safe_dump({
+            "assistant": {
+                "name": "Bot",
+                "persona_summary": "Helpful",
+                "learning_focus": ["Python"],
+                "ocean": {
+                    "openness": 0.3,
+                    "conscientiousness": 0.9,
+                    "extraversion": 0.2,
+                    "agreeableness": 0.8,
+                    "stability": 0.5,
+                },
+            },
+        }))
+        p = load_assistant_profile(cfg)
+        assert p.name == "Bot"
+        assert p.openness == 0.3
+        assert p.conscientiousness == 0.9
+
+    def test_load_defaults_when_ocean_missing(self, tmp_path) -> None:
+        cfg = tmp_path / "identity.yaml"
+        cfg.write_text(yaml.safe_dump({
+            "assistant": {"name": "Min"},
+        }))
+        p = load_assistant_profile(cfg)
+        assert p.openness == 0.7
+        assert p.stability == 0.6
+
+    def test_load_missing_section(self, tmp_path) -> None:
+        cfg = tmp_path / "identity.yaml"
+        cfg.write_text(yaml.safe_dump({"identity": {}}))
+        with pytest.raises(ValueError, match="assistant"):
+            load_assistant_profile(cfg)
+
+    def test_load_clamping(self, tmp_path) -> None:
+        cfg = tmp_path / "identity.yaml"
+        cfg.write_text(yaml.safe_dump({
+            "assistant": {
+                "name": "Extreme",
+                "ocean": {"openness": 5.0, "stability": -1.0},
+            },
+        }))
+        p = load_assistant_profile(cfg)
+        assert p.openness == 1.0
+        assert p.stability == 0.0
+
+    def test_load_from_real_config(self) -> None:
+        p = load_assistant_profile("config/identity.yaml")
+        assert p.name == "OpenBaD"
+        assert 0.0 <= p.openness <= 1.0


### PR DESCRIPTION
Closes #242

## Summary
Adds `AssistantProfile` dataclass with OCEAN personality sliders in `src/openbad/identity/assistant_profile.py`:

- **OCEAN sliders** (all 0.0–1.0, auto-clamped): openness (0.7), conscientiousness (0.8), extraversion (0.5), agreeableness (0.4), stability (0.6)
- **Fields**: name, persona_summary, learning_focus
- **`load_assistant_profile(path)`**: loads from YAML `assistant:` section with OCEAN clamping
- Config seed added to `config/identity.yaml` with `assistant:` section

## Tests
9 tests: defaults, custom values, clamping high/low, loading valid/defaults/missing/clamping, real config

## How to test
```bash
pytest tests/test_assistant_profile.py -v
```