### PR TITLE
#243: OCEAN personality → endocrine modulation mapping

### DIFF
--- a/src/openbad/identity/personality_modulator.py
+++ b/src/openbad/identity/personality_modulator.py
@@ -1,0 +1,58 @@
+"""OCEAN personality → endocrine modulation mapping.
+
+Computes modulation factors from OCEAN slider values and injects them
+into the endocrine system to shape agent behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from openbad.identity.assistant_profile import AssistantProfile
+
+
+@dataclass
+class ModulationFactors:
+    """Endocrine modulation factors derived from OCEAN personality values."""
+
+    exploration_budget_multiplier: float
+    max_reasoning_depth_multiplier: float
+    proactive_suggestion_threshold: float
+    challenge_probability: float
+    cortisol_decay_multiplier: float
+
+
+class PersonalityModulator:
+    """Maps OCEAN personality sliders to endocrine modulation factors.
+
+    Formulas:
+    - Openness → exploration_budget_multiplier = 0.5 + O
+    - Conscientiousness → max_reasoning_depth_multiplier = 0.5 + C
+    - Extraversion → proactive_suggestion_threshold = 1.0 - E
+    - Agreeableness → challenge_probability = 1.0 - A
+    - Stability → cortisol_decay_multiplier = 0.5 + S
+    """
+
+    def __init__(self, profile: AssistantProfile) -> None:
+        self._profile = profile
+        self._factors = self._compute(profile)
+
+    @property
+    def factors(self) -> ModulationFactors:
+        return self._factors
+
+    def update(self, profile: AssistantProfile) -> ModulationFactors:
+        """Recalculate modulation factors from an updated profile."""
+        self._profile = profile
+        self._factors = self._compute(profile)
+        return self._factors
+
+    @staticmethod
+    def _compute(profile: AssistantProfile) -> ModulationFactors:
+        return ModulationFactors(
+            exploration_budget_multiplier=0.5 + profile.openness,
+            max_reasoning_depth_multiplier=0.5 + profile.conscientiousness,
+            proactive_suggestion_threshold=1.0 - profile.extraversion,
+            challenge_probability=1.0 - profile.agreeableness,
+            cortisol_decay_multiplier=0.5 + profile.stability,
+        )

--- a/tests/test_personality_modulator.py
+++ b/tests/test_personality_modulator.py
@@ -1,0 +1,124 @@
+"""Tests for OCEAN personality → endocrine modulation mapping (#243)."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.identity.assistant_profile import AssistantProfile
+from openbad.identity.personality_modulator import (
+    PersonalityModulator,
+)
+
+
+class TestModulationFactors:
+    def test_default_ocean(self) -> None:
+        """Default OCEAN: O=0.7, C=0.8, E=0.5, A=0.4, S=0.6."""
+        p = AssistantProfile()
+        m = PersonalityModulator(p)
+        f = m.factors
+        assert f.exploration_budget_multiplier == pytest.approx(1.2)
+        assert f.max_reasoning_depth_multiplier == pytest.approx(1.3)
+        assert f.proactive_suggestion_threshold == pytest.approx(0.5)
+        assert f.challenge_probability == pytest.approx(0.6)
+        assert f.cortisol_decay_multiplier == pytest.approx(1.1)
+
+    def test_openness_zero(self) -> None:
+        p = AssistantProfile(openness=0.0)
+        f = PersonalityModulator(p).factors
+        assert f.exploration_budget_multiplier == pytest.approx(0.5)
+
+    def test_openness_one(self) -> None:
+        p = AssistantProfile(openness=1.0)
+        f = PersonalityModulator(p).factors
+        assert f.exploration_budget_multiplier == pytest.approx(1.5)
+
+    def test_openness_mid(self) -> None:
+        p = AssistantProfile(openness=0.5)
+        f = PersonalityModulator(p).factors
+        assert f.exploration_budget_multiplier == pytest.approx(1.0)
+
+    def test_conscientiousness_zero(self) -> None:
+        p = AssistantProfile(conscientiousness=0.0)
+        f = PersonalityModulator(p).factors
+        assert f.max_reasoning_depth_multiplier == pytest.approx(0.5)
+
+    def test_conscientiousness_one(self) -> None:
+        p = AssistantProfile(conscientiousness=1.0)
+        f = PersonalityModulator(p).factors
+        assert f.max_reasoning_depth_multiplier == pytest.approx(1.5)
+
+    def test_conscientiousness_mid(self) -> None:
+        p = AssistantProfile(conscientiousness=0.5)
+        f = PersonalityModulator(p).factors
+        assert f.max_reasoning_depth_multiplier == pytest.approx(1.0)
+
+    def test_extraversion_zero(self) -> None:
+        p = AssistantProfile(extraversion=0.0)
+        f = PersonalityModulator(p).factors
+        assert f.proactive_suggestion_threshold == pytest.approx(1.0)
+
+    def test_extraversion_one(self) -> None:
+        p = AssistantProfile(extraversion=1.0)
+        f = PersonalityModulator(p).factors
+        assert f.proactive_suggestion_threshold == pytest.approx(0.0)
+
+    def test_extraversion_mid(self) -> None:
+        p = AssistantProfile(extraversion=0.5)
+        f = PersonalityModulator(p).factors
+        assert f.proactive_suggestion_threshold == pytest.approx(0.5)
+
+    def test_agreeableness_zero(self) -> None:
+        p = AssistantProfile(agreeableness=0.0)
+        f = PersonalityModulator(p).factors
+        assert f.challenge_probability == pytest.approx(1.0)
+
+    def test_agreeableness_one(self) -> None:
+        p = AssistantProfile(agreeableness=1.0)
+        f = PersonalityModulator(p).factors
+        assert f.challenge_probability == pytest.approx(0.0)
+
+    def test_agreeableness_mid(self) -> None:
+        p = AssistantProfile(agreeableness=0.5)
+        f = PersonalityModulator(p).factors
+        assert f.challenge_probability == pytest.approx(0.5)
+
+    def test_stability_zero(self) -> None:
+        p = AssistantProfile(stability=0.0)
+        f = PersonalityModulator(p).factors
+        assert f.cortisol_decay_multiplier == pytest.approx(0.5)
+
+    def test_stability_one(self) -> None:
+        p = AssistantProfile(stability=1.0)
+        f = PersonalityModulator(p).factors
+        assert f.cortisol_decay_multiplier == pytest.approx(1.5)
+
+    def test_stability_mid(self) -> None:
+        p = AssistantProfile(stability=0.5)
+        f = PersonalityModulator(p).factors
+        assert f.cortisol_decay_multiplier == pytest.approx(1.0)
+
+
+class TestUpdate:
+    def test_update_recalculates(self) -> None:
+        p = AssistantProfile(openness=0.2)
+        m = PersonalityModulator(p)
+        assert m.factors.exploration_budget_multiplier == pytest.approx(0.7)
+
+        p2 = AssistantProfile(openness=0.9)
+        f = m.update(p2)
+        assert f.exploration_budget_multiplier == pytest.approx(1.4)
+        assert m.factors.exploration_budget_multiplier == pytest.approx(1.4)
+
+
+class TestCortisolIntegration:
+    def test_stability_affects_cortisol_decay(self) -> None:
+        """High stability → higher cortisol decay multiplier → faster recovery."""
+        low = AssistantProfile(stability=0.0)
+        high = AssistantProfile(stability=1.0)
+
+        low_factors = PersonalityModulator(low).factors
+        high_factors = PersonalityModulator(high).factors
+
+        assert high_factors.cortisol_decay_multiplier > low_factors.cortisol_decay_multiplier
+        assert low_factors.cortisol_decay_multiplier == pytest.approx(0.5)
+        assert high_factors.cortisol_decay_multiplier == pytest.approx(1.5)


### PR DESCRIPTION
Closes #243

## Summary
- `PersonalityModulator` class computes modulation factors from OCEAN values
- Formulas: O→exploration_budget (0.5+O), C→reasoning_depth (0.5+C), E→proactive_threshold (1.0-E), A→challenge_prob (1.0-A), S→cortisol_decay (0.5+S)
- `update()` method recalculates on OCEAN change
- 18 tests: boundary values (0.0, 0.5, 1.0) for each slider + integration test for stability→cortisol decay

## How to test
```bash
pytest tests/test_personality_modulator.py -v
```