### PR TITLE
#244: Dual-layer entity persistence (config seed + episodic LTM evolution)

### DIFF
--- a/src/openbad/identity/persistence.py
+++ b/src/openbad/identity/persistence.py
@@ -1,0 +1,222 @@
+"""Dual-layer identity persistence — config seed + episodic LTM evolution.
+
+Layer 1: ``identity.yaml`` provides factory-default values.
+Layer 2: Episodic LTM stores a shadow copy that evolves at runtime.
+During sleep consolidation, the shadow is reconciled with the live profile
+and written back to ``identity.yaml`` (with a timestamped backup).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import shutil
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from openbad.identity.assistant_profile import (
+    AssistantProfile,
+    load_assistant_profile,
+)
+from openbad.identity.user_profile import (
+    CommunicationStyle,
+    UserProfile,
+    load_user_profile,
+)
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.episodic import EpisodicMemory
+
+logger = logging.getLogger(__name__)
+
+_USER_SHADOW_KEY = "identity/user_shadow"
+_ASSISTANT_SHADOW_KEY = "identity/assistant_shadow"
+
+
+def _user_to_dict(profile: UserProfile) -> dict[str, Any]:
+    d = asdict(profile)
+    d["communication_style"] = profile.communication_style.value
+    return d
+
+
+def _dict_to_user(data: dict[str, Any]) -> UserProfile:
+    style = data.get("communication_style", "casual")
+    if isinstance(style, str):
+        style = CommunicationStyle(style.lower())
+    return UserProfile(
+        name=data.get("name", ""),
+        preferred_name=data.get("preferred_name", ""),
+        communication_style=style,
+        expertise_domains=data.get("expertise_domains", []),
+        interaction_history_summary=data.get(
+            "interaction_history_summary", "",
+        ),
+    )
+
+
+def _assistant_to_dict(profile: AssistantProfile) -> dict[str, Any]:
+    return asdict(profile)
+
+
+def _dict_to_assistant(data: dict[str, Any]) -> AssistantProfile:
+    return AssistantProfile(**data)
+
+
+class IdentityPersistence:
+    """Manages dual-layer persistence for user and assistant profiles.
+
+    Parameters
+    ----------
+    config_path:
+        Path to ``identity.yaml`` (Layer 1 seed).
+    episodic:
+        Episodic memory store for Layer 2 shadow copies.
+    """
+
+    def __init__(
+        self,
+        config_path: str | Path,
+        episodic: EpisodicMemory,
+    ) -> None:
+        self._config_path = Path(config_path)
+        self._episodic = episodic
+
+        # Layer 1 — immutable seed
+        self._user_seed = load_user_profile(self._config_path)
+        self._assistant_seed = load_assistant_profile(self._config_path)
+
+        # Live profiles — start from seed, overlay shadow
+        self._user = copy.deepcopy(self._user_seed)
+        self._assistant = copy.deepcopy(self._assistant_seed)
+        self._overlay_shadow()
+
+    # -------------------------------------------------------------- #
+    # Public properties
+    # -------------------------------------------------------------- #
+
+    @property
+    def user(self) -> UserProfile:
+        return self._user
+
+    @property
+    def assistant(self) -> AssistantProfile:
+        return self._assistant
+
+    # -------------------------------------------------------------- #
+    # Runtime evolution — store changes in LTM shadow
+    # -------------------------------------------------------------- #
+
+    def update_user(self, **changes: Any) -> UserProfile:
+        """Apply runtime changes to the user profile and persist to LTM."""
+        for key, value in changes.items():
+            if not hasattr(self._user, key):
+                msg = f"UserProfile has no field {key!r}"
+                raise AttributeError(msg)
+            setattr(self._user, key, value)
+        self._user.__post_init__()
+        self._write_shadow(_USER_SHADOW_KEY, _user_to_dict(self._user))
+        return self._user
+
+    def update_assistant(self, **changes: Any) -> AssistantProfile:
+        """Apply runtime changes to the assistant profile and persist to LTM."""
+        for key, value in changes.items():
+            if not hasattr(self._assistant, key):
+                msg = f"AssistantProfile has no field {key!r}"
+                raise AttributeError(msg)
+            setattr(self._assistant, key, value)
+        self._assistant.__post_init__()
+        self._write_shadow(
+            _ASSISTANT_SHADOW_KEY,
+            _assistant_to_dict(self._assistant),
+        )
+        return self._assistant
+
+    # -------------------------------------------------------------- #
+    # Sleep consolidation
+    # -------------------------------------------------------------- #
+
+    def consolidate(self) -> Path | None:
+        """Reconcile LTM shadow → live profile → write back to config.
+
+        Returns the backup path if a write-back occurred, else ``None``.
+        """
+        user_entry = self._episodic.read(_USER_SHADOW_KEY)
+        assistant_entry = self._episodic.read(_ASSISTANT_SHADOW_KEY)
+
+        if user_entry is None and assistant_entry is None:
+            return None
+
+        backup = self._backup_config()
+        self._write_config()
+        return backup
+
+    # -------------------------------------------------------------- #
+    # Reset to seed (factory defaults)
+    # -------------------------------------------------------------- #
+
+    def reset_to_seed(self) -> None:
+        """Discard LTM shadow and reload from config seed."""
+        self._episodic.delete(_USER_SHADOW_KEY)
+        self._episodic.delete(_ASSISTANT_SHADOW_KEY)
+        self._user = copy.deepcopy(self._user_seed)
+        self._assistant = copy.deepcopy(self._assistant_seed)
+
+    # -------------------------------------------------------------- #
+    # Internal helpers
+    # -------------------------------------------------------------- #
+
+    def _overlay_shadow(self) -> None:
+        """Overlay LTM shadow (if any) onto the live profile."""
+        user_entry = self._episodic.read(_USER_SHADOW_KEY)
+        if user_entry is not None and isinstance(user_entry.value, dict):
+            self._user = _dict_to_user(user_entry.value)
+
+        assistant_entry = self._episodic.read(_ASSISTANT_SHADOW_KEY)
+        if assistant_entry is not None and isinstance(
+            assistant_entry.value, dict,
+        ):
+            self._assistant = _dict_to_assistant(assistant_entry.value)
+
+    def _write_shadow(self, key: str, data: dict[str, Any]) -> None:
+        entry = MemoryEntry(
+            key=key,
+            value=data,
+            tier=MemoryTier.EPISODIC,
+            metadata={"source": "identity_persistence"},
+        )
+        self._episodic.write(entry)
+
+    def _backup_config(self) -> Path:
+        ts = time.strftime("%Y%m%dT%H%M%S")
+        backup = self._config_path.with_suffix(f".{ts}.bak")
+        shutil.copy2(self._config_path, backup)
+        return backup
+
+    def _write_config(self) -> None:
+        raw = yaml.safe_load(
+            self._config_path.read_text(encoding="utf-8"),
+        ) or {}
+
+        raw["user"] = _user_to_dict(self._user)
+
+        assistant_d = _assistant_to_dict(self._assistant)
+        raw["assistant"] = {
+            "name": assistant_d.pop("name"),
+            "persona_summary": assistant_d.pop("persona_summary"),
+            "learning_focus": assistant_d.pop("learning_focus"),
+            "ocean": {
+                "openness": assistant_d.pop("openness"),
+                "conscientiousness": assistant_d.pop("conscientiousness"),
+                "extraversion": assistant_d.pop("extraversion"),
+                "agreeableness": assistant_d.pop("agreeableness"),
+                "stability": assistant_d.pop("stability"),
+            },
+        }
+
+        self._config_path.write_text(
+            yaml.safe_dump(raw, default_flow_style=False, sort_keys=False),
+            encoding="utf-8",
+        )

--- a/tests/test_identity_persistence.py
+++ b/tests/test_identity_persistence.py
@@ -1,0 +1,192 @@
+"""Tests for dual-layer identity persistence (#244)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from openbad.identity.persistence import IdentityPersistence
+from openbad.identity.user_profile import CommunicationStyle
+from openbad.memory.episodic import EpisodicMemory
+
+
+def _write_config(tmp: Path) -> Path:
+    """Create a minimal identity.yaml in *tmp* and return its path."""
+    cfg = tmp / "identity.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "identity": {"secret_hex": "abc"},
+                "user": {
+                    "name": "Alice",
+                    "preferred_name": "Ali",
+                    "communication_style": "formal",
+                    "expertise_domains": ["python"],
+                    "interaction_history_summary": "",
+                },
+                "assistant": {
+                    "name": "OpenBaD",
+                    "persona_summary": "Helpful agent",
+                    "learning_focus": [],
+                    "ocean": {
+                        "openness": 0.7,
+                        "conscientiousness": 0.8,
+                        "extraversion": 0.5,
+                        "agreeableness": 0.4,
+                        "stability": 0.6,
+                    },
+                },
+            },
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+@pytest.fixture()
+def env(tmp_path: Path):
+    """Yield (config_path, episodic, persistence) triple."""
+    cfg = _write_config(tmp_path)
+    ep = EpisodicMemory(
+        storage_path=tmp_path / "episodic.json",
+        auto_persist=True,
+    )
+    ip = IdentityPersistence(cfg, ep)
+    return cfg, ep, ip
+
+
+# ------------------------------------------------------------------ #
+# Startup overlay
+# ------------------------------------------------------------------ #
+
+
+class TestStartupOverlay:
+    def test_loads_seed_when_no_shadow(self, env) -> None:
+        _, _, ip = env
+        assert ip.user.name == "Alice"
+        assert ip.user.communication_style == CommunicationStyle.FORMAL
+        assert ip.assistant.openness == pytest.approx(0.7)
+
+    def test_overlays_shadow_on_startup(self, tmp_path: Path) -> None:
+        cfg = _write_config(tmp_path)
+        ep = EpisodicMemory(
+            storage_path=tmp_path / "episodic.json",
+            auto_persist=True,
+        )
+        # Pre-populate a shadow before creating persistence.
+        ip1 = IdentityPersistence(cfg, ep)
+        ip1.update_user(preferred_name="AliceV2")
+        ip1.update_assistant(openness=0.3)
+
+        # New persistence instance should overlay the shadow.
+        ip2 = IdentityPersistence(cfg, ep)
+        assert ip2.user.preferred_name == "AliceV2"
+        assert ip2.assistant.openness == pytest.approx(0.3)
+
+
+# ------------------------------------------------------------------ #
+# Runtime updates
+# ------------------------------------------------------------------ #
+
+
+class TestRuntimeUpdates:
+    def test_update_user_stores_in_ltm(self, env) -> None:
+        _, ep, ip = env
+        ip.update_user(preferred_name="Bob")
+        assert ip.user.preferred_name == "Bob"
+        entry = ep.read("identity/user_shadow")
+        assert entry is not None
+        assert entry.value["preferred_name"] == "Bob"
+
+    def test_update_assistant_stores_in_ltm(self, env) -> None:
+        _, ep, ip = env
+        ip.update_assistant(stability=0.9)
+        assert ip.assistant.stability == pytest.approx(0.9)
+        entry = ep.read("identity/assistant_shadow")
+        assert entry is not None
+        assert entry.value["stability"] == pytest.approx(0.9)
+
+    def test_update_user_bad_field_raises(self, env) -> None:
+        _, _, ip = env
+        with pytest.raises(AttributeError, match="no_such_field"):
+            ip.update_user(no_such_field="x")
+
+    def test_update_assistant_bad_field_raises(self, env) -> None:
+        _, _, ip = env
+        with pytest.raises(AttributeError, match="no_such_field"):
+            ip.update_assistant(no_such_field="x")
+
+
+# ------------------------------------------------------------------ #
+# Sleep consolidation
+# ------------------------------------------------------------------ #
+
+
+class TestConsolidation:
+    def test_consolidate_no_shadow_returns_none(self, env) -> None:
+        _, _, ip = env
+        assert ip.consolidate() is None
+
+    def test_consolidate_writes_back_config(self, env) -> None:
+        cfg, _, ip = env
+        ip.update_user(preferred_name="Consolidated")
+        ip.update_assistant(openness=0.1)
+
+        backup = ip.consolidate()
+        assert backup is not None
+        assert backup.exists()
+
+        # Re-read identity.yaml for verification.
+        raw = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+        assert raw["user"]["preferred_name"] == "Consolidated"
+        assert raw["assistant"]["ocean"]["openness"] == pytest.approx(0.1)
+
+    def test_consolidate_preserves_identity_section(self, env) -> None:
+        cfg, _, ip = env
+        ip.update_user(preferred_name="X")
+        ip.consolidate()
+
+        raw = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+        assert raw["identity"]["secret_hex"] == "abc"  # noqa: S105
+
+    def test_backup_is_timestamped(self, env) -> None:
+        _, _, ip = env
+        ip.update_user(preferred_name="Y")
+        backup = ip.consolidate()
+        assert backup is not None
+        assert ".bak" in backup.suffix or backup.name.endswith(".bak")
+
+
+# ------------------------------------------------------------------ #
+# Reset to seed
+# ------------------------------------------------------------------ #
+
+
+class TestResetToSeed:
+    def test_reset_discards_shadow(self, env) -> None:
+        _, ep, ip = env
+        ip.update_user(preferred_name="Modified")
+        ip.update_assistant(openness=0.1)
+
+        ip.reset_to_seed()
+
+        assert ip.user.preferred_name == "Ali"
+        assert ip.assistant.openness == pytest.approx(0.7)
+        assert ep.read("identity/user_shadow") is None
+        assert ep.read("identity/assistant_shadow") is None
+
+    def test_reset_survives_new_instance(self, tmp_path: Path) -> None:
+        cfg = _write_config(tmp_path)
+        ep = EpisodicMemory(
+            storage_path=tmp_path / "episodic.json",
+            auto_persist=True,
+        )
+        ip1 = IdentityPersistence(cfg, ep)
+        ip1.update_user(preferred_name="Changed")
+        ip1.reset_to_seed()
+
+        ip2 = IdentityPersistence(cfg, ep)
+        assert ip2.user.preferred_name == "Ali"


### PR DESCRIPTION
Closes #244

## Summary
- `IdentityPersistence` class with dual-layer architecture:
  - Layer 1: Config seed from `identity.yaml` (factory defaults)
  - Layer 2: Episodic LTM shadow copies evolve at runtime
- On startup, Layer 2 shadow overlays Layer 1 seed
- `update_user()`/`update_assistant()` store changes in episodic LTM
- `consolidate()` reconciles shadow → config with timestamped backup
- `reset_to_seed()` discards shadow and restores factory defaults
- 12 tests covering overlay, updates, consolidation, write-back, and reset

## How to test
```bash
pytest tests/test_identity_persistence.py -v
```