### PR TITLE
#245: User learning pipeline — infer preferences from interaction patterns

### DIFF
--- a/src/openbad/identity/learning.py
+++ b/src/openbad/identity/learning.py
@@ -1,0 +1,172 @@
+"""User learning pipeline — infer preferences from interaction patterns.
+
+Observes cognitive events and updates the UserProfile LTM shadow with
+inferred preferences. All learning is local; no data leaves the system.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import statistics
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+from openbad.identity.persistence import IdentityPersistence
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class InteractionRecord:
+    """A single observed user interaction."""
+
+    message: str
+    timestamp: float = 0.0
+    topics: list[str] = field(default_factory=list)
+    is_correction: bool = False
+
+
+@dataclass
+class _Accumulator:
+    """Internal batch accumulator for tracked signals."""
+
+    message_lengths: list[int] = field(default_factory=list)
+    formal_markers: int = 0
+    casual_markers: int = 0
+    topic_counts: Counter = field(default_factory=Counter)
+    correction_count: int = 0
+    interaction_count: int = 0
+    activity_hours: list[int] = field(default_factory=list)
+
+    def reset(self) -> None:
+        self.message_lengths.clear()
+        self.formal_markers = 0
+        self.casual_markers = 0
+        self.topic_counts.clear()
+        self.correction_count = 0
+        self.interaction_count = 0
+        self.activity_hours.clear()
+
+
+_FORMAL_PATTERNS = re.compile(
+    r"\b(please|kindly|would you|could you|i would appreciate)\b",
+    re.IGNORECASE,
+)
+_CASUAL_PATTERNS = re.compile(
+    r"\b(hey|yo|lol|thx|k|nah|yeah|gonna|wanna)\b",
+    re.IGNORECASE,
+)
+
+
+class UserLearningPipeline:
+    """Learns user preferences from interaction patterns.
+
+    Updates are batched and written to the LTM shadow at configurable
+    intervals. Does not modify UserProfile directly.
+
+    Parameters
+    ----------
+    persistence:
+        The identity persistence layer managing LTM shadows.
+    batch_size:
+        Number of interactions before flushing to LTM (default 50).
+    """
+
+    def __init__(
+        self,
+        persistence: IdentityPersistence,
+        batch_size: int = 50,
+    ) -> None:
+        self._persistence = persistence
+        self._batch_size = batch_size
+        self._acc = _Accumulator()
+
+    @property
+    def pending(self) -> int:
+        """Number of interactions accumulated since last flush."""
+        return self._acc.interaction_count
+
+    def observe(self, record: InteractionRecord) -> bool:
+        """Process one user interaction.
+
+        Returns ``True`` if a batch flush was triggered.
+        """
+        acc = self._acc
+        acc.interaction_count += 1
+        acc.message_lengths.append(len(record.message))
+
+        if _FORMAL_PATTERNS.search(record.message):
+            acc.formal_markers += 1
+        if _CASUAL_PATTERNS.search(record.message):
+            acc.casual_markers += 1
+
+        for topic in record.topics:
+            acc.topic_counts[topic] += 1
+
+        if record.is_correction:
+            acc.correction_count += 1
+
+        ts = record.timestamp or time.time()
+        hour = time.localtime(ts).tm_hour
+        acc.activity_hours.append(hour)
+
+        if acc.interaction_count >= self._batch_size:
+            self.flush()
+            return True
+        return False
+
+    def flush(self) -> dict[str, Any]:
+        """Write accumulated signals to LTM shadow and reset.
+
+        Returns a dict summarising what was written.
+        """
+        acc = self._acc
+        if acc.interaction_count == 0:
+            return {}
+
+        updates: dict[str, Any] = {}
+
+        # --- communication style inference ---
+        if acc.formal_markers > acc.casual_markers:
+            updates["communication_style"] = "formal"
+        elif acc.casual_markers > acc.formal_markers:
+            updates["communication_style"] = "casual"
+        elif acc.message_lengths:
+            avg_len = statistics.mean(acc.message_lengths)
+            if avg_len < 30:
+                updates["communication_style"] = "terse"
+
+        # --- expertise domains ---
+        if acc.topic_counts:
+            top_topics = [
+                t for t, _ in acc.topic_counts.most_common(10)
+            ]
+            existing = list(self._persistence.user.expertise_domains)
+            merged = list(dict.fromkeys(existing + top_topics))
+            updates["expertise_domains"] = merged
+
+        # --- interaction history summary ---
+        parts: list[str] = []
+        if acc.message_lengths:
+            avg = statistics.mean(acc.message_lengths)
+            parts.append(f"avg_message_length={avg:.0f}")
+        if acc.correction_count:
+            parts.append(f"corrections={acc.correction_count}")
+        if acc.activity_hours:
+            mode_hour = max(set(acc.activity_hours), key=acc.activity_hours.count)
+            parts.append(f"peak_hour={mode_hour}")
+        if parts:
+            updates["interaction_history_summary"] = "; ".join(parts)
+
+        if updates:
+            self._persistence.update_user(**updates)
+
+        result = {
+            "interactions": acc.interaction_count,
+            "updates": updates,
+        }
+        acc.reset()
+        return result

--- a/tests/test_user_learning.py
+++ b/tests/test_user_learning.py
@@ -1,0 +1,217 @@
+"""Tests for UserLearningPipeline (#245)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from openbad.identity.learning import (
+    InteractionRecord,
+    UserLearningPipeline,
+)
+from openbad.identity.persistence import IdentityPersistence
+from openbad.memory.episodic import EpisodicMemory
+
+
+def _make_config(tmp: Path) -> Path:
+    cfg = tmp / "identity.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "user": {
+                    "name": "Alice",
+                    "preferred_name": "",
+                    "communication_style": "casual",
+                    "expertise_domains": [],
+                    "interaction_history_summary": "",
+                },
+                "assistant": {
+                    "name": "OpenBaD",
+                    "persona_summary": "",
+                    "learning_focus": [],
+                    "ocean": {
+                        "openness": 0.7,
+                        "conscientiousness": 0.8,
+                        "extraversion": 0.5,
+                        "agreeableness": 0.4,
+                        "stability": 0.6,
+                    },
+                },
+            },
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+@pytest.fixture()
+def env(tmp_path: Path):
+    cfg = _make_config(tmp_path)
+    ep = EpisodicMemory(tmp_path / "ep.json", auto_persist=True)
+    ip = IdentityPersistence(cfg, ep)
+    return ip, ep
+
+
+# ------------------------------------------------------------------ #
+# Batch triggering
+# ------------------------------------------------------------------ #
+
+
+class TestBatching:
+    def test_no_flush_below_batch_size(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=5)
+        for _ in range(4):
+            flushed = pipeline.observe(InteractionRecord(message="hi"))
+            assert flushed is False
+        assert pipeline.pending == 4
+
+    def test_auto_flush_at_batch_size(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=3)
+        for _i in range(3):
+            flushed = pipeline.observe(InteractionRecord(message="hello"))
+        assert flushed is True
+        assert pipeline.pending == 0
+
+    def test_manual_flush_resets(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=100)
+        pipeline.observe(InteractionRecord(message="hey"))
+        result = pipeline.flush()
+        assert result["interactions"] == 1
+        assert pipeline.pending == 0
+
+    def test_flush_empty_returns_empty_dict(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=10)
+        result = pipeline.flush()
+        assert result == {}
+
+
+# ------------------------------------------------------------------ #
+# Communication style inference
+# ------------------------------------------------------------------ #
+
+
+class TestCommunicationStyle:
+    def test_formal_inferred(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=100)
+        for _ in range(5):
+            pipeline.observe(
+                InteractionRecord(message="Would you please help me?"),
+            )
+        result = pipeline.flush()
+        assert result["updates"]["communication_style"] == "formal"
+
+    def test_casual_inferred(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=100)
+        for _ in range(5):
+            pipeline.observe(InteractionRecord(message="hey thx lol"))
+        result = pipeline.flush()
+        assert result["updates"]["communication_style"] == "casual"
+
+    def test_terse_inferred(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=100)
+        for _ in range(5):
+            pipeline.observe(InteractionRecord(message="ok"))
+        result = pipeline.flush()
+        assert result["updates"]["communication_style"] == "terse"
+
+
+# ------------------------------------------------------------------ #
+# Topic frequency
+# ------------------------------------------------------------------ #
+
+
+class TestTopicTracking:
+    def test_topics_merged(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=100)
+        pipeline.observe(
+            InteractionRecord(message="x", topics=["python", "rust"]),
+        )
+        pipeline.observe(
+            InteractionRecord(message="y", topics=["python"]),
+        )
+        result = pipeline.flush()
+        domains = result["updates"]["expertise_domains"]
+        assert "python" in domains
+        assert "rust" in domains
+
+    def test_topics_preserve_existing(self, env) -> None:
+        ip, _ = env
+        ip.update_user(expertise_domains=["go"])
+        pipeline = UserLearningPipeline(ip, batch_size=100)
+        pipeline.observe(
+            InteractionRecord(message="x", topics=["python"]),
+        )
+        result = pipeline.flush()
+        domains = result["updates"]["expertise_domains"]
+        assert "go" in domains
+        assert "python" in domains
+
+
+# ------------------------------------------------------------------ #
+# Correction tracking
+# ------------------------------------------------------------------ #
+
+
+class TestCorrectionTracking:
+    def test_corrections_in_summary(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=100)
+        pipeline.observe(
+            InteractionRecord(message="no, I meant X", is_correction=True),
+        )
+        result = pipeline.flush()
+        summary = result["updates"]["interaction_history_summary"]
+        assert "corrections=1" in summary
+
+
+# ------------------------------------------------------------------ #
+# Activity time tracking
+# ------------------------------------------------------------------ #
+
+
+class TestActivityTime:
+    def test_peak_hour_in_summary(self, env) -> None:
+        ip, _ = env
+        pipeline = UserLearningPipeline(ip, batch_size=100)
+        # Use a fixed timestamp at hour 14
+        ts = time.mktime(time.strptime("2025-01-15 14:30:00", "%Y-%m-%d %H:%M:%S"))
+        for _ in range(3):
+            pipeline.observe(
+                InteractionRecord(message="work", timestamp=ts),
+            )
+        result = pipeline.flush()
+        summary = result["updates"]["interaction_history_summary"]
+        assert "peak_hour=14" in summary
+
+
+# ------------------------------------------------------------------ #
+# LTM shadow integration
+# ------------------------------------------------------------------ #
+
+
+class TestLTMIntegration:
+    def test_updates_go_to_ltm_not_config(self, env) -> None:
+        ip, ep = env
+        pipeline = UserLearningPipeline(ip, batch_size=2)
+        pipeline.observe(
+            InteractionRecord(message="Would you please elaborate?"),
+        )
+        pipeline.observe(
+            InteractionRecord(message="Could you kindly explain?"),
+        )
+        # Shadow should exist in episodic LTM
+        entry = ep.read("identity/user_shadow")
+        assert entry is not None
+        assert entry.value["communication_style"] == "formal"


### PR DESCRIPTION
Closes #245

## Summary
- `UserLearningPipeline` observes `InteractionRecord`s and infers user preferences
- Tracks: message patterns (length/formality), topic frequency, corrections, activity hours
- Batched LTM writes at configurable interval (default every 50 interactions)
- Updates LTM shadow only — never modifies UserProfile or config directly
- All learning is local, no data leaves the system
- 12 tests covering batching, style inference, topic tracking, corrections, activity time, and LTM integration

## How to test
```bash
pytest tests/test_user_learning.py -v
```