### PR TITLE
#246: WUI Entity panel (user + assistant profiles, OCEAN sliders)

### DIFF
--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -682,6 +682,100 @@ async def _delete_toolbelt_role(request: web.Request) -> web.Response:
     return web.json_response(_serialize_toolbelt(registry))
 
 
+# ---------------------------------------------------------------------- #
+# Entity endpoints — user / assistant profile management
+# ---------------------------------------------------------------------- #
+
+
+def _serialize_user(profile) -> dict:
+    from dataclasses import asdict
+    d = asdict(profile)
+    d["communication_style"] = profile.communication_style.value
+    return d
+
+
+def _serialize_assistant(profile) -> dict:
+    from dataclasses import asdict
+    return asdict(profile)
+
+
+async def _get_entity_user(request: web.Request) -> web.Response:
+    persistence = request.app.get("identity_persistence")
+    if persistence is None:
+        raise web.HTTPServiceUnavailable(text="IdentityPersistence not available")
+    return web.json_response(_serialize_user(persistence.user))
+
+
+async def _get_entity_assistant(request: web.Request) -> web.Response:
+    persistence = request.app.get("identity_persistence")
+    if persistence is None:
+        raise web.HTTPServiceUnavailable(text="IdentityPersistence not available")
+    data = _serialize_assistant(persistence.assistant)
+    # Include computed modulation factors if PersonalityModulator is available.
+    modulator = request.app.get("personality_modulator")
+    if modulator is not None:
+        f = modulator.factors
+        data["modulation"] = {
+            "exploration_budget_multiplier": f.exploration_budget_multiplier,
+            "max_reasoning_depth_multiplier": f.max_reasoning_depth_multiplier,
+            "proactive_suggestion_threshold": f.proactive_suggestion_threshold,
+            "challenge_probability": f.challenge_probability,
+            "cortisol_decay_multiplier": f.cortisol_decay_multiplier,
+        }
+    return web.json_response(data)
+
+
+async def _put_entity_user(request: web.Request) -> web.Response:
+    persistence = request.app.get("identity_persistence")
+    if persistence is None:
+        raise web.HTTPServiceUnavailable(text="IdentityPersistence not available")
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise web.HTTPBadRequest(text="Request body must be a JSON object")
+    try:
+        persistence.update_user(**payload)
+    except (AttributeError, ValueError, TypeError) as exc:
+        raise web.HTTPBadRequest(text=str(exc)) from exc
+    return web.json_response(_serialize_user(persistence.user))
+
+
+async def _put_entity_assistant(request: web.Request) -> web.Response:
+    persistence = request.app.get("identity_persistence")
+    if persistence is None:
+        raise web.HTTPServiceUnavailable(text="IdentityPersistence not available")
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise web.HTTPBadRequest(text="Request body must be a JSON object")
+    try:
+        persistence.update_assistant(**payload)
+    except (AttributeError, ValueError, TypeError) as exc:
+        raise web.HTTPBadRequest(text=str(exc)) from exc
+    # Recalculate modulation factors if modulator is available.
+    modulator = request.app.get("personality_modulator")
+    if modulator is not None:
+        modulator.update(persistence.assistant)
+    return web.json_response(_serialize_assistant(persistence.assistant))
+
+
+async def _post_entity_user_reset(request: web.Request) -> web.Response:
+    persistence = request.app.get("identity_persistence")
+    if persistence is None:
+        raise web.HTTPServiceUnavailable(text="IdentityPersistence not available")
+    persistence.reset_to_seed()
+    return web.json_response(_serialize_user(persistence.user))
+
+
+async def _post_entity_assistant_reset(request: web.Request) -> web.Response:
+    persistence = request.app.get("identity_persistence")
+    if persistence is None:
+        raise web.HTTPServiceUnavailable(text="IdentityPersistence not available")
+    persistence.reset_to_seed()
+    modulator = request.app.get("personality_modulator")
+    if modulator is not None:
+        modulator.update(persistence.assistant)
+    return web.json_response(_serialize_assistant(persistence.assistant))
+
+
 def create_app(
     mqtt_host: str = "localhost",
     mqtt_port: int = 1883,
@@ -714,6 +808,12 @@ def create_app(
     app.router.add_get("/api/toolbelt", _get_toolbelt)
     app.router.add_put("/api/toolbelt/{role}", _put_toolbelt_role)
     app.router.add_delete("/api/toolbelt/{role}", _delete_toolbelt_role)
+    app.router.add_get("/api/entity/user", _get_entity_user)
+    app.router.add_put("/api/entity/user", _put_entity_user)
+    app.router.add_post("/api/entity/user/reset", _post_entity_user_reset)
+    app.router.add_get("/api/entity/assistant", _get_entity_assistant)
+    app.router.add_put("/api/entity/assistant", _put_entity_assistant)
+    app.router.add_post("/api/entity/assistant/reset", _post_entity_assistant_reset)
     # TODO: Remove after v1.0 once external consumers have migrated to /api/providers/*.
     app.router.add_get("/api/wiring/providers", _redirect_legacy_wiring_providers)
     app.router.add_post(

--- a/src/openbad/wui/static/app.js
+++ b/src/openbad/wui/static/app.js
@@ -134,6 +134,10 @@ const viewMeta = {
     title: 'Toolbelt',
     subtitle: 'Cabinet inventory, equipped tools, and health status.',
   },
+  entity: {
+    title: 'Entity',
+    subtitle: 'User and assistant identity profiles with OCEAN personality.',
+  },
   models: {
     title: 'Models',
     subtitle: 'Reserved for the upcoming model surface.',
@@ -211,6 +215,9 @@ function setView(name) {
   }
   if (name === 'toolbelt') {
     loadToolbelt();
+  }
+  if (name === 'entity') {
+    loadEntityUser();
   }
 }
 
@@ -1235,6 +1242,183 @@ function bindToolbeltButtons() {
   }
 }
 
+// ------------------------------------------------------------------ //
+// Entity panel — user + assistant profiles
+// ------------------------------------------------------------------ //
+
+async function loadEntityUser() {
+  try {
+    const resp = await fetch('/api/entity/user');
+    if (!resp.ok) return;
+    const data = await resp.json();
+    populateEntityUser(data);
+  } catch (err) {
+    logLine(`entity/user load failed: ${err.message}`);
+  }
+}
+
+function populateEntityUser(data) {
+  const f = id => document.getElementById(id);
+  f('eu-name').value = data.name || '';
+  f('eu-preferred-name').value = data.preferred_name || '';
+  f('eu-style').value = data.communication_style || 'casual';
+  f('eu-domains').value = (data.expertise_domains || []).join(', ');
+  f('eu-summary').textContent = data.interaction_history_summary || '—';
+}
+
+async function saveEntityUser() {
+  const f = id => document.getElementById(id);
+  const domainsRaw = f('eu-domains').value;
+  const domains = domainsRaw ? domainsRaw.split(',').map(s => s.trim()).filter(Boolean) : [];
+  const payload = {
+    name: f('eu-name').value,
+    preferred_name: f('eu-preferred-name').value,
+    communication_style: f('eu-style').value,
+    expertise_domains: domains,
+  };
+  const status = document.getElementById('entity-user-status');
+  try {
+    const resp = await fetch('/api/entity/user', {
+      method: 'PUT',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload),
+    });
+    if (!resp.ok) { status.textContent = `Error: ${resp.statusText}`; return; }
+    const data = await resp.json();
+    populateEntityUser(data);
+    status.textContent = 'Saved.';
+  } catch (err) {
+    status.textContent = `Save failed: ${err.message}`;
+  }
+}
+
+async function resetEntityUser() {
+  const status = document.getElementById('entity-user-status');
+  try {
+    const resp = await fetch('/api/entity/user/reset', {method: 'POST'});
+    const data = await resp.json();
+    populateEntityUser(data);
+    status.textContent = 'Reset to seed.';
+  } catch (err) {
+    status.textContent = `Reset failed: ${err.message}`;
+  }
+}
+
+async function loadEntityAssistant() {
+  try {
+    const resp = await fetch('/api/entity/assistant');
+    if (!resp.ok) return;
+    const data = await resp.json();
+    populateEntityAssistant(data);
+  } catch (err) {
+    logLine(`entity/assistant load failed: ${err.message}`);
+  }
+}
+
+function populateEntityAssistant(data) {
+  const f = id => document.getElementById(id);
+  f('ea-name').value = data.name || '';
+  f('ea-persona').value = data.persona_summary || '';
+  f('ea-focus').value = (data.learning_focus || []).join(', ');
+
+  const sliders = [
+    ['ea-openness', 'ea-o-val', 'ea-o-desc', data.openness, v => `exploration_budget = ${(0.5 + v).toFixed(2)}`],
+    ['ea-conscientiousness', 'ea-c-val', 'ea-c-desc', data.conscientiousness, v => `reasoning_depth = ${(0.5 + v).toFixed(2)}`],
+    ['ea-extraversion', 'ea-e-val', 'ea-e-desc', data.extraversion, v => `proactive_threshold = ${(1.0 - v).toFixed(2)}`],
+    ['ea-agreeableness', 'ea-a-val', 'ea-a-desc', data.agreeableness, v => `challenge_prob = ${(1.0 - v).toFixed(2)}`],
+    ['ea-stability', 'ea-s-val', 'ea-s-desc', data.stability, v => `cortisol_decay = ${(0.5 + v).toFixed(2)}`],
+  ];
+  for (const [sliderId, valId, descId, value, descFn] of sliders) {
+    const v = value ?? 0.5;
+    f(sliderId).value = v;
+    f(valId).textContent = Number(v).toFixed(2);
+    f(descId).textContent = descFn(Number(v));
+  }
+}
+
+function updateOceanPreview(sliderId, valId, descId, descFn) {
+  const slider = document.getElementById(sliderId);
+  if (!slider) return;
+  slider.addEventListener('input', () => {
+    const v = Number(slider.value);
+    document.getElementById(valId).textContent = v.toFixed(2);
+    document.getElementById(descId).textContent = descFn(v);
+  });
+}
+
+async function saveEntityAssistant() {
+  const f = id => document.getElementById(id);
+  const focusRaw = f('ea-focus').value;
+  const focus = focusRaw ? focusRaw.split(',').map(s => s.trim()).filter(Boolean) : [];
+  const payload = {
+    name: f('ea-name').value,
+    persona_summary: f('ea-persona').value,
+    learning_focus: focus,
+    openness: Number(f('ea-openness').value),
+    conscientiousness: Number(f('ea-conscientiousness').value),
+    extraversion: Number(f('ea-extraversion').value),
+    agreeableness: Number(f('ea-agreeableness').value),
+    stability: Number(f('ea-stability').value),
+  };
+  const status = document.getElementById('entity-assistant-status');
+  try {
+    const resp = await fetch('/api/entity/assistant', {
+      method: 'PUT',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload),
+    });
+    if (!resp.ok) { status.textContent = `Error: ${resp.statusText}`; return; }
+    await resp.json();
+    status.textContent = 'Saved.';
+  } catch (err) {
+    status.textContent = `Save failed: ${err.message}`;
+  }
+}
+
+async function resetEntityAssistant() {
+  const status = document.getElementById('entity-assistant-status');
+  try {
+    const resp = await fetch('/api/entity/assistant/reset', {method: 'POST'});
+    const data = await resp.json();
+    populateEntityAssistant(data);
+    status.textContent = 'Reset to seed.';
+  } catch (err) {
+    status.textContent = `Reset failed: ${err.message}`;
+  }
+}
+
+function bindEntityEvents() {
+  // Tab switching
+  for (const tab of document.querySelectorAll('.entity-tab')) {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.entity-tab').forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+      const target = tab.dataset.entityTab;
+      document.getElementById('entity-user-panel').classList.toggle('hidden', target !== 'user');
+      document.getElementById('entity-assistant-panel').classList.toggle('hidden', target !== 'assistant');
+      if (target === 'user') loadEntityUser();
+      else loadEntityAssistant();
+    });
+  }
+
+  // Save and reset
+  const userSave = document.getElementById('entity-user-save');
+  if (userSave) userSave.addEventListener('click', saveEntityUser);
+  const userReset = document.getElementById('entity-user-reset');
+  if (userReset) userReset.addEventListener('click', resetEntityUser);
+  const assistantSave = document.getElementById('entity-assistant-save');
+  if (assistantSave) assistantSave.addEventListener('click', saveEntityAssistant);
+  const assistantReset = document.getElementById('entity-assistant-reset');
+  if (assistantReset) assistantReset.addEventListener('click', resetEntityAssistant);
+
+  // OCEAN live preview
+  updateOceanPreview('ea-openness', 'ea-o-val', 'ea-o-desc', v => `exploration_budget = ${(0.5 + v).toFixed(2)}`);
+  updateOceanPreview('ea-conscientiousness', 'ea-c-val', 'ea-c-desc', v => `reasoning_depth = ${(0.5 + v).toFixed(2)}`);
+  updateOceanPreview('ea-extraversion', 'ea-e-val', 'ea-e-desc', v => `proactive_threshold = ${(1.0 - v).toFixed(2)}`);
+  updateOceanPreview('ea-agreeableness', 'ea-a-val', 'ea-a-desc', v => `challenge_prob = ${(1.0 - v).toFixed(2)}`);
+  updateOceanPreview('ea-stability', 'ea-s-val', 'ea-s-desc', v => `cortisol_decay = ${(0.5 + v).toFixed(2)}`);
+}
+
 function bindEvents() {
   for (const link of els.navLinks) {
     link.addEventListener('click', () => setView(link.dataset.viewTarget));
@@ -1307,6 +1491,10 @@ function bindEvents() {
   if (els.senses.saveBtn) {
     els.senses.saveBtn.addEventListener('click', saveSensesConfig);
   }
+
+  // Entity events
+  bindEntityEvents();
+
   // Collapsible sections
   document.querySelectorAll('[data-collapse-toggle]').forEach(toggle => {
     toggle.addEventListener('click', () => {

--- a/src/openbad/wui/static/index.html
+++ b/src/openbad/wui/static/index.html
@@ -24,6 +24,7 @@
         <button type="button" class="nav-link" data-view-target="providers">Providers</button>
         <button type="button" class="nav-link" data-view-target="senses">Senses</button>
         <button type="button" class="nav-link" data-view-target="toolbelt">Toolbelt</button>
+        <button type="button" class="nav-link" data-view-target="entity">Entity</button>
         <button type="button" class="nav-link" data-view-target="models">Models <span class="nav-chip">next</span></button>
       </nav>
       <div class="nav-status">
@@ -419,6 +420,87 @@
             <div id="toolbelt-swap-body" class="collapse-body">
               <ul id="toolbelt-swap-log" class="swap-log"></ul>
             </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="view-entity" class="view-panel reveal hidden" data-view="entity">
+        <div class="panel-grid single-column">
+          <div class="entity-tabs">
+            <button type="button" class="entity-tab active" data-entity-tab="user">User</button>
+            <button type="button" class="entity-tab" data-entity-tab="assistant">Assistant</button>
+          </div>
+
+          <!-- User tab -->
+          <article id="entity-user-panel" class="card section-card">
+            <div class="section-head">
+              <h3>User Profile</h3>
+              <span class="section-note">Identity layer 1 (config-seeded)</span>
+            </div>
+            <form id="entity-user-form" class="stack">
+              <label><span>Name</span><input id="eu-name" type="text"></label>
+              <label><span>Preferred name</span><input id="eu-preferred-name" type="text"></label>
+              <label>
+                <span>Communication style</span>
+                <select id="eu-style">
+                  <option value="casual">Casual</option>
+                  <option value="formal">Formal</option>
+                  <option value="terse">Terse</option>
+                </select>
+              </label>
+              <label><span>Expertise domains (comma-separated)</span><input id="eu-domains" type="text"></label>
+              <div class="row"><span>Learned summary</span><em id="eu-summary" class="mono">—</em></div>
+            </form>
+            <div class="wizard-actions">
+              <button id="entity-user-save" type="button" class="primary-button">Save</button>
+              <button id="entity-user-reset" type="button" class="secondary-button">Reset to seed</button>
+            </div>
+            <p id="entity-user-status" class="inline-status"></p>
+          </article>
+
+          <!-- Assistant tab -->
+          <article id="entity-assistant-panel" class="card section-card hidden">
+            <div class="section-head">
+              <h3>Assistant Profile</h3>
+              <span class="section-note">OCEAN personality with live modulation preview</span>
+            </div>
+            <form id="entity-assistant-form" class="stack">
+              <label><span>Name</span><input id="ea-name" type="text"></label>
+              <label><span>Persona summary</span><input id="ea-persona" type="text"></label>
+              <label><span>Learning focus (comma-separated)</span><input id="ea-focus" type="text"></label>
+              <div class="ocean-sliders">
+                <div class="ocean-row">
+                  <label>Openness <strong id="ea-o-val">0.7</strong></label>
+                  <input id="ea-openness" type="range" min="0" max="1" step="0.01" value="0.7">
+                  <em id="ea-o-desc" class="mono">exploration_budget = 1.20</em>
+                </div>
+                <div class="ocean-row">
+                  <label>Conscientiousness <strong id="ea-c-val">0.8</strong></label>
+                  <input id="ea-conscientiousness" type="range" min="0" max="1" step="0.01" value="0.8">
+                  <em id="ea-c-desc" class="mono">reasoning_depth = 1.30</em>
+                </div>
+                <div class="ocean-row">
+                  <label>Extraversion <strong id="ea-e-val">0.5</strong></label>
+                  <input id="ea-extraversion" type="range" min="0" max="1" step="0.01" value="0.5">
+                  <em id="ea-e-desc" class="mono">proactive_threshold = 0.50</em>
+                </div>
+                <div class="ocean-row">
+                  <label>Agreeableness <strong id="ea-a-val">0.4</strong></label>
+                  <input id="ea-agreeableness" type="range" min="0" max="1" step="0.01" value="0.4">
+                  <em id="ea-a-desc" class="mono">challenge_prob = 0.60</em>
+                </div>
+                <div class="ocean-row">
+                  <label>Stability <strong id="ea-s-val">0.6</strong></label>
+                  <input id="ea-stability" type="range" min="0" max="1" step="0.01" value="0.6">
+                  <em id="ea-s-desc" class="mono">cortisol_decay = 1.10</em>
+                </div>
+              </div>
+            </form>
+            <div class="wizard-actions">
+              <button id="entity-assistant-save" type="button" class="primary-button">Save</button>
+              <button id="entity-assistant-reset" type="button" class="secondary-button">Reset to seed</button>
+            </div>
+            <p id="entity-assistant-status" class="inline-status"></p>
           </article>
         </div>
       </section>

--- a/tests/test_wui_server.py
+++ b/tests/test_wui_server.py
@@ -691,3 +691,142 @@ async def test_delete_toolbelt_unequip(aiohttp_client):
     assert resp.status == 200
     data = await resp.json()
     assert data["belt"].get("cli") is None
+
+
+# ---------------------------------------------------------------------- #
+# Entity endpoints
+# ---------------------------------------------------------------------- #
+
+
+def _app_with_persistence(tmp_path):
+    """Create a WUI app with IdentityPersistence wired in."""
+
+    cfg_path = tmp_path / "identity.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump(
+            {
+                "user": {
+                    "name": "Alice",
+                    "preferred_name": "Ali",
+                    "communication_style": "casual",
+                    "expertise_domains": ["python"],
+                    "interaction_history_summary": "",
+                },
+                "assistant": {
+                    "name": "OpenBaD",
+                    "persona_summary": "Helpful",
+                    "learning_focus": [],
+                    "ocean": {
+                        "openness": 0.7,
+                        "conscientiousness": 0.8,
+                        "extraversion": 0.5,
+                        "agreeableness": 0.4,
+                        "stability": 0.6,
+                    },
+                },
+            },
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+
+    from openbad.identity.persistence import IdentityPersistence
+    from openbad.memory.episodic import EpisodicMemory
+
+    ep = EpisodicMemory(tmp_path / "ep.json", auto_persist=True)
+    persistence = IdentityPersistence(cfg_path, ep)
+
+    app = create_app(enable_mqtt=False)
+    app["identity_persistence"] = persistence
+    return app
+
+
+@pytest.mark.asyncio
+async def test_get_entity_user(aiohttp_client, tmp_path):
+    app = _app_with_persistence(tmp_path)
+    client = await aiohttp_client(app)
+    resp = await client.get("/api/entity/user")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["name"] == "Alice"
+    assert data["communication_style"] == "casual"
+
+
+@pytest.mark.asyncio
+async def test_get_entity_assistant(aiohttp_client, tmp_path):
+    app = _app_with_persistence(tmp_path)
+    client = await aiohttp_client(app)
+    resp = await client.get("/api/entity/assistant")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["name"] == "OpenBaD"
+    assert data["openness"] == pytest.approx(0.7)
+
+
+@pytest.mark.asyncio
+async def test_put_entity_user(aiohttp_client, tmp_path):
+    app = _app_with_persistence(tmp_path)
+    client = await aiohttp_client(app)
+    resp = await client.put(
+        "/api/entity/user",
+        json={"preferred_name": "Bob"},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["preferred_name"] == "Bob"
+
+
+@pytest.mark.asyncio
+async def test_put_entity_assistant(aiohttp_client, tmp_path):
+    app = _app_with_persistence(tmp_path)
+    client = await aiohttp_client(app)
+    resp = await client.put(
+        "/api/entity/assistant",
+        json={"openness": 0.9},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["openness"] == pytest.approx(0.9)
+
+
+@pytest.mark.asyncio
+async def test_put_entity_user_bad_field(aiohttp_client, tmp_path):
+    app = _app_with_persistence(tmp_path)
+    client = await aiohttp_client(app)
+    resp = await client.put(
+        "/api/entity/user",
+        json={"nonexistent": "x"},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_post_entity_user_reset(aiohttp_client, tmp_path):
+    app = _app_with_persistence(tmp_path)
+    client = await aiohttp_client(app)
+    # Modify first
+    await client.put("/api/entity/user", json={"preferred_name": "Changed"})
+    # Reset
+    resp = await client.post("/api/entity/user/reset")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["preferred_name"] == "Ali"
+
+
+@pytest.mark.asyncio
+async def test_post_entity_assistant_reset(aiohttp_client, tmp_path):
+    app = _app_with_persistence(tmp_path)
+    client = await aiohttp_client(app)
+    await client.put("/api/entity/assistant", json={"openness": 0.1})
+    resp = await client.post("/api/entity/assistant/reset")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["openness"] == pytest.approx(0.7)
+
+
+@pytest.mark.asyncio
+async def test_entity_no_persistence_returns_503(aiohttp_client):
+    app = create_app(enable_mqtt=False)
+    client = await aiohttp_client(app)
+    resp = await client.get("/api/entity/user")
+    assert resp.status == 503


### PR DESCRIPTION
Closes #246

## Summary
- Entity panel with User and Assistant tabs in WUI
- User tab: editable name, preferred_name, communication_style, expertise_domains + read-only learned summary
- Assistant tab: editable fields + OCEAN range sliders with live modulation factor preview
- REST endpoints: GET/PUT `/api/entity/{user|assistant}`, POST `/api/entity/{user|assistant}/reset`
- Save persists to LTM shadow via IdentityPersistence; Reset-to-Seed restores factory defaults
- 8 new tests covering all entity API endpoints + validation + 503 when no persistence

## How to test
```bash
pytest tests/test_wui_server.py -k entity -v
```