### PR TITLE
#247: Scaffold SvelteKit project with TypeScript, Vite, and project structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format test check proto
+.PHONY: install lint format test check proto wui-build wui-dev
 
 PROTO_SRC := src/openbad/nervous_system/schemas
 PROTO_FILES := $(wildcard $(PROTO_SRC)/*.proto)
@@ -29,3 +29,10 @@ test:
 
 test-all:
 	pytest
+
+wui-build:
+	cd wui-svelte && npm install && npm run build
+	@echo "Static assets built in wui-svelte/build/"
+
+wui-dev:
+	cd wui-svelte && npm run dev

--- a/tests/test_svelte_scaffold.py
+++ b/tests/test_svelte_scaffold.py
@@ -1,0 +1,88 @@
+"""Tests for SvelteKit project scaffold (#247)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent / "wui-svelte"
+
+
+def test_scaffold_directory_exists():
+    assert ROOT.is_dir()
+
+
+def test_package_json_valid():
+    pkg = ROOT / "package.json"
+    assert pkg.exists()
+    data = json.loads(pkg.read_text(encoding="utf-8"))
+    assert data["name"] == "openbad-wui"
+    assert "dev" in data["scripts"]
+    assert "build" in data["scripts"]
+
+
+def test_svelte_config_exists():
+    assert (ROOT / "svelte.config.js").exists()
+
+
+def test_vite_config_exists():
+    assert (ROOT / "vite.config.ts").exists()
+
+
+def test_tsconfig_exists():
+    assert (ROOT / "tsconfig.json").exists()
+
+
+def test_routes_exist():
+    routes = ROOT / "src" / "routes"
+    assert (routes / "+layout.svelte").exists()
+    assert (routes / "+page.svelte").exists()
+    for route in ("chat", "providers", "senses", "toolbelt", "entity", "health"):
+        assert (routes / route / "+page.svelte").exists(), f"Missing route: {route}"
+
+
+def test_lib_structure():
+    lib = ROOT / "src" / "lib"
+    assert (lib / "api" / "client.ts").exists()
+    assert (lib / "stores" / "telemetry.ts").exists()
+    assert (lib / "stores" / "config.ts").exists()
+    assert (lib / "components" / "Card.svelte").exists()
+
+
+def test_app_html_exists():
+    assert (ROOT / "src" / "app.html").exists()
+
+
+def test_static_adapter_configured():
+    config = (ROOT / "svelte.config.js").read_text(encoding="utf-8")
+    assert "adapter-static" in config
+    assert "fallback" in config
+
+
+def test_gitignore_present():
+    gi = ROOT / ".gitignore"
+    assert gi.exists()
+    text = gi.read_text(encoding="utf-8")
+    assert "node_modules" in text
+    assert "build" in text
+
+
+def test_layout_has_spa_mode():
+    layout_ts = ROOT / "src" / "routes" / "+layout.ts"
+    assert layout_ts.exists()
+    text = layout_ts.read_text(encoding="utf-8")
+    assert "prerender" in text
+    assert "ssr" in text
+
+
+def test_makefile_targets():
+    makefile = ROOT.parent / "Makefile"
+    text = makefile.read_text(encoding="utf-8")
+    assert "wui-build" in text
+    assert "wui-dev" in text
+
+
+def test_dependencies_are_dev_only():
+    """All SvelteKit deps should be devDependencies (no production deps)."""
+    pkg = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
+    assert "dependencies" not in pkg or len(pkg.get("dependencies", {})) == 0

--- a/wui-svelte/.gitignore
+++ b/wui-svelte/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+build/
+.svelte-kit/
+.env
+.env.*
+!.env.example

--- a/wui-svelte/package.json
+++ b/wui-svelte/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "openbad-wui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-static": "^3.0.0",
+    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/wui-svelte/src/app.d.ts
+++ b/wui-svelte/src/app.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="@sveltejs/kit" />
+
+declare namespace App {
+  // interface Error {}
+  // interface Locals {}
+  // interface PageData {}
+  // interface Platform {}
+}

--- a/wui-svelte/src/app.html
+++ b/wui-svelte/src/app.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenBaD Control Surface</title>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/wui-svelte/src/lib/api/client.ts
+++ b/wui-svelte/src/lib/api/client.ts
@@ -1,0 +1,37 @@
+/**
+ * REST API client helpers for the OpenBaD backend.
+ */
+
+const BASE = '';
+
+export async function get<T>(path: string): Promise<T> {
+  const resp = await fetch(`${BASE}${path}`);
+  if (!resp.ok) throw new Error(`GET ${path} failed: ${resp.statusText}`);
+  return resp.json() as Promise<T>;
+}
+
+export async function put<T>(path: string, body: unknown): Promise<T> {
+  const resp = await fetch(`${BASE}${path}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) throw new Error(`PUT ${path} failed: ${resp.statusText}`);
+  return resp.json() as Promise<T>;
+}
+
+export async function post<T>(path: string, body?: unknown): Promise<T> {
+  const resp = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!resp.ok) throw new Error(`POST ${path} failed: ${resp.statusText}`);
+  return resp.json() as Promise<T>;
+}
+
+export async function del<T>(path: string): Promise<T> {
+  const resp = await fetch(`${BASE}${path}`, { method: 'DELETE' });
+  if (!resp.ok) throw new Error(`DELETE ${path} failed: ${resp.statusText}`);
+  return resp.json() as Promise<T>;
+}

--- a/wui-svelte/src/lib/components/Card.svelte
+++ b/wui-svelte/src/lib/components/Card.svelte
@@ -1,0 +1,9 @@
+<!-- Placeholder shared component -->
+<script lang="ts">
+  let { label = 'Card', children }: { label?: string; children: import('svelte').Snippet } = $props();
+</script>
+
+<article class="card">
+  <h3>{label}</h3>
+  {@render children()}
+</article>

--- a/wui-svelte/src/lib/stores/config.ts
+++ b/wui-svelte/src/lib/stores/config.ts
@@ -1,0 +1,24 @@
+/**
+ * Config store — manages provider and system configuration state.
+ */
+
+import { writable } from 'svelte/store';
+import { get, put } from '$lib/api/client';
+
+export interface ProviderConfig {
+  enabled: boolean;
+  default_provider: string;
+  providers: Array<{ name: string; model: string; verified: boolean }>;
+}
+
+export const providerConfig = writable<ProviderConfig | null>(null);
+
+export async function loadProviders(): Promise<void> {
+  const data = await get<ProviderConfig>('/api/providers');
+  providerConfig.set(data);
+}
+
+export async function saveProviders(config: ProviderConfig): Promise<void> {
+  const data = await put<ProviderConfig>('/api/providers', config);
+  providerConfig.set(data);
+}

--- a/wui-svelte/src/lib/stores/telemetry.ts
+++ b/wui-svelte/src/lib/stores/telemetry.ts
@@ -1,0 +1,68 @@
+/**
+ * Telemetry store — connects to the SSE event stream and exposes
+ * reactive state for health metrics, hormones, and FSM state.
+ */
+
+import { writable } from 'svelte/store';
+
+export const connected = writable(false);
+export const fsmState = writable('UNKNOWN');
+
+export interface Vitals {
+  cpu: number;
+  memory: number;
+  disk: number;
+  netTx: number;
+  netRx: number;
+}
+
+export const vitals = writable<Vitals>({
+  cpu: 0,
+  memory: 0,
+  disk: 0,
+  netTx: 0,
+  netRx: 0,
+});
+
+export interface Hormones {
+  dopamine: number;
+  adrenaline: number;
+  cortisol: number;
+  endorphin: number;
+}
+
+export const hormones = writable<Hormones>({
+  dopamine: 0,
+  adrenaline: 0,
+  cortisol: 0,
+  endorphin: 0,
+});
+
+let eventSource: EventSource | null = null;
+
+export function connectTelemetry(): void {
+  if (eventSource) return;
+  eventSource = new EventSource('/events');
+  eventSource.onopen = () => connected.set(true);
+  eventSource.onerror = () => connected.set(false);
+  eventSource.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      if (data.topic && data.payload) {
+        handleEvent(data.topic, data.payload);
+      }
+    } catch {
+      // ignore non-JSON messages
+    }
+  };
+}
+
+function handleEvent(topic: string, payload: Record<string, unknown>): void {
+  if (topic === 'agent/telemetry/vitals') {
+    vitals.set(payload as unknown as Vitals);
+  } else if (topic === 'agent/telemetry/endocrine') {
+    hormones.set(payload as unknown as Hormones);
+  } else if (topic === 'agent/fsm/state') {
+    fsmState.set(String(payload.state ?? 'UNKNOWN'));
+  }
+}

--- a/wui-svelte/src/routes/+layout.svelte
+++ b/wui-svelte/src/routes/+layout.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let { children }: { children: Snippet } = $props();
+</script>
+
+<div class="app-shell">
+  <nav class="side-nav">
+    <div class="brand-mark">OB</div>
+    <h1>OpenBaD</h1>
+    <ul>
+      <li><a href="/">Health</a></li>
+      <li><a href="/chat">Chat</a></li>
+      <li><a href="/providers">Providers</a></li>
+      <li><a href="/senses">Senses</a></li>
+      <li><a href="/toolbelt">Toolbelt</a></li>
+      <li><a href="/entity">Entity</a></li>
+    </ul>
+  </nav>
+  <main class="workspace">
+    {@render children()}
+  </main>
+</div>

--- a/wui-svelte/src/routes/+layout.ts
+++ b/wui-svelte/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const ssr = false;

--- a/wui-svelte/src/routes/+page.svelte
+++ b/wui-svelte/src/routes/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  // Health dashboard — live telemetry
+</script>
+
+<h2>Health</h2>
+<p>Live runtime telemetry and subsystem health.</p>

--- a/wui-svelte/src/routes/chat/+page.svelte
+++ b/wui-svelte/src/routes/chat/+page.svelte
@@ -1,0 +1,2 @@
+<h2>Chat</h2>
+<p>Operator conversation surface.</p>

--- a/wui-svelte/src/routes/entity/+page.svelte
+++ b/wui-svelte/src/routes/entity/+page.svelte
@@ -1,0 +1,2 @@
+<h2>Entity</h2>
+<p>User and assistant identity profiles with OCEAN personality.</p>

--- a/wui-svelte/src/routes/health/+page.svelte
+++ b/wui-svelte/src/routes/health/+page.svelte
@@ -1,0 +1,2 @@
+<h2>Health</h2>
+<p>System health overview.</p>

--- a/wui-svelte/src/routes/providers/+page.svelte
+++ b/wui-svelte/src/routes/providers/+page.svelte
@@ -1,0 +1,2 @@
+<h2>Providers</h2>
+<p>Verified providers and model access for the runtime.</p>

--- a/wui-svelte/src/routes/senses/+page.svelte
+++ b/wui-svelte/src/routes/senses/+page.svelte
@@ -1,0 +1,2 @@
+<h2>Senses</h2>
+<p>Configure vision, hearing, and speech modalities.</p>

--- a/wui-svelte/src/routes/toolbelt/+page.svelte
+++ b/wui-svelte/src/routes/toolbelt/+page.svelte
@@ -1,0 +1,2 @@
+<h2>Toolbelt</h2>
+<p>Cabinet inventory, equipped tools, and health status.</p>

--- a/wui-svelte/svelte.config.js
+++ b/wui-svelte/svelte.config.js
@@ -1,0 +1,21 @@
+import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter({
+      pages: 'build',
+      assets: 'build',
+      fallback: 'index.html',
+      precompress: false,
+      strict: true
+    }),
+    paths: {
+      base: ''
+    }
+  }
+};
+
+export default config;

--- a/wui-svelte/tsconfig.json
+++ b/wui-svelte/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}

--- a/wui-svelte/vite.config.ts
+++ b/wui-svelte/vite.config.ts
@@ -1,0 +1,13 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [sveltekit()],
+  server: {
+    proxy: {
+      '/api': 'http://127.0.0.1:9200',
+      '/health': 'http://127.0.0.1:9200',
+      '/events': 'http://127.0.0.1:9200'
+    }
+  }
+});


### PR DESCRIPTION
Closes #247

## Summary
- SvelteKit project scaffolded in `wui-svelte/` with TypeScript + Vite
- Static adapter configured (SPA mode with fallback to index.html)
- Directory structure: routes (health, chat, providers, senses, toolbelt, entity), lib (api, stores, components)
- Vite proxy configured for `/api`, `/health`, `/events` → aiohttp backend
- Makefile targets: `wui-build` (npm install + build), `wui-dev` (dev server)
- All SvelteKit deps are MIT/Apache/BSD (devDependencies only)
- 13 tests validating scaffold structure

## How to test
```bash
pytest tests/test_svelte_scaffold.py -v
# When Node.js is available:
cd wui-svelte && npm install && npm run build
```