### PR TITLE
#250: Senses panel — vision, hearing, speech config with live preview

### DIFF
--- a/tests/test_senses_panel.py
+++ b/tests/test_senses_panel.py
@@ -1,0 +1,128 @@
+"""Tests for SvelteKit Senses panel (#250)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_WUI = Path(__file__).resolve().parent.parent / "wui-svelte"
+PAGE = _WUI / "src" / "routes" / "senses" / "+page.svelte"
+
+
+def _text() -> str:
+    return PAGE.read_text(encoding="utf-8")
+
+
+def test_senses_page_exists():
+    assert PAGE.exists()
+
+
+# -- Vision section --
+
+def test_vision_section():
+    t = _text()
+    assert "Vision" in t
+
+
+def test_capture_region_control():
+    t = _text()
+    assert "capture_region" in t
+    assert "full-screen" in t
+    assert "active-window" in t
+
+
+def test_capture_interval_control():
+    t = _text()
+    assert "capture_interval_s" in t
+
+
+def test_resolution_controls():
+    t = _text()
+    assert "max_resolution" in t
+    assert "Max Width" in t
+    assert "Max Height" in t
+
+
+def test_compression_controls():
+    t = _text()
+    assert "compression" in t
+    assert "quality" in t.lower()
+
+
+# -- Hearing section --
+
+def test_hearing_section():
+    t = _text()
+    assert "Hearing" in t
+
+
+def test_asr_engine_control():
+    t = _text()
+    assert "ASR Engine" in t
+    assert "vosk" in t.lower()
+    assert "whisper" in t.lower()
+
+
+def test_vad_sensitivity():
+    t = _text()
+    assert "vad_sensitivity" in t
+
+
+def test_wake_phrases():
+    t = _text()
+    assert "Wake Phrases" in t
+    assert "addPhrase" in t
+
+
+# -- Speech section --
+
+def test_speech_section():
+    t = _text()
+    assert "Speech" in t
+
+
+def test_tts_engine():
+    t = _text()
+    assert "TTS Engine" in t
+    assert "piper" in t.lower()
+
+
+def test_voice_speed_volume():
+    t = _text()
+    assert "speaking_rate" in t
+    assert "volume" in t.lower()
+
+
+def test_output_device():
+    t = _text()
+    assert "output_device" in t
+
+
+# -- Test buttons --
+
+def test_test_tts_button():
+    t = _text()
+    assert "Test TTS" in t
+    assert "testTts" in t
+
+
+def test_preview_capture_button():
+    t = _text()
+    assert "Preview Capture" in t
+    assert "previewCapture" in t
+
+
+# -- Save and REST --
+
+def test_save_button():
+    t = _text()
+    assert "/api/senses" in t
+    assert "apiPut" in t
+
+
+# -- Collapsible sections --
+
+def test_collapsible_sections():
+    t = _text()
+    assert "visionOpen" in t
+    assert "hearingOpen" in t
+    assert "speechOpen" in t

--- a/wui-svelte/src/routes/senses/+page.svelte
+++ b/wui-svelte/src/routes/senses/+page.svelte
@@ -1,2 +1,430 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import Card from '$lib/components/Card.svelte';
+  import {
+    get as apiGet,
+    put as apiPut,
+    post as apiPost,
+  } from '$lib/api/client';
+
+  // ----------------------------------------------------------------
+  // Types mirroring config YAML
+  // ----------------------------------------------------------------
+
+  interface VisionConfig {
+    capture_region: string;
+    capture_interval_s: number;
+    max_resolution: [number, number];
+    compression: { format: string; quality: number };
+  }
+
+  interface HearingConfig {
+    asr: {
+      default_engine: string;
+      vosk_model_path: string;
+      vad_sensitivity: number;
+    };
+    wake_word: { phrases: string[] };
+  }
+
+  interface SpeechConfig {
+    engine: string;
+    voice_model: string;
+    speaking_rate: number;
+    volume: number;
+    output_device: string;
+  }
+
+  interface SensesData {
+    vision: VisionConfig;
+    audio: {
+      asr: HearingConfig['asr'];
+      wake_word: HearingConfig['wake_word'];
+      tts: SpeechConfig;
+    };
+  }
+
+  // ----------------------------------------------------------------
+  // State
+  // ----------------------------------------------------------------
+
+  let vision: VisionConfig = $state({
+    capture_region: 'active-window',
+    capture_interval_s: 1.0,
+    max_resolution: [1920, 1080],
+    compression: { format: 'jpeg', quality: 85 },
+  });
+
+  let hearing: HearingConfig = $state({
+    asr: {
+      default_engine: 'vosk',
+      vosk_model_path: '',
+      vad_sensitivity: 0.5,
+    },
+    wake_word: { phrases: ['hey agent'] },
+  });
+
+  let speech: SpeechConfig = $state({
+    engine: 'piper',
+    voice_model: '',
+    speaking_rate: 1.0,
+    volume: 1.0,
+    output_device: '',
+  });
+
+  let dirty = $state(false);
+  let saving = $state(false);
+  let statusMsg = $state('');
+
+  let visionOpen = $state(true);
+  let hearingOpen = $state(true);
+  let speechOpen = $state(true);
+
+  // ----------------------------------------------------------------
+  // Data loading
+  // ----------------------------------------------------------------
+
+  async function load(): Promise<void> {
+    try {
+      const d = await apiGet<SensesData>('/api/senses');
+      if (d.vision) vision = d.vision;
+      if (d.audio?.asr) {
+        hearing = {
+          asr: d.audio.asr,
+          wake_word: d.audio.wake_word ?? { phrases: [] },
+        };
+      }
+      if (d.audio?.tts) speech = d.audio.tts;
+    } catch (e) {
+      statusMsg = `Load failed: ${e}`;
+    }
+  }
+
+  onMount(() => { load(); });
+
+  // ----------------------------------------------------------------
+  // Save
+  // ----------------------------------------------------------------
+
+  async function save(): Promise<void> {
+    saving = true;
+    statusMsg = '';
+    try {
+      await apiPut('/api/senses', {
+        vision,
+        audio: {
+          asr: hearing.asr,
+          wake_word: hearing.wake_word,
+          tts: speech,
+        },
+      });
+      dirty = false;
+      statusMsg = 'Saved';
+    } catch (e) {
+      statusMsg = `Save failed: ${e}`;
+    } finally {
+      saving = false;
+    }
+  }
+
+  function markDirty(): void { dirty = true; }
+
+  // ----------------------------------------------------------------
+  // Test buttons
+  // ----------------------------------------------------------------
+
+  async function testTts(): Promise<void> {
+    try {
+      await apiPost('/api/senses/test-tts', {
+        text: 'Hello from OpenBaD',
+      });
+    } catch (e) {
+      statusMsg = `TTS test failed: ${e}`;
+    }
+  }
+
+  async function previewCapture(): Promise<void> {
+    try {
+      await apiPost('/api/senses/preview-capture');
+    } catch (e) {
+      statusMsg = `Preview failed: ${e}`;
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Wake phrase helpers
+  // ----------------------------------------------------------------
+
+  function addPhrase(): void {
+    hearing.wake_word.phrases = [
+      ...hearing.wake_word.phrases,
+      '',
+    ];
+    dirty = true;
+  }
+
+  function removePhrase(idx: number): void {
+    hearing.wake_word.phrases =
+      hearing.wake_word.phrases.filter((_, i) => i !== idx);
+    dirty = true;
+  }
+</script>
+
 <h2>Senses</h2>
-<p>Configure vision, hearing, and speech modalities.</p>
+
+<!-- Vision -->
+<Card label="Vision">
+  <button
+    class="collapse-toggle"
+    onclick={() => visionOpen = !visionOpen}
+  >
+    {visionOpen ? '▾' : '▸'} Vision
+  </button>
+  {#if visionOpen}
+    <div class="form-grid">
+      <label>Capture Region
+        <select
+          bind:value={vision.capture_region}
+          onchange={markDirty}
+        >
+          <option value="full-screen">Full Screen</option>
+          <option value="active-window">Active Window</option>
+          <option value="custom-rect">Custom Rect</option>
+        </select>
+      </label>
+
+      <label>Interval (s)
+        <input
+          type="number" min="0.1" step="0.1"
+          bind:value={vision.capture_interval_s}
+          oninput={markDirty}
+        />
+      </label>
+
+      <label>Max Width
+        <input
+          type="number" min="320" step="1"
+          bind:value={vision.max_resolution[0]}
+          oninput={markDirty}
+        />
+      </label>
+
+      <label>Max Height
+        <input
+          type="number" min="240" step="1"
+          bind:value={vision.max_resolution[1]}
+          oninput={markDirty}
+        />
+      </label>
+
+      <label>Compression Format
+        <select
+          bind:value={vision.compression.format}
+          onchange={markDirty}
+        >
+          <option value="jpeg">JPEG</option>
+          <option value="png">PNG</option>
+          <option value="raw_rgb">Raw RGB</option>
+        </select>
+      </label>
+
+      <label>Quality
+        <input
+          type="range" min="10" max="100" step="1"
+          bind:value={vision.compression.quality}
+          oninput={markDirty}
+        />
+        <span>{vision.compression.quality}</span>
+      </label>
+
+      <button class="test-btn" onclick={previewCapture}>
+        Preview Capture
+      </button>
+    </div>
+  {/if}
+</Card>
+
+<!-- Hearing -->
+<Card label="Hearing">
+  <button
+    class="collapse-toggle"
+    onclick={() => hearingOpen = !hearingOpen}
+  >
+    {hearingOpen ? '▾' : '▸'} Hearing
+  </button>
+  {#if hearingOpen}
+    <div class="form-grid">
+      <label>ASR Engine
+        <select
+          bind:value={hearing.asr.default_engine}
+          onchange={markDirty}
+        >
+          <option value="vosk">Vosk</option>
+          <option value="whisper">Whisper</option>
+        </select>
+      </label>
+
+      <label>Model Path
+        <input
+          type="text"
+          bind:value={hearing.asr.vosk_model_path}
+          oninput={markDirty}
+        />
+      </label>
+
+      <label>VAD Sensitivity
+        <input
+          type="range" min="0" max="1" step="0.05"
+          bind:value={hearing.asr.vad_sensitivity}
+          oninput={markDirty}
+        />
+        <span>{hearing.asr.vad_sensitivity}</span>
+      </label>
+
+      <fieldset>
+        <legend>Wake Phrases</legend>
+        {#each hearing.wake_word.phrases as phrase, i}
+          <div class="phrase-row">
+            <input
+              type="text"
+              value={phrase}
+              oninput={(e: Event) => {
+                hearing.wake_word.phrases[i] =
+                  (e.target as HTMLInputElement).value;
+                dirty = true;
+              }}
+            />
+            <button
+              class="small-btn"
+              onclick={() => removePhrase(i)}
+            >✕</button>
+          </div>
+        {/each}
+        <button class="small-btn" onclick={addPhrase}>
+          + Add phrase
+        </button>
+      </fieldset>
+    </div>
+  {/if}
+</Card>
+
+<!-- Speech -->
+<Card label="Speech">
+  <button
+    class="collapse-toggle"
+    onclick={() => speechOpen = !speechOpen}
+  >
+    {speechOpen ? '▾' : '▸'} Speech
+  </button>
+  {#if speechOpen}
+    <div class="form-grid">
+      <label>TTS Engine
+        <select bind:value={speech.engine} onchange={markDirty}>
+          <option value="piper">Piper</option>
+          <option value="espeak">eSpeak</option>
+        </select>
+      </label>
+
+      <label>Voice Model
+        <input
+          type="text"
+          bind:value={speech.voice_model}
+          oninput={markDirty}
+        />
+      </label>
+
+      <label>Speed
+        <input
+          type="range" min="0.5" max="2.0" step="0.1"
+          bind:value={speech.speaking_rate}
+          oninput={markDirty}
+        />
+        <span>{speech.speaking_rate}</span>
+      </label>
+
+      <label>Volume
+        <input
+          type="range" min="0" max="1" step="0.05"
+          bind:value={speech.volume}
+          oninput={markDirty}
+        />
+        <span>{speech.volume}</span>
+      </label>
+
+      <label>Output Device
+        <input
+          type="text"
+          bind:value={speech.output_device}
+          oninput={markDirty}
+        />
+      </label>
+
+      <button class="test-btn" onclick={testTts}>Test TTS</button>
+    </div>
+  {/if}
+</Card>
+
+<!-- Save -->
+<div class="actions">
+  <button onclick={save} disabled={!dirty || saving}>
+    {saving ? 'Saving…' : 'Save'}
+  </button>
+  {#if statusMsg}
+    <span class="status">{statusMsg}</span>
+  {/if}
+</div>
+
+<style>
+  .form-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  .form-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .form-grid input, .form-grid select {
+    padding: 0.3rem 0.5rem;
+  }
+  .collapse-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    padding: 0;
+    margin-bottom: 0.5rem;
+  }
+  .test-btn {
+    align-self: flex-start;
+    padding: 0.4rem 1rem;
+    margin-top: 0.5rem;
+  }
+  .phrase-row {
+    display: flex;
+    gap: 0.3rem;
+    align-items: center;
+    margin-bottom: 0.3rem;
+  }
+  .phrase-row input { flex: 1; }
+  .small-btn {
+    padding: 0.2rem 0.5rem;
+    font-size: 0.8rem;
+  }
+  fieldset {
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 0.5rem;
+  }
+  legend { font-weight: 600; }
+  .actions {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    margin-top: 1rem;
+  }
+  .actions button { padding: 0.5rem 1.5rem; }
+  .status { font-size: 0.85rem; opacity: 0.8; }
+</style>


### PR DESCRIPTION
Closes #250

## Summary
- Senses panel at `/senses` with three collapsible sections
- **Vision**: capture region, interval, resolution, compression format/quality, Preview Capture button
- **Hearing**: ASR engine (Vosk/Whisper), model path, VAD sensitivity, wake phrases (add/remove)
- **Speech**: TTS engine (Piper/eSpeak), voice model, speed, volume, output device, Test TTS button
- Save persists to `/api/senses` via REST PUT
- 18 tests covering all acceptance criteria

## How to test
```bash
pytest tests/test_senses_panel.py -v
```