### PR TITLE
#253: Chat panel — conversation UI with streaming, context budget, system selector

### DIFF
--- a/tests/test_chat_panel.py
+++ b/tests/test_chat_panel.py
@@ -1,0 +1,104 @@
+"""Tests for SvelteKit Chat panel (#253)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_WUI = Path(__file__).resolve().parent.parent / "wui-svelte"
+PAGE = _WUI / "src" / "routes" / "chat" / "+page.svelte"
+
+
+def _text() -> str:
+    return PAGE.read_text(encoding="utf-8")
+
+
+def test_chat_page_exists():
+    assert PAGE.exists()
+
+
+# -- Message list --
+
+def test_message_bubbles():
+    t = _text()
+    assert "msg.role" in t or "msg role" in t or 'class="msg' in t
+    assert "user" in t
+    assert "assistant" in t
+
+
+def test_message_timestamps():
+    t = _text()
+    assert "timestamp" in t
+
+
+# -- Streaming --
+
+def test_streaming_token_display():
+    t = _text()
+    assert "streaming" in t
+    assert "token" in t
+
+
+def test_sse_data_parsing():
+    t = _text()
+    assert "data: " in t or "data:" in t
+    assert "[DONE]" in t
+
+
+# -- Input --
+
+def test_input_box():
+    t = _text()
+    assert "textarea" in t
+    assert "Send" in t
+
+
+def test_shift_enter_newline():
+    t = _text()
+    assert "shiftKey" in t or "Shift+Enter" in t
+
+
+# -- System selector --
+
+def test_system_selector():
+    t = _text()
+    assert "CHAT" in t
+    assert "REASONING" in t
+    assert "system" in t
+
+
+# -- Context budget --
+
+def test_context_budget_indicator():
+    t = _text()
+    assert "tokensUsed" in t
+    assert "tokensMax" in t
+    assert "budget" in t.lower()
+
+
+# -- Chain of thought --
+
+def test_cot_toggle():
+    t = _text()
+    assert "showCot" in t
+    assert "Chain of Thought" in t
+
+
+def test_reasoning_trace():
+    t = _text()
+    assert "reasoning" in t
+
+
+# -- Scroll behavior --
+
+def test_scroll_to_bottom():
+    t = _text()
+    assert "scrollToBottom" in t
+    assert "autoScroll" in t
+
+
+# -- Responsive --
+
+def test_responsive_layout():
+    t = _text()
+    assert "flex" in t
+    assert "flex-wrap" in t

--- a/wui-svelte/src/routes/chat/+page.svelte
+++ b/wui-svelte/src/routes/chat/+page.svelte
@@ -1,2 +1,329 @@
-<h2>Chat</h2>
-<p>Operator conversation surface.</p>
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { post as apiPost } from '$lib/api/client';
+
+  // ----------------------------------------------------------------
+  // Types
+  // ----------------------------------------------------------------
+
+  interface ChatMessage {
+    role: 'user' | 'assistant';
+    content: string;
+    timestamp: string;
+    reasoning?: string;
+  }
+
+  // ----------------------------------------------------------------
+  // State
+  // ----------------------------------------------------------------
+
+  let messages: ChatMessage[] = $state([]);
+  let inputText = $state('');
+  let system: 'CHAT' | 'REASONING' = $state('CHAT');
+  let showCot = $state(false);
+  let streaming = $state(false);
+  let tokensUsed = $state(0);
+  let tokensMax = $state(8192);
+
+  // Scroll management
+  let chatContainer: HTMLDivElement | undefined = $state();
+  let autoScroll = $state(true);
+
+  function scrollToBottom(): void {
+    if (chatContainer && autoScroll) {
+      chatContainer.scrollTop = chatContainer.scrollHeight;
+    }
+  }
+
+  function onScroll(): void {
+    if (!chatContainer) return;
+    const { scrollTop, scrollHeight, clientHeight } = chatContainer;
+    autoScroll = scrollHeight - scrollTop - clientHeight < 40;
+  }
+
+  // ----------------------------------------------------------------
+  // Send message
+  // ----------------------------------------------------------------
+
+  async function send(): Promise<void> {
+    const text = inputText.trim();
+    if (!text || streaming) return;
+
+    const userMsg: ChatMessage = {
+      role: 'user',
+      content: text,
+      timestamp: new Date().toISOString(),
+    };
+    messages = [...messages, userMsg];
+    inputText = '';
+
+    await tick();
+    scrollToBottom();
+
+    // Placeholder assistant message for streaming
+    const assistantMsg: ChatMessage = {
+      role: 'assistant',
+      content: '',
+      timestamp: new Date().toISOString(),
+    };
+    messages = [...messages, assistantMsg];
+    streaming = true;
+
+    try {
+      const resp = await fetch('/api/chat/stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text, system }),
+      });
+
+      if (!resp.ok) {
+        assistantMsg.content = `Error: ${resp.statusText}`;
+        messages = [...messages.slice(0, -1), assistantMsg];
+        streaming = false;
+        return;
+      }
+
+      const reader = resp.body?.getReader();
+      const decoder = new TextDecoder();
+
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const chunk = decoder.decode(value, { stream: true });
+
+          // Parse SSE data lines
+          for (const line of chunk.split('\n')) {
+            if (!line.startsWith('data: ')) continue;
+            const raw = line.slice(6);
+            if (raw === '[DONE]') break;
+            try {
+              const parsed = JSON.parse(raw);
+              if (parsed.token) {
+                assistantMsg.content += parsed.token;
+              }
+              if (parsed.reasoning) {
+                assistantMsg.reasoning =
+                  (assistantMsg.reasoning ?? '') + parsed.reasoning;
+              }
+              if (parsed.tokens_used !== undefined) {
+                tokensUsed = parsed.tokens_used;
+              }
+              if (parsed.tokens_max !== undefined) {
+                tokensMax = parsed.tokens_max;
+              }
+            } catch {
+              // non-JSON SSE line, ignore
+            }
+          }
+
+          messages = [
+            ...messages.slice(0, -1),
+            { ...assistantMsg },
+          ];
+          await tick();
+          scrollToBottom();
+        }
+      }
+    } catch (e) {
+      assistantMsg.content = `Error: ${e}`;
+      messages = [...messages.slice(0, -1), assistantMsg];
+    } finally {
+      streaming = false;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Init
+  // ----------------------------------------------------------------
+
+  onMount(() => {
+    scrollToBottom();
+  });
+</script>
+
+<div class="chat-layout">
+  <!-- Header bar -->
+  <div class="chat-header">
+    <h2>Chat</h2>
+    <div class="header-controls">
+      <label class="sys-select">
+        System
+        <select bind:value={system}>
+          <option value="CHAT">CHAT</option>
+          <option value="REASONING">REASONING</option>
+        </select>
+      </label>
+      <label class="cot-toggle">
+        <input type="checkbox" bind:checked={showCot} />
+        Chain of Thought
+      </label>
+    </div>
+  </div>
+
+  <!-- Context budget -->
+  <div class="budget-bar">
+    <div
+      class="budget-fill"
+      style="width:{Math.min(tokensUsed / tokensMax * 100, 100)}%"
+    ></div>
+    <span class="budget-label">
+      {tokensUsed} / {tokensMax} tokens
+    </span>
+  </div>
+
+  <!-- Message list -->
+  <div
+    class="messages"
+    bind:this={chatContainer}
+    onscroll={onScroll}
+  >
+    {#each messages as msg}
+      <div class="msg {msg.role}">
+        <div class="bubble">
+          <p class="content">{msg.content}</p>
+          {#if showCot && msg.reasoning}
+            <details class="reasoning">
+              <summary>Reasoning trace</summary>
+              <pre>{msg.reasoning}</pre>
+            </details>
+          {/if}
+          <time class="ts">{msg.timestamp}</time>
+        </div>
+      </div>
+    {/each}
+    {#if streaming}
+      <div class="streaming-indicator">●●●</div>
+    {/if}
+  </div>
+
+  <!-- Input -->
+  <div class="input-area">
+    <textarea
+      bind:value={inputText}
+      placeholder="Type a message… (Shift+Enter for newline)"
+      onkeydown={handleKeydown}
+      rows="2"
+    ></textarea>
+    <button onclick={send} disabled={streaming || !inputText.trim()}>
+      Send
+    </button>
+  </div>
+</div>
+
+<style>
+  .chat-layout {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    max-height: calc(100vh - 4rem);
+  }
+  .chat-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+  .chat-header h2 { margin: 0; }
+  .header-controls {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+  }
+  .sys-select select { margin-left: 0.3rem; }
+  .cot-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+  }
+
+  .budget-bar {
+    position: relative;
+    height: 14px;
+    background: #333;
+    border-radius: 7px;
+    overflow: hidden;
+    margin-bottom: 0.5rem;
+  }
+  .budget-fill {
+    height: 100%;
+    background: #3b82f6;
+    transition: width 0.3s ease;
+  }
+  .budget-label {
+    position: absolute;
+    top: 0;
+    left: 0.5rem;
+    font-size: 0.7rem;
+    line-height: 14px;
+    color: #fff;
+  }
+
+  .messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem 0;
+  }
+  .msg {
+    display: flex;
+    margin-bottom: 0.5rem;
+  }
+  .msg.user { justify-content: flex-end; }
+  .msg.assistant { justify-content: flex-start; }
+  .bubble {
+    max-width: 75%;
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+    word-break: break-word;
+  }
+  .msg.user .bubble { background: #2563eb; color: #fff; }
+  .msg.assistant .bubble { background: #374151; color: #e5e7eb; }
+  .content { margin: 0; white-space: pre-wrap; }
+  .ts {
+    display: block;
+    font-size: 0.65rem;
+    opacity: 0.5;
+    margin-top: 0.25rem;
+  }
+  .reasoning {
+    margin-top: 0.4rem;
+    font-size: 0.8rem;
+  }
+  .reasoning pre {
+    white-space: pre-wrap;
+    opacity: 0.7;
+    margin: 0.25rem 0 0 0;
+  }
+  .streaming-indicator {
+    text-align: center;
+    opacity: 0.5;
+    animation: pulse 1s infinite;
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 0.8; }
+  }
+
+  .input-area {
+    display: flex;
+    gap: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid #444;
+  }
+  .input-area textarea {
+    flex: 1;
+    resize: none;
+    padding: 0.5rem;
+  }
+  .input-area button { padding: 0.5rem 1.5rem; }
+</style>


### PR DESCRIPTION
Closes #253

## Summary
- Chat panel at `/chat` route with full conversation UI
- Message list with user/assistant bubbles and timestamps
- Streaming token display via SSE (`data:` lines with `[DONE]` sentinel)
- Input box with Send button and Shift+Enter for newlines
- System selector dropdown (CHAT, REASONING)
- Context budget indicator bar (tokens used / max)
- Chain-of-thought toggle to show reasoning trace
- Scroll-to-bottom on new messages with manual scroll override
- Responsive layout
- 13 tests validating all acceptance criteria

## How to test
```bash
pytest tests/test_chat_panel.py -v
```