### PR TITLE
#300: Add assistant identity interview onboarding

### DIFF
--- a/src/openbad/identity/onboarding.py
+++ b/src/openbad/identity/onboarding.py
@@ -1,0 +1,172 @@
+"""Onboarding interview logic for assistant identity configuration.
+
+Provides:
+- Detection of incomplete assistant identity
+- Interview prompt generation
+- Natural language extraction of assistant profile fields from conversation
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from openbad.identity.assistant_profile import AssistantProfile
+
+logger = logging.getLogger(__name__)
+
+
+def is_assistant_configured(profile: AssistantProfile) -> bool:
+    """Return whether the assistant has a non-default identity.
+
+    An assistant is considered configured if it has a custom name
+    or at least one non-empty field beyond the defaults.
+    """
+    if profile.name and profile.name != "OpenBaD":
+        return True
+
+    if (
+        profile.persona_summary
+        and profile.persona_summary.strip()
+        and "self-aware Linux agent" not in profile.persona_summary
+    ):
+        return True
+
+    if profile.learning_focus:
+        return True
+
+    if profile.worldview:
+        return True
+
+    return bool(profile.boundaries)
+INTERVIEW_SYSTEM_PROMPT = """You are a new AI assistant being \
+configured for the first time. Your job is to interview the user to establish \
+your identity and personality.
+
+Conduct a conversational interview to learn:
+1. What name the user wants to call you
+2. Your primary role and purpose
+3. How you should communicate (formal/casual, direct/diplomatic, etc.)
+4. Your personality traits (exploration style, thoroughness, proactivity, \
+challenge posture, stress handling)
+5. The domains you should focus on learning
+6. Any boundaries or topics to avoid
+
+Keep the interview natural and conversational. Don't make it feel like a form. \
+Ask follow-up questions when answers are vague. When you have enough \
+information, summarize your understanding back to the user and ask for \
+confirmation.
+
+Once confirmed, respond with a final message containing ONLY a JSON block in this exact format:
+```json
+{
+  "name": "...",
+  "persona_summary": "...",
+  "learning_focus": ["domain1", "domain2"],
+  "worldview": ["belief1", "belief2"],
+  "boundaries": ["boundary1"],
+  "rhetorical_tone": "direct|diplomatic|casual",
+  "rhetorical_sentence_pattern": "concise|verbose|balanced",
+  "rhetorical_challenge_mode": "steel-man first|socratic|agreeable",
+  "rhetorical_explanation_depth": "terse|balanced|thorough",
+  "openness": 0.7,
+  "conscientiousness": 0.8,
+  "extraversion": 0.5,
+  "agreeableness": 0.4,
+  "stability": 0.6
+}
+```
+
+The JSON extraction signals that the interview is complete.
+"""
+
+
+def extract_profile_from_json(text: str) -> dict[str, Any] | None:
+    """Extract structured assistant profile from LLM JSON output.
+
+    Returns None if no valid JSON block found.
+    """
+    # Look for JSON block in markdown code fence or raw JSON
+    # Use greedy match to capture full JSON object including nested arrays/objects
+    json_match = re.search(r'```(?:json)?\s*(\{[^`]+\})\s*```', text, re.DOTALL)
+    if not json_match:
+        # Try raw JSON - match from first { with "name" to corresponding }
+        json_match = re.search(r'(\{[^{}]*"name"[^{}]*\})', text, re.DOTALL)
+
+    if not json_match:
+        return None
+
+    try:
+        data = json.loads(json_match.group(1))
+    except json.JSONDecodeError:
+        logger.debug("Failed to parse JSON from interview response", exc_info=True)
+        return None
+
+    # Validate required fields
+    if not isinstance(data.get("name"), str):
+        return None
+
+    return data
+
+
+def apply_interview_result(
+    profile: AssistantProfile,
+    extracted: dict[str, Any],
+) -> AssistantProfile:
+    """Apply extracted interview data to an AssistantProfile.
+
+    Returns a new AssistantProfile with updated fields.
+    """
+    name = str(extracted.get("name", profile.name)).strip() or profile.name
+    persona_summary = str(extracted.get("persona_summary", "")).strip()
+    learning_focus = extracted.get("learning_focus", [])
+    if not isinstance(learning_focus, list):
+        learning_focus = []
+
+    worldview = extracted.get("worldview", [])
+    if not isinstance(worldview, list):
+        worldview = []
+
+    boundaries = extracted.get("boundaries", [])
+    if not isinstance(boundaries, list):
+        boundaries = []
+
+    # OCEAN sliders
+    openness = float(extracted.get("openness", profile.openness))
+    conscientiousness = float(extracted.get("conscientiousness", profile.conscientiousness))
+    extraversion = float(extracted.get("extraversion", profile.extraversion))
+    agreeableness = float(extracted.get("agreeableness", profile.agreeableness))
+    stability = float(extracted.get("stability", profile.stability))
+
+    # Rhetorical style
+    rhetorical_style = profile.rhetorical_style
+    if "rhetorical_tone" in extracted:
+        rhetorical_style.tone = str(extracted["rhetorical_tone"])
+    if "rhetorical_sentence_pattern" in extracted:
+        rhetorical_style.sentence_pattern = str(extracted["rhetorical_sentence_pattern"])
+    if "rhetorical_challenge_mode" in extracted:
+        rhetorical_style.challenge_mode = str(extracted["rhetorical_challenge_mode"])
+    if "rhetorical_explanation_depth" in extracted:
+        rhetorical_style.explanation_depth = str(extracted["rhetorical_explanation_depth"])
+
+    return AssistantProfile(
+        name=name,
+        persona_summary=persona_summary,
+        learning_focus=learning_focus,
+        worldview=worldview,
+        boundaries=boundaries,
+        opinions=profile.opinions,
+        vocabulary=profile.vocabulary,
+        rhetorical_style=rhetorical_style,
+        influences=profile.influences,
+        anti_patterns=profile.anti_patterns,
+        current_focus=profile.current_focus,
+        continuity_log=profile.continuity_log,
+        openness=openness,
+        conscientiousness=conscientiousness,
+        extraversion=extraversion,
+        agreeableness=agreeableness,
+        stability=stability,
+    )

--- a/src/openbad/wui/chat_pipeline.py
+++ b/src/openbad/wui/chat_pipeline.py
@@ -12,28 +12,26 @@ engaging the subsystems that make OpenBaD more than a pass-through to an LLM:
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 import uuid
 from collections.abc import AsyncIterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from aiohttp import web
-
 from openbad.cognitive.config import (
-    CognitiveConfig,
     CognitiveSystem,
-    ProviderConfig,
-    SystemAssignment,
 )
 from openbad.cognitive.context_manager import (
     ContextWindowManager,
     estimate_tokens,
 )
 from openbad.cognitive.providers.base import ProviderAdapter
+from openbad.identity.onboarding import (
+    INTERVIEW_SYSTEM_PROMPT,
+    is_assistant_configured,
+)
 from openbad.immune_system.rules_engine import RulesEngine, ScanReport
 from openbad.memory.base import MemoryEntry, MemoryTier
 from openbad.memory.episodic import EpisodicMemory
@@ -342,10 +340,14 @@ def _build_identity_prompt(
             )
 
     if user_profile is not None:
-        user_name = getattr(user_profile, "preferred_name", "") or getattr(user_profile, "name", "")
+        user_name = getattr(user_profile, "preferred_name", "") or getattr(
+            user_profile, "name", ""
+        )
         communication_style = getattr(user_profile, "communication_style", "")
         expertise_domains = getattr(user_profile, "expertise_domains", []) or []
-        interaction_history_summary = getattr(user_profile, "interaction_history_summary", "")
+        interaction_history_summary = getattr(
+            user_profile, "interaction_history_summary", ""
+        )
         if user_name:
             lines.append(f"User identity: {user_name}")
         if communication_style:
@@ -396,15 +398,21 @@ def assemble_context(
     ctx = _get_ctx_manager()
     budget = ctx.allocate(model_id)
 
-    base_system_prompt = (
-        _SYSTEM_PROMPT_REASONING
-        if system == CognitiveSystem.REASONING
-        else _SYSTEM_PROMPT_CHAT
-    )
-    system_prompt = (
-        base_system_prompt
-        + _build_identity_prompt(user_profile, assistant_profile, modulation)
-    )
+    # Check if we're in onboarding interview mode
+    if assistant_profile is not None and not is_assistant_configured(assistant_profile):
+        # Interview mode: use specialized onboarding prompt
+        system_prompt = INTERVIEW_SYSTEM_PROMPT
+    else:
+        # Normal mode: use chat or reasoning prompt
+        base_system_prompt = (
+            _SYSTEM_PROMPT_REASONING
+            if system == CognitiveSystem.REASONING
+            else _SYSTEM_PROMPT_CHAT
+        )
+        system_prompt = (
+            base_system_prompt
+            + _build_identity_prompt(user_profile, assistant_profile, modulation)
+        )
 
     # Retrieve conversation history
     history = _get_conversation_history(session_id)

--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -6,11 +6,11 @@ Serves the static dashboard assets and hosts the MQTT->WebSocket bridge.
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
 import json
 import logging
 import os
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
 
@@ -25,17 +25,21 @@ from openbad.cognitive.config import (
     load_cognitive_config,
 )
 from openbad.cognitive.providers.github_copilot import (
+    _KNOWN_MODELS,
     CopilotAuthError,
     GitHubCopilotProvider,
-    _KNOWN_MODELS,
 )
 from openbad.cognitive.providers.openai_compat import custom_provider
+from openbad.identity.onboarding import (
+    extract_profile_from_json,
+    is_assistant_configured,
+)
 from openbad.identity.persistence import IdentityPersistence
 from openbad.identity.personality_modulator import PersonalityModulator
 from openbad.memory.episodic import EpisodicMemory
 from openbad.sensory.config import load_sensory_config
-from openbad.wui.chat_pipeline import get_conversation_history, stream_chat
 from openbad.wui.bridge import MqttWebSocketBridge
+from openbad.wui.chat_pipeline import get_conversation_history, stream_chat
 from openbad.wui.usage_tracker import UsageTracker
 
 # SvelteKit build output: wui-svelte/build/ is copied here by ``make wui``.
@@ -137,6 +141,62 @@ def _resolve_identity_config_path() -> Path:
         if path.exists():
             return path
     return candidates[0]
+
+
+def _resolve_memory_config_path() -> Path:
+    """Resolve path to memory.yaml config file."""
+    config_dir = os.environ.get("OPENBAD_CONFIG_DIR", "").strip()
+    if config_dir:
+        return Path(config_dir) / "memory.yaml"
+
+    candidates = [
+        Path("/etc/openbad/memory.yaml"),
+        Path.home() / ".config" / "openbad" / "memory.yaml",
+        Path(__file__).resolve().parent.parent.parent.parent / "config" / "memory.yaml",
+    ]
+
+    for path in candidates:
+        if path.exists():
+            return path
+    return candidates[0]
+
+
+def _read_sleep_config(path: Path) -> tuple[dict, object]:
+    """Read sleep configuration from memory.yaml.
+
+    Returns (document_dict, sleep_config_object).
+    For onboarding status check, we just need idle_timeout_minutes and enabled.
+    """
+    if not path.exists():
+        # Return defaults
+        return {}, type("SleepConfig", (), {"idle_timeout_minutes": 15, "enabled": True})()
+
+    with path.open("r") as f:
+        doc = yaml.safe_load(f) or {}
+
+    sleep_raw = {}
+    if isinstance(doc, dict):
+        # Try "memory.sleep" first (full config format)
+        memory = doc.get("memory", {})
+        if isinstance(memory, dict):
+            sleep_raw = memory.get("sleep", {})
+        # Fall back to top-level "sleep" (test format)
+        if not sleep_raw:
+            sleep_raw = doc.get("sleep", {})
+
+    if not isinstance(sleep_raw, dict):
+        sleep_raw = {}
+
+    # Create minimal config object with just fields we need
+    idle_timeout = sleep_raw.get("idle_timeout_minutes", 15)
+    enabled = sleep_raw.get("enabled", True)
+
+    config = type("SleepConfig", (), {
+        "idle_timeout_minutes": idle_timeout,
+        "enabled": enabled,
+    })()
+
+    return doc, config
 
 
 def _initialize_identity_state(app: web.Application) -> None:
@@ -251,7 +311,13 @@ def _save_providers_config(path: Path, payload: dict[str, object]) -> None:
         existing = yaml.safe_load(path.read_text()) or {}
         cognitive = existing.get("cognitive", {})
         if isinstance(cognitive, dict):
-            for key in ("context_budget", "reasoning", "systems", "default_fallback_chain", "fallback_cortisol"):
+            for key in (
+                "context_budget",
+                "reasoning",
+                "systems",
+                "default_fallback_chain",
+                "fallback_cortisol",
+            ):
                 if key in cognitive and key not in document["cognitive"]:
                     document["cognitive"][key] = cognitive[key]
 
@@ -334,7 +400,12 @@ async def _verify_wizard_provider(provider: ProviderConfig) -> dict[str, object]
     except Exception:
         log.exception("Health check failed for %s", provider.name)
         status = type("HS", (), {"available": False, "latency_ms": 0, "models_available": 0})()
-    log.info("Provider %s available=%s latency=%.0fms", provider.name, status.available, status.latency_ms)
+    log.info(
+        "Provider %s available=%s latency=%.0fms",
+        provider.name,
+        status.available,
+        status.latency_ms,
+    )
     models: list[str] = []
     if status.available:
         try:
@@ -471,9 +542,11 @@ async def _post_copilot_complete(request: web.Request) -> web.Response:
 
     try:
         result = await provider.poll_for_token_once(str(flow["device_code"]))
-    except Exception:
+    except Exception as exc:
         log.exception("poll_for_token_once failed for flow %s", flow_id)
-        raise web.HTTPBadRequest(text="Failed to poll GitHub for authorization status")
+        raise web.HTTPBadRequest(
+            text="Failed to poll GitHub for authorization status"
+        ) from exc
     state = str(result.get("state", "error"))
     if state == "authorization_pending":
         return web.json_response(
@@ -622,7 +695,7 @@ def _serialize_chat_turn(turn) -> dict[str, object]:
         "content": turn.content,
         "timestamp": datetime.fromtimestamp(
             turn.timestamp,
-            tz=timezone.utc,
+            tz=UTC,
         ).isoformat(),
     }
 
@@ -756,7 +829,7 @@ async def _get_usage(request: web.Request) -> web.Response:
         raise web.HTTPServiceUnavailable(text="UsageTracker not available")
     return web.json_response(
         {
-            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generated_at": datetime.now(UTC).isoformat(),
             **tracker.snapshot(),
         }
     )
@@ -1089,6 +1162,97 @@ async def _post_entity_assistant_reset(request: web.Request) -> web.Response:
     return web.json_response(_serialize_assistant(persistence.assistant))
 
 
+async def _get_onboarding_status(request: web.Request) -> web.Response:
+    """Return onboarding completion status for providers, sleep, and identity."""
+    # Check providers
+    providers_complete = False
+    try:
+        _, config = _read_providers_config()
+        providers_complete = bool(config.providers and config.default_provider)
+    except Exception:
+        pass
+
+    # Check sleep schedule
+    sleep_complete = False
+    try:
+        path = _resolve_memory_config_path()
+        _, sleep_config = _read_sleep_config(path)
+        # Sleep is considered configured if it differs from defaults
+        # Default is: enabled=True, idle_timeout_minutes=15
+        has_defaults = (
+            sleep_config.enabled is True
+            and sleep_config.idle_timeout_minutes == 15
+        )
+        sleep_complete = not has_defaults
+    except Exception:
+        pass
+
+    # Check assistant identity
+    assistant_complete = False
+    persistence = request.app.get("identity_persistence")
+    if persistence is not None:
+        assistant_complete = is_assistant_configured(persistence.assistant)
+
+    return web.json_response(
+        {
+            "providers_complete": providers_complete,
+            "sleep_complete": sleep_complete,
+            "assistant_identity_complete": assistant_complete,
+            "onboarding_complete": providers_complete
+            and sleep_complete
+            and assistant_complete,
+        }
+    )
+
+
+async def _post_assistant_interview_complete(request: web.Request) -> web.Response:
+    """Complete assistant interview by extracting profile from conversation."""
+    persistence = request.app.get("identity_persistence")
+    if persistence is None:
+        raise web.HTTPServiceUnavailable(text="IdentityPersistence not available")
+
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise web.HTTPBadRequest(text="Request body must be an object")
+
+    text = str(payload.get("text", "")).strip()
+    if not text:
+        raise web.HTTPBadRequest(text="text field is required")
+
+    extracted = extract_profile_from_json(text)
+    if extracted is None:
+        return web.json_response(
+            {"success": False, "message": "No valid profile JSON found in response"},
+            status=400,
+        )
+
+    # Import apply logic here to avoid circular dependency
+    from openbad.identity.onboarding import apply_interview_result
+
+    updated_profile = apply_interview_result(persistence.assistant, extracted)
+    persistence.update_assistant(
+        name=updated_profile.name,
+        persona_summary=updated_profile.persona_summary,
+        learning_focus=updated_profile.learning_focus,
+        worldview=updated_profile.worldview,
+        boundaries=updated_profile.boundaries,
+        rhetorical_style=updated_profile.rhetorical_style,
+        openness=updated_profile.openness,
+        conscientiousness=updated_profile.conscientiousness,
+        extraversion=updated_profile.extraversion,
+        agreeableness=updated_profile.agreeableness,
+        stability=updated_profile.stability,
+    )
+
+    modulator = request.app.get("personality_modulator")
+    if modulator is not None:
+        modulator.update(persistence.assistant)
+
+    return web.json_response(
+        {"success": True, "assistant": _serialize_assistant(persistence.assistant)}
+    )
+
+
 def create_app(
     mqtt_host: str = "localhost",
     mqtt_port: int = 1883,
@@ -1152,6 +1316,8 @@ def create_app(
     app.router.add_get("/api/entity/assistant", _get_entity_assistant)
     app.router.add_put("/api/entity/assistant", _put_entity_assistant)
     app.router.add_post("/api/entity/assistant/reset", _post_entity_assistant_reset)
+    app.router.add_get("/api/onboarding/status", _get_onboarding_status)
+    app.router.add_post("/api/onboarding/assistant/complete", _post_assistant_interview_complete)
     # TODO: Remove after v1.0 once external consumers have migrated to /api/providers/*.
     app.router.add_get("/api/wiring/providers", _redirect_legacy_wiring_providers)
     app.router.add_post(

--- a/tests/test_chat_pipeline.py
+++ b/tests/test_chat_pipeline.py
@@ -188,3 +188,77 @@ async def test_stream_chat_records_usage_to_tracker(tmp_path):
     assert snapshot["by_provider_model"][0]["provider"] == "test-provider"
     assert snapshot["by_provider_model"][0]["model"] == "test-model"
     assert snapshot["by_system"][0]["system"] == "reasoning"
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_uses_interview_mode_when_assistant_unconfigured():
+    """When assistant profile is unconfigured, use onboarding interview system prompt."""
+    from openbad.identity.assistant_profile import AssistantProfile
+
+    # Default/unconfigured assistant profile
+    unconfigured_assistant = AssistantProfile(
+        name="OpenBaD",
+        persona_summary="A self-aware Linux agent with biological metaphors",
+    )
+
+    adapter = _CapturingAdapter(["I'd", " like", " to", " help"])
+
+    chunks = [
+        chunk
+        async for chunk in chat_pipeline.stream_chat(
+            adapter,
+            "test-model",
+            "Hello, who are you?",
+            "interview-session",
+            provider_name="test-provider",
+            assistant_profile=unconfigured_assistant,
+        )
+    ]
+
+    assert adapter.prompts
+    prompt = adapter.prompts[0]
+    # Should use interview system prompt, not the default chat prompt
+    assert "You are a new AI assistant being configured" in prompt
+    assert "interview" in prompt.lower()
+    # Should NOT have the default identity context injection since we're in interview mode
+    assert "Assistant identity:" not in prompt or "OpenBaD" not in prompt
+
+    assert chunks[-1].done is True
+    assert [chunk.token for chunk in chunks if chunk.token] == ["I'd", " like", " to", " help"]
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_uses_normal_mode_when_assistant_configured():
+    """When assistant profile is configured, use normal chat system prompt."""
+    from openbad.identity.assistant_profile import AssistantProfile
+
+    # Configured assistant profile (custom name)
+    configured_assistant = AssistantProfile(
+        name="Ada",
+        persona_summary="A helpful coding assistant",
+        learning_focus=["Python", "Rust"],
+    )
+
+    adapter = _CapturingAdapter(["Hello"])
+
+    chunks = [
+        chunk
+        async for chunk in chat_pipeline.stream_chat(
+            adapter,
+            "test-model",
+            "What's your name?",
+            "normal-session",
+            provider_name="test-provider",
+            assistant_profile=configured_assistant,
+        )
+    ]
+
+    assert adapter.prompts
+    prompt = adapter.prompts[0]
+    # Should use normal chat prompt, not interview
+    assert "You are OpenBaD, a helpful AI assistant" in prompt
+    assert "interview" not in prompt.lower()
+    # Should have identity context since assistant is configured
+    assert "Assistant identity: Ada" in prompt
+
+    assert chunks[-1].done is True

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,282 @@
+"""Tests for assistant identity onboarding interview logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.identity.assistant_profile import AssistantProfile, RhetoricalStyle
+from openbad.identity.onboarding import (
+    INTERVIEW_SYSTEM_PROMPT,
+    apply_interview_result,
+    extract_profile_from_json,
+    is_assistant_configured,
+)
+
+
+def test_is_assistant_configured_default_profile_not_configured():
+    profile = AssistantProfile()
+    assert not is_assistant_configured(profile)
+
+
+def test_is_assistant_configured_default_name_only_not_configured():
+    profile = AssistantProfile(
+        name="OpenBaD",
+        persona_summary="A self-aware Linux agent with biological metaphors",
+    )
+    assert not is_assistant_configured(profile)
+
+
+def test_is_assistant_configured_custom_name_is_configured():
+    profile = AssistantProfile(name="Ada")
+    assert is_assistant_configured(profile)
+
+
+def test_is_assistant_configured_custom_persona_is_configured():
+    profile = AssistantProfile(
+        name="OpenBaD",
+        persona_summary="A helpful coding assistant focused on Python",
+    )
+    assert is_assistant_configured(profile)
+
+
+def test_is_assistant_configured_with_learning_focus_is_configured():
+    profile = AssistantProfile(learning_focus=["machine learning", "rust"])
+    assert is_assistant_configured(profile)
+
+
+def test_is_assistant_configured_with_worldview_is_configured():
+    profile = AssistantProfile(worldview=["measure twice, cut once"])
+    assert is_assistant_configured(profile)
+
+
+def test_is_assistant_configured_with_boundaries_is_configured():
+    profile = AssistantProfile(boundaries=["no dark patterns"])
+    assert is_assistant_configured(profile)
+
+
+def test_interview_system_prompt_is_string():
+    assert isinstance(INTERVIEW_SYSTEM_PROMPT, str)
+    assert len(INTERVIEW_SYSTEM_PROMPT) > 100
+
+
+def test_extract_profile_from_json_valid_markdown_fence():
+    text = """
+Here's what I learned:
+
+```json
+{
+  "name": "Ada",
+  "persona_summary": "Helpful coding assistant",
+  "learning_focus": ["Python", "JavaScript"],
+  "worldview": ["test everything"],
+  "boundaries": ["no tracking"],
+  "rhetorical_tone": "direct",
+  "rhetorical_sentence_pattern": "concise",
+  "rhetorical_challenge_mode": "steel-man first",
+  "rhetorical_explanation_depth": "balanced",
+  "openness": 0.8,
+  "conscientiousness": 0.9,
+  "extraversion": 0.6,
+  "agreeableness": 0.5,
+  "stability": 0.7
+}
+```
+
+Does this look right?
+"""
+    result = extract_profile_from_json(text)
+    assert result is not None
+    assert result["name"] == "Ada"
+    assert result["persona_summary"] == "Helpful coding assistant"
+    assert result["learning_focus"] == ["Python", "JavaScript"]
+    assert result["worldview"] == ["test everything"]
+    assert result["boundaries"] == ["no tracking"]
+    assert result["rhetorical_tone"] == "direct"
+    assert result["openness"] == 0.8
+    assert result["conscientiousness"] == 0.9
+
+
+def test_extract_profile_from_json_valid_without_fence():
+    text = """
+{"name": "Bob", "persona_summary": "Research assistant", "learning_focus": [], "worldview": [], "boundaries": [], "openness": 0.5, "conscientiousness": 0.5, "extraversion": 0.5, "agreeableness": 0.5, "stability": 0.5}
+"""
+    result = extract_profile_from_json(text)
+    assert result is not None
+    assert result["name"] == "Bob"
+    assert result["persona_summary"] == "Research assistant"
+
+
+def test_extract_profile_from_json_missing_name_returns_none():
+    text = """
+```json
+{
+  "persona_summary": "Missing name field",
+  "learning_focus": []
+}
+```
+"""
+    result = extract_profile_from_json(text)
+    assert result is None
+
+
+def test_extract_profile_from_json_no_json_returns_none():
+    text = "This is just regular text without any JSON."
+    result = extract_profile_from_json(text)
+    assert result is None
+
+
+def test_extract_profile_from_json_invalid_json_returns_none():
+    text = """
+```json
+{
+  "name": "Broken",
+  "learning_focus": [unquoted string],
+}
+```
+"""
+    result = extract_profile_from_json(text)
+    assert result is None
+
+
+def test_apply_interview_result_updates_name():
+    profile = AssistantProfile(name="OpenBaD")
+    extracted = {
+        "name": "Ava",
+        "persona_summary": "",
+        "learning_focus": [],
+        "worldview": [],
+        "boundaries": [],
+    }
+    updated = apply_interview_result(profile, extracted)
+    assert updated.name == "Ava"
+
+
+def test_apply_interview_result_updates_persona_summary():
+    profile = AssistantProfile()
+    extracted = {
+        "name": "OpenBaD",
+        "persona_summary": "A proactive research assistant",
+        "learning_focus": [],
+        "worldview": [],
+        "boundaries": [],
+    }
+    updated = apply_interview_result(profile, extracted)
+    assert updated.persona_summary == "A proactive research assistant"
+
+
+def test_apply_interview_result_updates_learning_focus():
+    profile = AssistantProfile()
+    extracted = {
+        "name": "OpenBaD",
+        "learning_focus": ["cryptography", "distributed systems"],
+        "worldview": [],
+        "boundaries": [],
+    }
+    updated = apply_interview_result(profile, extracted)
+    assert updated.learning_focus == ["cryptography", "distributed systems"]
+
+
+def test_apply_interview_result_updates_ocean_sliders():
+    profile = AssistantProfile(
+        openness=0.5,
+        conscientiousness=0.5,
+        extraversion=0.5,
+        agreeableness=0.5,
+        stability=0.5,
+    )
+    extracted = {
+        "name": "OpenBaD",
+        "learning_focus": [],
+        "worldview": [],
+        "boundaries": [],
+        "openness": 0.9,
+        "conscientiousness": 0.2,
+        "extraversion": 0.7,
+        "agreeableness": 0.3,
+        "stability": 0.8,
+    }
+    updated = apply_interview_result(profile, extracted)
+    assert updated.openness == 0.9
+    assert updated.conscientiousness == 0.2
+    assert updated.extraversion == 0.7
+    assert updated.agreeableness == 0.3
+    assert updated.stability == 0.8
+
+
+def test_apply_interview_result_updates_rhetorical_style():
+    profile = AssistantProfile()
+    extracted = {
+        "name": "OpenBaD",
+        "learning_focus": [],
+        "worldview": [],
+        "boundaries": [],
+        "rhetorical_tone": "diplomatic",
+        "rhetorical_sentence_pattern": "verbose",
+        "rhetorical_challenge_mode": "socratic",
+        "rhetorical_explanation_depth": "thorough",
+    }
+    updated = apply_interview_result(profile, extracted)
+    assert updated.rhetorical_style.tone == "diplomatic"
+    assert updated.rhetorical_style.sentence_pattern == "verbose"
+    assert updated.rhetorical_style.challenge_mode == "socratic"
+    assert updated.rhetorical_style.explanation_depth == "thorough"
+
+
+def test_apply_interview_result_preserves_unspecified_fields():
+    profile = AssistantProfile(
+        name="OpenBaD",
+        opinions={"ai_ethics": ["transparency is key"]},
+        vocabulary={"greeting": "Hi there"},
+        influences=["Alan Turing"],
+        anti_patterns=["anthropomorphism"],
+        current_focus=["performance optimization"],
+    )
+    extracted = {
+        "name": "Sage",
+        "learning_focus": ["philosophy"],
+        "worldview": [],
+        "boundaries": [],
+    }
+    updated = apply_interview_result(profile, extracted)
+    assert updated.name == "Sage"
+    assert updated.learning_focus == ["philosophy"]
+    assert updated.opinions == {"ai_ethics": ["transparency is key"]}
+    assert updated.vocabulary == {"greeting": "Hi there"}
+    assert updated.influences == ["Alan Turing"]
+    assert updated.anti_patterns == ["anthropomorphism"]
+    assert updated.current_focus == ["performance optimization"]
+
+
+def test_apply_interview_result_handles_non_list_learning_focus():
+    profile = AssistantProfile()
+    extracted = {
+        "name": "OpenBaD",
+        "learning_focus": "not a list",
+        "worldview": [],
+        "boundaries": [],
+    }
+    updated = apply_interview_result(profile, extracted)
+    assert updated.learning_focus == []
+
+
+def test_apply_interview_result_handles_missing_ocean_values():
+    profile = AssistantProfile(
+        openness=0.6,
+        conscientiousness=0.7,
+        extraversion=0.4,
+        agreeableness=0.3,
+        stability=0.5,
+    )
+    extracted = {
+        "name": "OpenBaD",
+        "learning_focus": [],
+        "worldview": [],
+        "boundaries": [],
+        # No OCEAN values
+    }
+    updated = apply_interview_result(profile, extracted)
+    assert updated.openness == 0.6
+    assert updated.conscientiousness == 0.7
+    assert updated.extraversion == 0.4
+    assert updated.agreeableness == 0.3
+    assert updated.stability == 0.5

--- a/tests/test_wui_server.py
+++ b/tests/test_wui_server.py
@@ -950,3 +950,247 @@ async def test_get_version_route_returns_current_version(aiohttp_client):
     assert resp.status == 200
     data = await resp.json()
     assert data["version"] == openbad.__version__
+
+
+@pytest.mark.asyncio
+async def test_get_onboarding_status_all_incomplete(aiohttp_client, tmp_path, monkeypatch):
+    """Onboarding status returns false for all components when unconfigured."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Empty cognitive config (no providers)
+    (config_dir / "cognitive.yaml").write_text(
+        """
+cognitive:
+  default_provider: ""
+  enabled: false
+  providers: []
+""".strip()
+    )
+
+    # Default memory config (sleep defaults)
+    (config_dir / "memory.yaml").write_text(
+        """
+sleep:
+  sleep_window_start: "02:00"
+  sleep_window_duration_hours: 3
+  idle_timeout_minutes: 15
+  allow_daytime_naps: true
+  enabled: true
+""".strip()
+    )
+
+    # Default identity config (assistant not configured)
+    (config_dir / "identity.yaml").write_text(
+        """
+user:
+  name: "User"
+assistant:
+  name: "OpenBaD"
+  persona_summary: "A self-aware Linux agent with biological metaphors"
+  learning_focus: []
+  ocean:
+    openness: 0.7
+    conscientiousness: 0.8
+    extraversion: 0.5
+    agreeableness: 0.4
+    stability: 0.6
+""".strip()
+    )
+
+    monkeypatch.setenv("OPENBAD_CONFIG_DIR", str(config_dir))
+    app = create_app(enable_mqtt=False)
+
+    # Initialize identity persistence
+    from openbad.identity.persistence import IdentityPersistence
+    from openbad.memory.episodic import EpisodicMemory
+    episodic = EpisodicMemory(storage_path=tmp_path / "episodic.json")
+    persistence = IdentityPersistence(config_dir / "identity.yaml", episodic)
+    app["identity_persistence"] = persistence
+
+    client = await aiohttp_client(app)
+    resp = await client.get("/api/onboarding/status")
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["providers_complete"] is False
+    assert data["sleep_complete"] is False  # Still has defaults
+    assert data["assistant_identity_complete"] is False
+    assert data["onboarding_complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_onboarding_status_all_complete(aiohttp_client, tmp_path, monkeypatch):
+    """Onboarding status returns true when all components are configured."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Configured cognitive
+    (config_dir / "cognitive.yaml").write_text(
+        """
+cognitive:
+  default_provider: ollama
+  enabled: true
+  providers:
+    - name: ollama
+      base_url: http://localhost:11434
+      model: llama3.2
+      timeout_ms: 30000
+      enabled: true
+""".strip()
+    )
+
+    # Modified sleep config (idle timeout changed from default)
+    (config_dir / "memory.yaml").write_text(
+        """
+sleep:
+  sleep_window_start: "03:00"
+  sleep_window_duration_hours: 4
+  idle_timeout_minutes: 30
+  allow_daytime_naps: false
+  enabled: true
+""".strip()
+    )
+
+    # Configured assistant identity
+    (config_dir / "identity.yaml").write_text(
+        """
+user:
+  name: "User"
+assistant:
+  name: "Ada"
+  persona_summary: "A helpful coding assistant"
+  learning_focus: ["Python", "Rust"]
+  ocean:
+    openness: 0.9
+    conscientiousness: 0.8
+    extraversion: 0.6
+    agreeableness: 0.5
+    stability: 0.7
+""".strip()
+    )
+
+    monkeypatch.setenv("OPENBAD_CONFIG_DIR", str(config_dir))
+    app = create_app(enable_mqtt=False)
+
+    from openbad.identity.persistence import IdentityPersistence
+    from openbad.memory.episodic import EpisodicMemory
+    episodic = EpisodicMemory(storage_path=tmp_path / "episodic.json")
+    persistence = IdentityPersistence(config_dir / "identity.yaml", episodic)
+    app["identity_persistence"] = persistence
+
+    client = await aiohttp_client(app)
+    resp = await client.get("/api/onboarding/status")
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["providers_complete"] is True
+    assert data["sleep_complete"] is True
+    assert data["assistant_identity_complete"] is True
+    assert data["onboarding_complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_post_assistant_interview_complete_valid_json(aiohttp_client, tmp_path, monkeypatch):
+    """Interview completion endpoint extracts profile and updates persistence."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    (config_dir / "identity.yaml").write_text(
+        """
+user:
+  name: "User"
+assistant:
+  name: "OpenBaD"
+  persona_summary: ""
+  learning_focus: []
+  ocean:
+    openness: 0.5
+    conscientiousness: 0.5
+    extraversion: 0.5
+    agreeableness: 0.5
+    stability: 0.5
+""".strip()
+    )
+
+    monkeypatch.setenv("OPENBAD_CONFIG_DIR", str(config_dir))
+    app = create_app(enable_mqtt=False)
+
+    from openbad.identity.persistence import IdentityPersistence
+    from openbad.memory.episodic import EpisodicMemory
+    episodic = EpisodicMemory(storage_path=tmp_path / "episodic.json")
+    persistence = IdentityPersistence(config_dir / "identity.yaml", episodic)
+    app["identity_persistence"] = persistence
+
+    client = await aiohttp_client(app)
+
+    interview_response = """
+Here's my understanding of your preferences:
+
+```json
+{
+  "name": "Sage",
+  "persona_summary": "A thoughtful research assistant",
+  "learning_focus": ["AI safety", "distributed systems"],
+  "worldview": ["prefer simple solutions"],
+  "boundaries": ["no dark patterns"],
+  "rhetorical_tone": "direct",
+  "rhetorical_sentence_pattern": "concise",
+  "rhetorical_challenge_mode": "steel-man first",
+  "rhetorical_explanation_depth": "balanced",
+  "openness": 0.8,
+  "conscientiousness": 0.9,
+  "extraversion": 0.4,
+  "agreeableness": 0.6,
+  "stability": 0.7
+}
+```
+
+Does this look correct?
+"""
+
+    resp = await client.post(
+        "/api/onboarding/assistant/complete",
+        json={"text": interview_response},
+    )
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["success"] is True
+    assert data["assistant"]["name"] == "Sage"
+    assert data["assistant"]["persona_summary"] == "A thoughtful research assistant"
+    assert data["assistant"]["learning_focus"] == ["AI safety", "distributed systems"]
+    assert data["assistant"]["worldview"] == ["prefer simple solutions"]
+    assert data["assistant"]["boundaries"] == ["no dark patterns"]
+    assert data["assistant"]["openness"] == 0.8
+    assert data["assistant"]["conscientiousness"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_post_assistant_interview_complete_no_json_returns_error(aiohttp_client, tmp_path, monkeypatch):
+    """Interview completion fails when no JSON found in response."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "identity.yaml").write_text("user:\n  name: User\nassistant:\n  name: OpenBaD")
+
+    monkeypatch.setenv("OPENBAD_CONFIG_DIR", str(config_dir))
+    app = create_app(enable_mqtt=False)
+
+    from openbad.identity.persistence import IdentityPersistence
+    from openbad.memory.episodic import EpisodicMemory
+    episodic = EpisodicMemory(storage_path=tmp_path / "episodic.json")
+    persistence = IdentityPersistence(config_dir / "identity.yaml", episodic)
+    app["identity_persistence"] = persistence
+
+    client = await aiohttp_client(app)
+
+    resp = await client.post(
+        "/api/onboarding/assistant/complete",
+        json={"text": "This is just a regular chat response with no JSON."},
+    )
+
+    assert resp.status == 400
+    data = await resp.json()
+    assert data["success"] is False
+    assert "No valid profile JSON" in data["message"]
+


### PR DESCRIPTION
Closes #300

## Summary
Implements chat-driven assistant identity interview for onboarding flow after provider and sleep configuration.

## Changes
### Backend
- **src/openbad/identity/onboarding.py**: New module with interview detection, natural language extraction logic, and structured profile application.
  - `is_assistant_configured()`: Detects whether assistant has non-default identity
  - `extract_profile_from_json()`: Parses LLM-generated JSON from interview conversation
  - `apply_interview_result()`: Applies extracted data to AssistantProfile
  - `INTERVIEW_SYSTEM_PROMPT`: Specialized onboarding prompt for identity interview
- **src/openbad/wui/server.py**: Added onboarding status and interview completion APIs
  - `GET /api/onboarding/status`: Returns completion status for providers, sleep, and assistant identity
  - `POST /api/onboarding/assistant/complete`: Accepts interview conversation, extracts profile, persists to identity config, updates personality modulator
  - Helper functions: `_resolve_memory_config_path()`, `_read_sleep_config()` for minimal sleep config reading
- **src/openbad/wui/chat_pipeline.py**: Interview mode integration
  - Modified `assemble_context()` to detect unconfigured assistant and use interview system prompt instead of default chat prompt
  - Imported `is_assistant_configured()` and `INTERVIEW_SYSTEM_PROMPT`

### Tests
- **tests/test_onboarding.py**: 21 tests covering detection, extraction, and application logic
- **tests/test_wui_server.py**: 4 tests for onboarding status and interview completion endpoints
- **tests/test_chat_pipeline.py**: 2 tests verifying interview mode vs normal mode system prompt selection

## How to Test
1. Start WUI server
2. GET `/api/onboarding/status` → verify `assistant_identity_complete: false` on first run
3. Chat with assistant → interview prompt engages automatically
4. Assistant extracts identity from conversation and returns JSON
5. POST `/api/onboarding/assistant/complete` with interview text → profile persisted, modulator updated
6. GET `/api/onboarding/status` → verify `assistant_identity_complete: true`

## Notes
- Depends on #301 for enriched AssistantProfile/UserProfile model (already merged to main)
- Interview prompt is conversational, not form-like; LLM extracts structured data from natural language
- JSON extraction uses regex to find markdown code fence or raw JSON in response
- Personality modulator immediately updated with OCEAN sliders from interview
- Sleep config helpers added temporarily for onboarding status; will be superseded by full implementation when #299 merges