### PR TITLE
#304: FSM activation from WUI chat and idle timeout

### DIFF
--- a/config/fsm.yaml
+++ b/config/fsm.yaml
@@ -1,0 +1,11 @@
+# FSM (Finite State Machine) Configuration
+
+# Chat activity idle timeout
+# When no COGNITIVE_INPUT events received for this duration,
+# transition from ACTIVE → IDLE automatically
+idle_timeout_seconds: 300  # 5 minutes
+
+# Debounce window for activate events
+# Prevents redundant activate triggers when multiple messages
+# arrive in quick succession
+debounce_window_seconds: 2

--- a/src/openbad/reflex_arc/chat_activator.py
+++ b/src/openbad/reflex_arc/chat_activator.py
@@ -1,0 +1,199 @@
+"""Chat activity FSM activator.
+
+Subscribes to COGNITIVE_INPUT events from the nervous system and triggers
+FSM activation when user chat activity is detected. Manages idle timeout
+to transition back to IDLE when user stops interacting.
+
+Design
+------
+- On COGNITIVE_INPUT → trigger activate if FSM is in IDLE or SLEEP
+- On idle timeout (configurable) → trigger deactivate (ACTIVE → IDLE)
+- Debounce rapid messages to prevent spam activations
+- Respect EMERGENCY state (do not override)
+- THROTTLED → ACTIVE transition allowed (user takes priority)
+
+Integration
+-----------
+- Subscribe to topics.COGNITIVE_INPUT
+- Read current FSM state from topics.REFLEX_STATE
+- Call fsm.fire("activate") or fsm.fire("deactivate") directly
+- Not a daemon subprocess — instantiated by main daemon or tests
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from openbad.nervous_system.client import NervousSystemClient
+    from openbad.reflex_arc.fsm import AgentFSM
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_IDLE_TIMEOUT = 300  # 5 minutes
+DEFAULT_DEBOUNCE_WINDOW = 2  # 2 seconds
+
+
+def load_config(config_path: Path | None = None) -> dict[str, int]:
+    """Load FSM config from yaml, return dict with idle_timeout and debounce_window."""
+    if config_path is None:
+        # Try system path first, then fallback to local config
+        config_path = Path("/etc/openbad/fsm.yaml")
+        try:
+            if not config_path.exists():
+                config_path = Path(__file__).parents[3] / "config" / "fsm.yaml"
+        except (PermissionError, OSError):
+            # Can't access /etc/openbad, use local config
+            config_path = Path(__file__).parents[3] / "config" / "fsm.yaml"
+
+    try:
+        if not config_path.exists():
+            logger.warning("FSM config not found at %s, using defaults", config_path)
+            return {
+                "idle_timeout_seconds": DEFAULT_IDLE_TIMEOUT,
+                "debounce_window_seconds": DEFAULT_DEBOUNCE_WINDOW,
+            }
+    except (PermissionError, OSError):
+        logger.warning("Cannot access FSM config at %s, using defaults", config_path)
+        return {
+            "idle_timeout_seconds": DEFAULT_IDLE_TIMEOUT,
+            "debounce_window_seconds": DEFAULT_DEBOUNCE_WINDOW,
+        }
+
+    with config_path.open("r") as f:
+        data = yaml.safe_load(f) or {}
+
+    return {
+        "idle_timeout_seconds": data.get("idle_timeout_seconds", DEFAULT_IDLE_TIMEOUT),
+        "debounce_window_seconds": data.get(
+            "debounce_window_seconds", DEFAULT_DEBOUNCE_WINDOW
+        ),
+    }
+
+
+class ChatActivator:
+    """Monitors COGNITIVE_INPUT events and activates FSM on chat activity."""
+
+    def __init__(
+        self,
+        fsm: AgentFSM,
+        client: NervousSystemClient,
+        config_path: Path | None = None,
+    ) -> None:
+        self.fsm = fsm
+        self.client = client
+        self._config = load_config(config_path)
+        self._idle_timeout = self._config["idle_timeout_seconds"]
+        self._debounce_window = self._config["debounce_window_seconds"]
+
+        self._last_activity: float = 0.0
+        self._last_activate: float = 0.0
+        self._idle_timer: threading.Timer | None = None
+        self._lock = threading.Lock()
+        self._running = False
+
+    def start(self) -> None:
+        """Start subscribing to COGNITIVE_INPUT events."""
+        from openbad.nervous_system import topics
+
+        self._running = True
+        self.client.subscribe(topics.COGNITIVE_INPUT, self._on_cognitive_input)
+        logger.info("ChatActivator started (idle_timeout=%ds)", self._idle_timeout)
+
+    def stop(self) -> None:
+        """Stop monitoring and cancel any pending timers."""
+        self._running = False
+        with self._lock:
+            if self._idle_timer is not None:
+                self._idle_timer.cancel()
+                self._idle_timer = None
+        logger.info("ChatActivator stopped")
+
+    def _on_cognitive_input(self, topic: str, payload: bytes) -> None:
+        """Handle COGNITIVE_INPUT event: activate FSM and reset idle timer."""
+        if not self._running:
+            return
+
+        # Parse JSON payload for timestamp (optional)
+        try:
+            data = json.loads(payload.decode())
+            logger.debug("COGNITIVE_INPUT: %s", data.get("source", "unknown"))
+        except Exception:
+            logger.debug("COGNITIVE_INPUT: received raw payload")
+
+        now = time.time()
+        with self._lock:
+            self._last_activity = now
+
+            # Debounce: skip activation if within debounce window
+            if (now - self._last_activate) < self._debounce_window:
+                logger.debug("ChatActivator: debounce skip")
+                self._reset_idle_timer()
+                return
+
+            # Check FSM state before activating
+            current_state = getattr(self.fsm, "state", "UNKNOWN")
+
+            # EMERGENCY: never override
+            if current_state == "EMERGENCY":
+                logger.debug("ChatActivator: FSM in EMERGENCY, skip activate")
+                return
+
+            # ACTIVE: already active, just reset timer
+            if current_state == "ACTIVE":
+                logger.debug("ChatActivator: already ACTIVE, reset timer")
+                self._reset_idle_timer()
+                return
+
+            # IDLE, SLEEP, THROTTLED → activate
+            if current_state in ("IDLE", "SLEEP", "THROTTLED"):
+                success = self.fsm.fire("activate")
+                if success:
+                    logger.info("ChatActivator: activated FSM from %s", current_state)
+                    self._last_activate = now
+                else:
+                    logger.warning(
+                        "ChatActivator: failed to activate from %s", current_state
+                    )
+
+            # Reset idle timer regardless
+            self._reset_idle_timer()
+
+    def _reset_idle_timer(self) -> None:
+        """Reset the idle timeout timer (cancel old, start new)."""
+        # Cancel existing timer
+        if self._idle_timer is not None:
+            self._idle_timer.cancel()
+
+        # Start new timer
+        self._idle_timer = threading.Timer(self._idle_timeout, self._on_idle_timeout)
+        self._idle_timer.daemon = True
+        self._idle_timer.start()
+
+    def _on_idle_timeout(self) -> None:
+        """Called when idle timeout expires: deactivate FSM if ACTIVE."""
+        if not self._running:
+            return
+
+        with self._lock:
+            current_state = getattr(self.fsm, "state", "UNKNOWN")
+
+            # Only deactivate if currently ACTIVE
+            if current_state == "ACTIVE":
+                success = self.fsm.fire("deactivate")
+                if success:
+                    logger.info("ChatActivator: idle timeout, deactivated FSM")
+                else:
+                    logger.warning("ChatActivator: failed to deactivate from ACTIVE")
+            else:
+                logger.debug(
+                    "ChatActivator: idle timeout but FSM not ACTIVE (state=%s)",
+                    current_state,
+                )

--- a/tests/test_chat_activator.py
+++ b/tests/test_chat_activator.py
@@ -1,0 +1,353 @@
+"""Tests for chat activator FSM integration."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+from openbad.nervous_system import topics
+from openbad.reflex_arc.chat_activator import ChatActivator, load_config
+
+if TYPE_CHECKING:
+    pass
+
+
+# ------------------------------------------------------------------ #
+# Config loading
+# ------------------------------------------------------------------ #
+
+
+def test_load_config_defaults() -> None:
+    """When config file doesn't exist, should return defaults."""
+    cfg = load_config(Path("/nonexistent/fsm.yaml"))
+    assert cfg["idle_timeout_seconds"] == 300  # 5 minutes
+    assert cfg["debounce_window_seconds"] == 2  # 2 seconds
+
+
+def test_load_config_from_file(tmp_path: Path) -> None:
+    """When config file exists, should load values."""
+    config_file = tmp_path / "fsm.yaml"
+    config_file.write_text("idle_timeout_seconds: 60\ndebounce_window_seconds: 5\n")
+
+    cfg = load_config(config_file)
+    assert cfg["idle_timeout_seconds"] == 60
+    assert cfg["debounce_window_seconds"] == 5
+
+
+# ------------------------------------------------------------------ #
+# FSM activation
+# ------------------------------------------------------------------ #
+
+
+def test_activates_from_idle_on_input() -> None:
+    """When COGNITIVE_INPUT received and FSM is IDLE, should activate."""
+    mock_fsm = Mock()
+    mock_fsm.state = "IDLE"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client)
+    activator.start()
+
+    # Simulate COGNITIVE_INPUT
+    payload = json.dumps({"source": "wui", "timestamp": time.time()}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    # Should call fire("activate")
+    mock_fsm.fire.assert_called_with("activate")
+
+
+def test_activates_from_sleep_on_input() -> None:
+    """When COGNITIVE_INPUT received and FSM is SLEEP, should activate."""
+    mock_fsm = Mock()
+    mock_fsm.state = "SLEEP"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client)
+    activator.start()
+
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    mock_fsm.fire.assert_called_with("activate")
+
+
+def test_activates_from_throttled_on_input() -> None:
+    """When COGNITIVE_INPUT received and FSM is THROTTLED, should activate."""
+    mock_fsm = Mock()
+    mock_fsm.state = "THROTTLED"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client)
+    activator.start()
+
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    mock_fsm.fire.assert_called_with("activate")
+
+
+def test_does_not_activate_when_already_active() -> None:
+    """When COGNITIVE_INPUT received and FSM is already ACTIVE, should not call fire."""
+    mock_fsm = Mock()
+    mock_fsm.state = "ACTIVE"
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client)
+    activator.start()
+
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    # Should NOT call fire when already active
+    mock_fsm.fire.assert_not_called()
+
+
+def test_does_not_activate_in_emergency() -> None:
+    """When FSM is in EMERGENCY state, chat input should not override."""
+    mock_fsm = Mock()
+    mock_fsm.state = "EMERGENCY"
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client)
+    activator.start()
+
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    # Should not call fire in emergency
+    mock_fsm.fire.assert_not_called()
+
+
+# ------------------------------------------------------------------ #
+# Debouncing
+# ------------------------------------------------------------------ #
+
+
+def test_debounces_rapid_messages(tmp_path: Path) -> None:
+    """When multiple messages arrive within debounce window, should only activate once."""
+    # Use short debounce window for test
+    config_file = tmp_path / "fsm.yaml"
+    config_file.write_text("idle_timeout_seconds: 300\ndebounce_window_seconds: 1\n")
+
+    mock_fsm = Mock()
+    mock_fsm.state = "IDLE"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client, config_path=config_file)
+    activator.start()
+
+    # Send 3 messages in quick succession
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    # Should only activate once (first call)
+    assert mock_fsm.fire.call_count == 1
+
+
+def test_allows_activation_after_debounce_window(tmp_path: Path) -> None:
+    """When messages arrive outside debounce window, both should trigger."""
+    # Use very short debounce for test speed
+    config_file = tmp_path / "fsm.yaml"
+    config_file.write_text("idle_timeout_seconds: 300\ndebounce_window_seconds: 0.1\n")
+
+    mock_fsm = Mock()
+    mock_fsm.state = "IDLE"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client, config_path=config_file)
+    activator.start()
+
+    # First message
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+    assert mock_fsm.fire.call_count == 1
+
+    # Wait for debounce window to expire
+    time.sleep(0.15)
+
+    # Reset FSM to IDLE for second activation
+    mock_fsm.state = "IDLE"
+
+    # Second message (outside debounce window)
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+    assert mock_fsm.fire.call_count == 2
+
+
+# ------------------------------------------------------------------ #
+# Idle timeout
+# ------------------------------------------------------------------ #
+
+
+def test_deactivates_after_idle_timeout(tmp_path: Path) -> None:
+    """When no input for idle_timeout, should deactivate FSM from ACTIVE."""
+    # Use very short timeout for test speed
+    config_file = tmp_path / "fsm.yaml"
+    config_file.write_text("idle_timeout_seconds: 0.2\ndebounce_window_seconds: 0.1\n")
+
+    mock_fsm = Mock()
+    mock_fsm.state = "IDLE"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client, config_path=config_file)
+    activator.start()
+
+    # Activate via input
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    # FSM transitions to ACTIVE
+    mock_fsm.state = "ACTIVE"
+
+    # Wait for idle timeout to expire
+    time.sleep(0.3)
+
+    # Should have called fire("deactivate")
+    assert any(
+        call[0][0] == "deactivate" for call in mock_fsm.fire.call_args_list
+    ), "Should call deactivate after idle timeout"
+
+
+def test_idle_timeout_resets_on_new_input(tmp_path: Path) -> None:
+    """When new input arrives, idle timer should reset."""
+    # Use short timeout
+    config_file = tmp_path / "fsm.yaml"
+    config_file.write_text("idle_timeout_seconds: 0.3\ndebounce_window_seconds: 0.1\n")
+
+    mock_fsm = Mock()
+    mock_fsm.state = "IDLE"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client, config_path=config_file)
+    activator.start()
+
+    # First input
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+    mock_fsm.state = "ACTIVE"
+
+    # Wait half the timeout
+    time.sleep(0.15)
+
+    # Second input (resets timer)
+    # Need to be outside debounce window
+    time.sleep(0.1)
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    # Wait another half timeout
+    time.sleep(0.15)
+
+    # Should NOT have deactivated yet (timer was reset)
+    # Only the first "activate" call should have happened
+    deactivate_calls = [
+        call for call in mock_fsm.fire.call_args_list if call[0][0] == "deactivate"
+    ]
+    assert len(deactivate_calls) == 0, "Should not deactivate if timer was reset"
+
+
+def test_does_not_deactivate_if_not_active(tmp_path: Path) -> None:
+    """When idle timeout fires but FSM not ACTIVE, should not call deactivate."""
+    config_file = tmp_path / "fsm.yaml"
+    config_file.write_text("idle_timeout_seconds: 0.1\ndebounce_window_seconds: 0.05\n")
+
+    mock_fsm = Mock()
+    mock_fsm.state = "IDLE"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client, config_path=config_file)
+    activator.start()
+
+    # Trigger input to start timer
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    # But FSM stays in IDLE (activation failed or state changed)
+    mock_fsm.state = "IDLE"
+
+    # Wait for timeout
+    time.sleep(0.2)
+
+    # Should not call deactivate when not ACTIVE
+    deactivate_calls = [
+        call for call in mock_fsm.fire.call_args_list if call[0][0] == "deactivate"
+    ]
+    assert len(deactivate_calls) == 0
+
+
+# ------------------------------------------------------------------ #
+# Start/stop
+# ------------------------------------------------------------------ #
+
+
+def test_stop_cancels_idle_timer(tmp_path: Path) -> None:
+    """When activator is stopped, should cancel pending idle timer."""
+    config_file = tmp_path / "fsm.yaml"
+    config_file.write_text("idle_timeout_seconds: 0.3\ndebounce_window_seconds: 0.1\n")
+
+    mock_fsm = Mock()
+    mock_fsm.state = "IDLE"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client, config_path=config_file)
+    activator.start()
+
+    # Trigger input to start timer
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+    mock_fsm.state = "ACTIVE"
+
+    # Stop activator before timeout
+    activator.stop()
+
+    # Wait for what would have been the timeout
+    time.sleep(0.4)
+
+    # Should not have called deactivate (timer was cancelled)
+    deactivate_calls = [
+        call for call in mock_fsm.fire.call_args_list if call[0][0] == "deactivate"
+    ]
+    assert len(deactivate_calls) == 0
+
+
+def test_ignores_events_after_stop() -> None:
+    """After stop, should not process COGNITIVE_INPUT events."""
+    mock_fsm = Mock()
+    mock_fsm.state = "IDLE"
+    mock_fsm.fire.return_value = True
+
+    mock_client = Mock()
+
+    activator = ChatActivator(mock_fsm, mock_client)
+    activator.start()
+    activator.stop()
+
+    # Send event after stop
+    payload = json.dumps({"source": "wui"}).encode()
+    activator._on_cognitive_input(topics.COGNITIVE_INPUT, payload)
+
+    # Should not call fire after stopped
+    mock_fsm.fire.assert_not_called()


### PR DESCRIPTION
Closes #304

## Summary
Implements FSM activation from WUI chat activity via nervous system events. Chat interactions now drive FSM state transitions, and idle timeouts automatically deactivate when user stops interacting.

## Changes

### Configuration (`config/fsm.yaml`)
- `idle_timeout_seconds: 300` - Default 5 minute idle timeout before ACTIVE → IDLE
- `debounce_window_seconds: 2` - Prevents redundant activation on rapid messages

### Chat Activator (`src/openbad/reflex_arc/chat_activator.py`)
- Subscribe to `COGNITIVE_INPUT` events from nervous system (#303)
- On event: trigger `fsm.fire("activate")` if in IDLE, SLEEP, or THROTTLED
- Respects EMERGENCY state (no override)
- Already ACTIVE: just reset idle timer
- Idle timeout: After configured duration, calls `fsm.fire("deactivate")`
- Debouncing: Prevents spam activations on rapid messages
- Config loading: Graceful fallback to defaults on permission errors

### Tests (`tests/test_chat_activator.py`)
- **Config loading**: Defaults, file-based config
- **Activation**: From IDLE, SLEEP, THROTTLED states
- **No-ops**: Already ACTIVE, EMERGENCY state
- **Debouncing**: Rapid messages, debounce window expiry
- **Idle timeout**: Deactivation after timeout, timer reset on new input, skip if not ACTIVE
- **Lifecycle**: Stop cancels timer, ignores events after stop
- **14 tests pass in 1.64s**

## Integration

The ChatActivator is designed to be instantiated by the main daemon alongside the FSM:

```python
fsm = AgentFSM(client=nervous_system_client)
activator = ChatActivator(fsm, nervous_system_client)
activator.start()
```

## Testing

```bash
pytest tests/test_chat_activator.py -v
```

## Notes

- Depends on #303 COGNITIVE_INPUT events
- FSM state transitions publish to `agent/reflex/state` (already implemented)
- Endocrine system and sleep scheduler already subscribe to FSM state changes
- WUI dashboard can now display real-time FSM state reflecting chat activity
