### PR TITLE
#324: Add SQLite task state schema and migration runner

### DIFF
--- a/10-OpenBaD Built-In Capabilities Spec.md
+++ b/10-OpenBaD Built-In Capabilities Spec.md
@@ -1,0 +1,82 @@
+Here is the detailed, discrete technical specification for integrating the Level 1 and Level 2 built-in skills into the OpenBaD heartbeat architecture. This spec targets the current state of your src/openbad/ directory and aligns with the separation of the autonomic daemon.py process and the interactive wui/server.py process.
+
+# ---
+
+**Specification: OpenBaD Built-In Capabilities (Phase 9+ Tools)**
+
+## **1\. Level 1: File System Operations (read\_file, write\_file)**
+
+**Objective:** Provide in-process, trusted file manipulation governed by the immune system and disk I/O interoception.
+
+* \[ \] **Task 1.1: Create FS Tool Module**  
+  * Create src/openbad/toolbelt/fs\_tool.py.  
+  * Implement read\_file(path) and write\_file(path, content) functions.  
+* \[ \] **Task 1.2: Immune System Gating**  
+  * Update src/openbad/immune\_system/rules\_engine.py to include a FileOperationRule.  
+  * Define restricted path patterns (e.g., /etc/, \~/.ssh/, system binaries). If write\_file attempts to target these, trigger src/openbad/immune\_system/interceptor.py to block the action and flag the payload.  
+* \[ \] **Task 1.3: Endocrine Throttling Integration**  
+  * In fs\_tool.py, import interoception.disk\_network.  
+  * Before executing a large read/write, check disk I/O metrics. If the baseline is saturated (high Cortisol state), yield the TaskNode lease back to the heartbeat scheduler with a DEFERRED\_RESOURCES status.
+
+## **2\. Level 1: Command Line Execution (exec\_command)**
+
+**Objective:** Allow shell execution within strict quarantine boundaries.
+
+* \[ \] **Task 2.1: Refactor cli\_tool.py for Asynchronous Task DAG**  
+  * Modify src/openbad/toolbelt/cli\_tool.py to ensure it does not run blocking subprocess.run calls directly in the main thread. It must use asyncio.create\_subprocess\_shell yielding back to the daemon.py event loop.  
+* \[ \] **Task 2.2: The Quarantine Gate**  
+  * Hook cli\_tool.py execution into src/openbad/immune\_system/rules\_engine.py.  
+  * If a destructive signature (e.g., rm \-rf, mkfs, chmod \-R 777 /) is detected, do not execute.  
+  * Update the SQLite task DAG state to QUARANTINED and use nervous\_system/client.py to publish an alert to agent/immune/alert for the WUI to display.
+
+## **3\. Level 1: Web Information (web\_search, web\_fetch)**
+
+**Objective:** Fast, stateless external data gathering for Active Inference to reduce surprise.
+
+* \[ \] **Task 3.1: Expand Web Search Module**  
+  * Open src/openbad/toolbelt/web\_search.py. Ensure both a web\_search(query) and a web\_fetch(url) function exist (fetching raw HTML/Markdown of a single page).  
+* \[ \] **Task 3.2: Research Queue Escalation Bridge**  
+  * Wrap web\_fetch execution in a try/except block.  
+  * If the fetch returns a 404, 403, or times out, catch the exception.  
+  * Instead of failing the node, program the worker to suspend the current TaskNode and push a ResearchNode onto src/openbad/active\_inference/insight\_queue.py to investigate the broken link/concept autonomously.
+
+## **4\. Dual-Mode Communication (ask\_user)**
+
+**Objective:** A context-aware tool that behaves synchronously during active chat, but asynchronously via MQTT when the user is disconnected.
+
+* \[ \] **Task 4.1: Track WUI Presence**  
+  * Modify src/openbad/wui/bridge.py and server.py to manage a UserSession singleton.  
+  * Set UserSession.is\_active \= True when a WebSocket is connected, and track the timestamp of the last inbound message from chat\_pipeline.py.  
+  * Expose this presence state to the MQTT broker (e.g., topic system/wui/presence).  
+* \[ \] **Task 4.2: Implement ask\_user.py**  
+  * Create src/openbad/toolbelt/ask\_user.py.  
+  * **Mode A (Active):** If presence is True, publish question to agent/chat/response and await a reply from agent/chat/inbound with a short timeout.  
+  * **Mode B (Inactive):** If presence is False, update the SQLite TaskNode status to BLOCKED\_ON\_USER. Publish the payload to agent/escalation. Yield the lease immediately so daemon.py can move to the next task.  
+* \[ \] **Task 4.3: Re-Engagement Hook in WUI**  
+  * Modify src/openbad/reflex\_arc/chat\_activator.py.  
+  * On a new WebSocket connection (user login), query the SQLite database for any TaskNode in the BLOCKED\_ON\_USER state.  
+  * Push these pending questions to the WUI chat feed *before* the standard greeting. Once answered, publish to agent/chat/inbound to unblock the daemon.
+
+## **5\. Level 2: Isolated MCP Bridge (browser & External SaaS)**
+
+**Objective:** Keep heavy/complex tools out of the ambient context window and load them only when specifically requested by a task node.
+
+* \[ \] **Task 5.1: Create the MCP Execution Sandbox**  
+  * Create a new directory: src/openbad/toolbelt/mcp\_bridge/.  
+  * Implement an mcp\_runner.py that can dynamically load an MCP server schema (e.g., standard Playwright browser or GitHub).  
+* \[ \] **Task 5.2: Scope Browser Context**  
+  * Wrap the existing CDP DOM logic (src/openbad/sensory/vision/cdp\_dom.py) into this transient bridge.  
+  * Ensure the browser session spins up *only* when daemon.py executes a TaskNode explicitly tagged for the browser capability, and tears down completely when the task node finishes.  
+* \[ \] **Task 5.3: Interoceptive Governor**  
+  * Before launching the isolated MCP bridge, query src/openbad/interoception/monitor.py for RAM and Thermal states.  
+  * If system limits are breached, refuse the tool execution, defer the task, and trigger the Adrenaline hook (if the task priority is CRITICAL) or the Cortisol hook (to force hibernation/cooldown).
+
+## **6\. Autonomic Memory Migration**
+
+**Objective:** Remove explicit "Memory Search" tool overhead to save tokens and mimic biological reflex.
+
+* \[ \] **Task 6.1: Deprecate Explicit Memory Tool**  
+  * Remove memory\_search schemas from the default tool registry passed to the LLM in src/openbad/cognitive/model\_router.py.  
+* \[ \] **Task 6.2: Ensure Autonomic Context Injection**  
+  * Verify src/openbad/cognitive/event\_loop.py handles context enrichment.  
+  * Before sending a prompt payload to model\_router.py, the event loop must natively query src/openbad/memory/semantic.py (and Muninn graph if connected) using the prompt's intent vector, automatically prepending the relevant facts to the context window behind the scenes.

--- a/src/openbad/state/__init__.py
+++ b/src/openbad/state/__init__.py
@@ -1,0 +1,5 @@
+"""SQLite-backed state layer for task and scheduler subsystems."""
+
+from openbad.state.db import StateDatabase, initialize_state_db
+
+__all__ = ["StateDatabase", "initialize_state_db"]

--- a/src/openbad/state/db.py
+++ b/src/openbad/state/db.py
@@ -1,0 +1,98 @@
+"""SQLite state database initialization and migration runner."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_STATE_DB_PATH = Path("data/state.db")
+_MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
+
+
+@dataclass(frozen=True)
+class Migration:
+    name: str
+    path: Path
+
+
+def _discover_migrations() -> list[Migration]:
+    migrations: list[Migration] = []
+    for path in sorted(_MIGRATIONS_DIR.glob("*.sql")):
+        migrations.append(Migration(name=path.stem, path=path))
+    return migrations
+
+
+def _create_migration_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            name TEXT PRIMARY KEY,
+            applied_at REAL NOT NULL DEFAULT (unixepoch('now'))
+        )
+        """
+    )
+
+
+def _applied_migrations(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT name FROM schema_migrations").fetchall()
+    return {str(row[0]) for row in rows}
+
+
+def _apply_migration(conn: sqlite3.Connection, migration: Migration) -> None:
+    sql = migration.path.read_text()
+    try:
+        conn.executescript(sql)
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (name) VALUES (?)",
+            (migration.name,),
+        )
+    except sqlite3.DatabaseError as exc:
+        raise RuntimeError(
+            f"Failed applying migration {migration.name} from {migration.path}: {exc}"
+        ) from exc
+
+
+def initialize_state_db(db_path: str | Path = DEFAULT_STATE_DB_PATH) -> sqlite3.Connection:
+    """Create or open the state DB and apply pending migrations."""
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+
+    try:
+        _create_migration_table(conn)
+        applied = _applied_migrations(conn)
+        for migration in _discover_migrations():
+            if migration.name in applied:
+                continue
+            _apply_migration(conn, migration)
+            applied.add(migration.name)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+
+    return conn
+
+
+class StateDatabase:
+    """Thin lifecycle wrapper around the SQLite state database connection."""
+
+    def __init__(self, db_path: str | Path = DEFAULT_STATE_DB_PATH) -> None:
+        self._db_path = Path(db_path)
+        self._conn = initialize_state_db(self._db_path)
+
+    @property
+    def db_path(self) -> Path:
+        return self._db_path
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return self._conn
+
+    def close(self) -> None:
+        self._conn.close()

--- a/src/openbad/state/migrations/0001_initial.sql
+++ b/src/openbad/state/migrations/0001_initial.sql
@@ -1,0 +1,191 @@
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id TEXT PRIMARY KEY,
+    title TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
+    kind TEXT NOT NULL DEFAULT 'user_requested',
+    horizon TEXT NOT NULL DEFAULT 'short',
+    priority INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'pending',
+    due_at REAL,
+    parent_task_id TEXT,
+    root_task_id TEXT NOT NULL DEFAULT '',
+    owner TEXT NOT NULL DEFAULT 'system',
+    lease_owner TEXT,
+    recurrence_rule TEXT,
+    requires_context INTEGER NOT NULL DEFAULT 0,
+    isolated_execution INTEGER NOT NULL DEFAULT 0,
+    notes_path TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_nodes (
+    node_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    node_type TEXT NOT NULL DEFAULT 'reason',
+    status TEXT NOT NULL DEFAULT 'pending',
+    capability_requirements TEXT NOT NULL DEFAULT '[]',
+    model_requirements TEXT NOT NULL DEFAULT '[]',
+    reward_program_id TEXT,
+    expected_info_gain REAL NOT NULL DEFAULT 0.0,
+    blockage_score REAL NOT NULL DEFAULT 0.0,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    max_retries INTEGER NOT NULL DEFAULT 0,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    FOREIGN KEY(task_id) REFERENCES tasks(task_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS task_edges (
+    task_id TEXT NOT NULL,
+    from_node_id TEXT NOT NULL,
+    to_node_id TEXT NOT NULL,
+    PRIMARY KEY (task_id, from_node_id, to_node_id),
+    FOREIGN KEY(task_id) REFERENCES tasks(task_id) ON DELETE CASCADE,
+    FOREIGN KEY(from_node_id) REFERENCES task_nodes(node_id) ON DELETE CASCADE,
+    FOREIGN KEY(to_node_id) REFERENCES task_nodes(node_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS task_runs (
+    run_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    node_id TEXT,
+    status TEXT NOT NULL DEFAULT 'running',
+    actor TEXT NOT NULL DEFAULT 'system',
+    routing_provider TEXT,
+    routing_model TEXT,
+    started_at REAL NOT NULL,
+    finished_at REAL,
+    FOREIGN KEY(task_id) REFERENCES tasks(task_id) ON DELETE CASCADE,
+    FOREIGN KEY(node_id) REFERENCES task_nodes(node_id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_events (
+    event_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    node_id TEXT,
+    event_type TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    FOREIGN KEY(task_id) REFERENCES tasks(task_id) ON DELETE CASCADE,
+    FOREIGN KEY(node_id) REFERENCES task_nodes(node_id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_notes (
+    note_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    note_text TEXT NOT NULL,
+    summary_json TEXT,
+    FOREIGN KEY(task_id) REFERENCES tasks(task_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS task_leases (
+    lease_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    resource_id TEXT NOT NULL,
+    leased_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS heartbeat_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    last_heartbeat_at REAL,
+    last_triage_at REAL,
+    last_context_required_dispatch_at REAL,
+    last_research_review_at REAL,
+    last_sleep_cycle_at REAL,
+    last_maintenance_at REAL,
+    silent_skip_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS research_nodes (
+    research_id TEXT PRIMARY KEY,
+    source_task_id TEXT NOT NULL,
+    source_node_id TEXT,
+    trigger_reason TEXT NOT NULL DEFAULT '',
+    blockage_score REAL NOT NULL DEFAULT 0.0,
+    expected_info_gain REAL NOT NULL DEFAULT 0.0,
+    urgency_score REAL NOT NULL DEFAULT 0.0,
+    priority_score REAL NOT NULL DEFAULT 0.0,
+    status TEXT NOT NULL DEFAULT 'pending',
+    findings_summary TEXT,
+    artifact_path TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    FOREIGN KEY(source_task_id) REFERENCES tasks(task_id) ON DELETE CASCADE,
+    FOREIGN KEY(source_node_id) REFERENCES task_nodes(node_id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS research_findings (
+    finding_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    research_id TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    summary TEXT NOT NULL,
+    artifact_path TEXT,
+    payload_json TEXT,
+    FOREIGN KEY(research_id) REFERENCES research_nodes(research_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS reward_programs (
+    program_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    version TEXT NOT NULL,
+    rules_json TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mcp_audit (
+    audit_id TEXT PRIMARY KEY,
+    task_id TEXT,
+    run_id TEXT,
+    tool_name TEXT NOT NULL,
+    server_name TEXT NOT NULL,
+    started_at REAL NOT NULL,
+    finished_at REAL,
+    status TEXT NOT NULL,
+    input_summary TEXT,
+    output_summary TEXT,
+    error_summary TEXT,
+    FOREIGN KEY(task_id) REFERENCES tasks(task_id) ON DELETE SET NULL,
+    FOREIGN KEY(run_id) REFERENCES task_runs(run_id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS scheduler_windows (
+    window_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    window_type TEXT NOT NULL,
+    start_at REAL NOT NULL,
+    end_at REAL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    metadata_json TEXT,
+    last_run_at REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status_due_at
+    ON tasks (status, due_at);
+CREATE INDEX IF NOT EXISTS idx_task_nodes_task_status
+    ON task_nodes (task_id, status);
+CREATE INDEX IF NOT EXISTS idx_task_edges_task_from
+    ON task_edges (task_id, from_node_id);
+CREATE INDEX IF NOT EXISTS idx_task_edges_task_to
+    ON task_edges (task_id, to_node_id);
+CREATE INDEX IF NOT EXISTS idx_task_runs_task_started_at
+    ON task_runs (task_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_task_events_task_created_at
+    ON task_events (task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_task_events_node_created_at
+    ON task_events (node_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_task_leases_owner_expires_at
+    ON task_leases (owner_id, expires_at);
+CREATE INDEX IF NOT EXISTS idx_task_leases_resource
+    ON task_leases (resource_type, resource_id);
+CREATE INDEX IF NOT EXISTS idx_research_nodes_status_priority
+    ON research_nodes (status, priority_score, created_at);
+CREATE INDEX IF NOT EXISTS idx_mcp_audit_task_started_at
+    ON mcp_audit (task_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_scheduler_windows_type_start_at
+    ON scheduler_windows (window_type, start_at);

--- a/tests/test_state_db.py
+++ b/tests/test_state_db.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from openbad.state.db import StateDatabase, initialize_state_db
+
+REQUIRED_TABLES = {
+    "schema_migrations",
+    "tasks",
+    "task_nodes",
+    "task_edges",
+    "task_runs",
+    "task_events",
+    "task_notes",
+    "task_leases",
+    "heartbeat_state",
+    "research_nodes",
+    "research_findings",
+    "reward_programs",
+    "mcp_audit",
+    "scheduler_windows",
+}
+
+REQUIRED_INDEXES = {
+    "idx_tasks_status_due_at",
+    "idx_task_nodes_task_status",
+    "idx_task_edges_task_from",
+    "idx_task_edges_task_to",
+    "idx_task_runs_task_started_at",
+    "idx_task_events_task_created_at",
+    "idx_task_events_node_created_at",
+    "idx_task_leases_owner_expires_at",
+    "idx_task_leases_resource",
+    "idx_research_nodes_status_priority",
+    "idx_mcp_audit_task_started_at",
+    "idx_scheduler_windows_type_start_at",
+}
+
+
+def _sqlite_objects(conn: sqlite3.Connection, object_type: str) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = ?",
+        (object_type,),
+    ).fetchall()
+    return {str(row[0]) for row in rows}
+
+
+def test_initialize_state_db_creates_schema(tmp_path: Path) -> None:
+    db_path = tmp_path / "state" / "state.db"
+
+    conn = initialize_state_db(db_path)
+    conn.close()
+
+    assert db_path.exists()
+
+    verify = sqlite3.connect(str(db_path))
+    tables = _sqlite_objects(verify, "table")
+    indexes = _sqlite_objects(verify, "index")
+    verify.close()
+
+    assert REQUIRED_TABLES.issubset(tables)
+    assert REQUIRED_INDEXES.issubset(indexes)
+
+
+def test_initialize_state_db_is_idempotent(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+
+    first = initialize_state_db(db_path)
+    second = initialize_state_db(db_path)
+
+    migration_count = second.execute(
+        "SELECT COUNT(*) FROM schema_migrations"
+    ).fetchone()[0]
+
+    first.close()
+    second.close()
+
+    assert migration_count == 1
+
+
+def test_state_database_wrapper_initializes_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "db" / "state.db"
+
+    db = StateDatabase(db_path)
+    tables = _sqlite_objects(db.connection, "table")
+    db.close()
+
+    assert "tasks" in tables
+    assert db_path.exists()


### PR DESCRIPTION
Closes #324

## Summary
- add new state package with SQLite initialization and migration runner
- add first migration creating task, research, scheduler, lease, reward, and MCP audit tables plus indexes
- add tests for fresh schema creation, idempotent reruns, and required schema objects

## How to test
- ruff check src/openbad/state tests/test_state_db.py
- pytest tests/test_state_db.py -q