### PR TITLE
#335: Task DB bootstrap and connection factory

### DIFF
--- a/src/openbad/state/db.py
+++ b/src/openbad/state/db.py
@@ -60,6 +60,7 @@ def initialize_state_db(db_path: str | Path = DEFAULT_STATE_DB_PATH) -> sqlite3.
 
     conn = sqlite3.connect(str(path))
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA foreign_keys = ON")
 
     try:

--- a/tests/test_state_db.py
+++ b/tests/test_state_db.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from openbad.state.db import StateDatabase, initialize_state_db
+from openbad.state.db import DEFAULT_STATE_DB_PATH, StateDatabase, initialize_state_db
 
 REQUIRED_TABLES = {
     "schema_migrations",
@@ -88,3 +88,28 @@ def test_state_database_wrapper_initializes_db(tmp_path: Path) -> None:
 
     assert "tasks" in tables
     assert db_path.exists()
+
+
+def test_default_db_path_is_configurable() -> None:
+    assert Path("data/state.db") == DEFAULT_STATE_DB_PATH
+
+
+def test_custom_db_path_resolution(tmp_path: Path) -> None:
+    custom_path = tmp_path / "custom" / "nested" / "my.db"
+    conn = initialize_state_db(custom_path)
+    conn.close()
+
+    assert custom_path.exists()
+    assert custom_path.parent.is_dir()
+
+
+def test_connection_pragmas_applied(tmp_path: Path) -> None:
+    db_path = tmp_path / "pragma_test.db"
+    conn = initialize_state_db(db_path)
+
+    journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    fk_enabled = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    conn.close()
+
+    assert journal_mode == "wal"
+    assert fk_enabled == 1


### PR DESCRIPTION
Closes #335

## Summary
- Added `PRAGMA journal_mode = WAL` to `initialize_state_db` alongside the existing `foreign_keys = ON` pragma
- Added three new unit tests:
  - `test_default_db_path_is_configurable`: verifies `DEFAULT_STATE_DB_PATH == Path('data/state.db')`
  - `test_custom_db_path_resolution`: verifies deeply-nested custom path is created on open
  - `test_connection_pragmas_applied`: verifies WAL journal mode and FK enforcement are active

## How to test
```
pytest tests/test_state_db.py -q   # 6 passed
```