### PR TITLE
#336: Initial task-state migration SQL (tables + indexes)

### DIFF
--- a/tests/test_state_db.py
+++ b/tests/test_state_db.py
@@ -113,3 +113,16 @@ def test_connection_pragmas_applied(tmp_path: Path) -> None:
 
     assert journal_mode == "wal"
     assert fk_enabled == 1
+
+
+def test_migration_schema_version_is_persisted(tmp_path: Path) -> None:
+    db_path = tmp_path / "version_test.db"
+    conn = initialize_state_db(db_path)
+
+    applied = {
+        row[0]
+        for row in conn.execute("SELECT name FROM schema_migrations").fetchall()
+    }
+    conn.close()
+
+    assert "0001_initial" in applied


### PR DESCRIPTION
Closes #336

## Summary
The migration SQL (`0001_initial.sql`) was already created as part of #324 with all required tables (tasks, task_nodes, task_edges, task_runs, task_events, task_notes, task_leases, heartbeat_state, research_nodes, research_findings, reward_programs, mcp_audit, scheduler_windows) and indexes.

This PR adds the explicit AC-matching test `test_migration_schema_version_is_persisted` that verifies the migration name `0001_initial` is recorded in `schema_migrations` after first run.

Existing tests already cover table and index existence checks.

## How to test
```
pytest tests/test_state_db.py -q   # 7 passed
```