### PR TITLE
#337: Migration runner idempotency and failure handling

### DIFF
--- a/src/openbad/state/db.py
+++ b/src/openbad/state/db.py
@@ -16,9 +16,9 @@ class Migration:
     path: Path
 
 
-def _discover_migrations() -> list[Migration]:
+def _discover_migrations(migrations_dir: Path = _MIGRATIONS_DIR) -> list[Migration]:
     migrations: list[Migration] = []
-    for path in sorted(_MIGRATIONS_DIR.glob("*.sql")):
+    for path in sorted(migrations_dir.glob("*.sql")):
         migrations.append(Migration(name=path.stem, path=path))
     return migrations
 
@@ -53,7 +53,11 @@ def _apply_migration(conn: sqlite3.Connection, migration: Migration) -> None:
         ) from exc
 
 
-def initialize_state_db(db_path: str | Path = DEFAULT_STATE_DB_PATH) -> sqlite3.Connection:
+def initialize_state_db(
+    db_path: str | Path = DEFAULT_STATE_DB_PATH,
+    *,
+    migrations_dir: Path | None = None,
+) -> sqlite3.Connection:
     """Create or open the state DB and apply pending migrations."""
     path = Path(db_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -63,10 +67,12 @@ def initialize_state_db(db_path: str | Path = DEFAULT_STATE_DB_PATH) -> sqlite3.
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA foreign_keys = ON")
 
+    effective_dir = migrations_dir if migrations_dir is not None else _MIGRATIONS_DIR
+
     try:
         _create_migration_table(conn)
         applied = _applied_migrations(conn)
-        for migration in _discover_migrations():
+        for migration in _discover_migrations(effective_dir):
             if migration.name in applied:
                 continue
             _apply_migration(conn, migration)

--- a/tests/test_state_db.py
+++ b/tests/test_state_db.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from openbad.state.db import DEFAULT_STATE_DB_PATH, StateDatabase, initialize_state_db
 
 REQUIRED_TABLES = {
@@ -126,3 +128,70 @@ def test_migration_schema_version_is_persisted(tmp_path: Path) -> None:
     conn.close()
 
     assert "0001_initial" in applied
+
+
+# ---------------------------------------------------------------------------
+# Issue #337: migration runner idempotency, failure handling, ordering
+# ---------------------------------------------------------------------------
+
+
+def test_migration_runner_ordered_application(tmp_path: Path) -> None:
+    mig_dir = tmp_path / "migrations"
+    mig_dir.mkdir()
+    (mig_dir / "0001_first.sql").write_text(
+        "CREATE TABLE first_table (id INTEGER PRIMARY KEY);"
+    )
+    (mig_dir / "0002_second.sql").write_text(
+        "CREATE TABLE second_table (id INTEGER PRIMARY KEY);"
+    )
+
+    db_path = tmp_path / "ordered.db"
+    conn = initialize_state_db(db_path, migrations_dir=mig_dir)
+
+    applied = [
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM schema_migrations ORDER BY applied_at ASC"
+        ).fetchall()
+    ]
+    conn.close()
+
+    assert applied == ["0001_first", "0002_second"]
+
+
+def test_migration_runner_failure_includes_identifier(tmp_path: Path) -> None:
+    mig_dir = tmp_path / "migrations"
+    mig_dir.mkdir()
+    (mig_dir / "0001_bad.sql").write_text("NOT VALID SQL !!!")
+
+    db_path = tmp_path / "fail.db"
+
+    with pytest.raises(RuntimeError, match="0001_bad"):
+        initialize_state_db(db_path, migrations_dir=mig_dir)
+
+
+def test_migration_runner_failure_leaves_no_partial_state(tmp_path: Path) -> None:
+    mig_dir = tmp_path / "migrations"
+    mig_dir.mkdir()
+    (mig_dir / "0001_good.sql").write_text(
+        "CREATE TABLE good_table (id INTEGER PRIMARY KEY);"
+    )
+    (mig_dir / "0002_bad.sql").write_text("NOT VALID SQL !!!")
+
+    db_path = tmp_path / "partial.db"
+
+    with pytest.raises(RuntimeError):
+        initialize_state_db(db_path, migrations_dir=mig_dir)
+
+    # DB file may exist but schema_migrations should not record a partial run
+    verify = sqlite3.connect(str(db_path))
+    try:
+        applied = [
+            row[0]
+            for row in verify.execute("SELECT name FROM schema_migrations").fetchall()
+        ]
+    except sqlite3.OperationalError:
+        applied = []
+    verify.close()
+
+    assert "0002_bad" not in applied


### PR DESCRIPTION
Closes #337

## Summary
- Refactored `initialize_state_db` to accept an optional `migrations_dir` keyword parameter (defaults to the built-in migrations dir) — enables isolated unit testing of ordering and failure scenarios
- Added three new tests:
  - `test_migration_runner_ordered_application`: verifies migrations are applied in sorted (alphanumeric) order by asserting recorded names appear in order in `schema_migrations`
  - `test_migration_runner_failure_includes_identifier`: verifies `RuntimeError` message contains the failing migration name
  - `test_migration_runner_failure_leaves_no_partial_state`: verifies that a failing second migration is not recorded in `schema_migrations`

## How to test
```
pytest tests/test_state_db.py -q   # 10 passed
```