### PR TITLE
#339: Implement SQLite task store CRUD operations

### DIFF
--- a/src/openbad/tasks/__init__.py
+++ b/src/openbad/tasks/__init__.py
@@ -12,6 +12,7 @@ from openbad.tasks.models import (
     is_valid_node_transition,
     is_valid_task_transition,
 )
+from openbad.tasks.store import TaskStore
 
 __all__ = [
     "NodeStatus",
@@ -20,8 +21,9 @@ __all__ = [
     "TaskKind",
     "TaskPriority",
     "TaskStatus",
-    "assert_valid_task_transition",
+    "TaskStore",
     "assert_valid_node_transition",
-    "is_valid_task_transition",
+    "assert_valid_task_transition",
     "is_valid_node_transition",
+    "is_valid_task_transition",
 ]

--- a/src/openbad/tasks/store.py
+++ b/src/openbad/tasks/store.py
@@ -1,0 +1,270 @@
+"""SQLite CRUD operations for tasks, nodes, and events."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+
+from openbad.tasks.models import NodeModel, NodeStatus, TaskModel, TaskStatus
+
+
+class TaskStore:
+    """Provides CRUD operations backed by a SQLite connection."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    # ------------------------------------------------------------------
+    # Task operations
+    # ------------------------------------------------------------------
+
+    def create_task(self, task: TaskModel) -> TaskModel:
+        """Insert *task* and return it unchanged."""
+        self._conn.execute(
+            """
+            INSERT INTO tasks (
+                task_id, title, description, kind, horizon, priority, status,
+                due_at, parent_task_id, root_task_id, owner, lease_owner,
+                recurrence_rule, requires_context, isolated_execution,
+                notes_path, created_at, updated_at
+            ) VALUES (
+                :task_id, :title, :description, :kind, :horizon, :priority,
+                :status, :due_at, :parent_task_id, :root_task_id, :owner,
+                :lease_owner, :recurrence_rule, :requires_context,
+                :isolated_execution, :notes_path, :created_at, :updated_at
+            )
+            """,
+            _task_to_row(task),
+        )
+        self._conn.commit()
+        return task
+
+    def get_task(self, task_id: str) -> TaskModel | None:
+        """Return the task with *task_id*, or ``None`` if not found."""
+        row = self._conn.execute(
+            "SELECT * FROM tasks WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        return _task_from_row(row) if row else None
+
+    def update_task_status(self, task_id: str, status: TaskStatus) -> None:
+        """Update the status of an existing task."""
+        self._conn.execute(
+            "UPDATE tasks SET status = ?, updated_at = ? WHERE task_id = ?",
+            (status.value, time.time(), task_id),
+        )
+        self._conn.commit()
+
+    def list_tasks(
+        self,
+        *,
+        status: TaskStatus | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[TaskModel]:
+        """Return tasks, optionally filtered by *status*, with pagination."""
+        if status is not None:
+            rows = self._conn.execute(
+                "SELECT * FROM tasks WHERE status = ? ORDER BY created_at ASC"
+                " LIMIT ? OFFSET ?",
+                (status.value, limit, offset),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM tasks ORDER BY created_at ASC LIMIT ? OFFSET ?",
+                (limit, offset),
+            ).fetchall()
+        return [_task_from_row(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Node operations
+    # ------------------------------------------------------------------
+
+    def create_node(self, node: NodeModel) -> NodeModel:
+        """Insert *node* and return it unchanged."""
+        self._conn.execute(
+            """
+            INSERT INTO task_nodes (
+                node_id, task_id, title, node_type, status,
+                capability_requirements, model_requirements,
+                reward_program_id, expected_info_gain, blockage_score,
+                retry_count, max_retries, created_at, updated_at
+            ) VALUES (
+                :node_id, :task_id, :title, :node_type, :status,
+                :capability_requirements, :model_requirements,
+                :reward_program_id, :expected_info_gain, :blockage_score,
+                :retry_count, :max_retries, :created_at, :updated_at
+            )
+            """,
+            _node_to_row(node),
+        )
+        self._conn.commit()
+        return node
+
+    def get_node(self, node_id: str) -> NodeModel | None:
+        """Return the node with *node_id*, or ``None`` if not found."""
+        row = self._conn.execute(
+            "SELECT * FROM task_nodes WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        return _node_from_row(row) if row else None
+
+    def update_node_status(self, node_id: str, status: NodeStatus) -> None:
+        """Update the status of an existing node."""
+        self._conn.execute(
+            "UPDATE task_nodes SET status = ?, updated_at = ? WHERE node_id = ?",
+            (status.value, time.time(), node_id),
+        )
+        self._conn.commit()
+
+    def list_nodes(self, task_id: str) -> list[NodeModel]:
+        """Return all nodes for *task_id* ordered by creation time."""
+        rows = self._conn.execute(
+            "SELECT * FROM task_nodes WHERE task_id = ? ORDER BY created_at ASC",
+            (task_id,),
+        ).fetchall()
+        return [_node_from_row(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Event operations (append-only)
+    # ------------------------------------------------------------------
+
+    def append_event(
+        self,
+        task_id: str,
+        event_type: str,
+        *,
+        node_id: str | None = None,
+        payload: dict | None = None,
+    ) -> str:
+        """Append an event record and return its generated *event_id*."""
+        event_id = str(uuid.uuid4())
+        self._conn.execute(
+            """
+            INSERT INTO task_events (event_id, task_id, node_id, event_type,
+                                     created_at, payload_json)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                task_id,
+                node_id,
+                event_type,
+                time.time(),
+                json.dumps(payload or {}),
+            ),
+        )
+        self._conn.commit()
+        return event_id
+
+    def list_events(self, task_id: str) -> list[dict]:
+        """Return all events for *task_id* in insertion order."""
+        rows = self._conn.execute(
+            "SELECT event_id, task_id, node_id, event_type, created_at,"
+            " payload_json FROM task_events WHERE task_id = ? ORDER BY created_at ASC",
+            (task_id,),
+        ).fetchall()
+        result = []
+        for row in rows:
+            result.append(
+                {
+                    "event_id": row["event_id"],
+                    "task_id": row["task_id"],
+                    "node_id": row["node_id"],
+                    "event_type": row["event_type"],
+                    "created_at": row["created_at"],
+                    "payload": json.loads(row["payload_json"]),
+                }
+            )
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Row ↔ model helpers
+# ---------------------------------------------------------------------------
+
+
+def _task_to_row(task: TaskModel) -> dict:
+    return {
+        "task_id": task.task_id,
+        "title": task.title,
+        "description": task.description,
+        "kind": task.kind.value,
+        "horizon": task.horizon,
+        "priority": task.priority,
+        "status": task.status.value,
+        "due_at": task.due_at,
+        "parent_task_id": task.parent_task_id,
+        "root_task_id": task.root_task_id,
+        "owner": task.owner,
+        "lease_owner": task.lease_owner,
+        "recurrence_rule": task.recurrence_rule,
+        "requires_context": int(task.requires_context),
+        "isolated_execution": int(task.isolated_execution),
+        "notes_path": task.notes_path,
+        "created_at": task.created_at,
+        "updated_at": task.updated_at,
+    }
+
+
+def _task_from_row(row: sqlite3.Row) -> TaskModel:
+    from openbad.tasks.models import TaskKind
+
+    return TaskModel(
+        task_id=row["task_id"],
+        title=row["title"],
+        description=row["description"],
+        kind=TaskKind(row["kind"]),
+        horizon=row["horizon"],
+        priority=row["priority"],
+        status=TaskStatus(row["status"]),
+        due_at=row["due_at"],
+        parent_task_id=row["parent_task_id"],
+        root_task_id=row["root_task_id"],
+        owner=row["owner"],
+        lease_owner=row["lease_owner"],
+        recurrence_rule=row["recurrence_rule"],
+        requires_context=bool(row["requires_context"]),
+        isolated_execution=bool(row["isolated_execution"]),
+        notes_path=row["notes_path"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _node_to_row(node: NodeModel) -> dict:
+    return {
+        "node_id": node.node_id,
+        "task_id": node.task_id,
+        "title": node.title,
+        "node_type": node.node_type,
+        "status": node.status.value,
+        "capability_requirements": json.dumps(node.capability_requirements),
+        "model_requirements": json.dumps(node.model_requirements),
+        "reward_program_id": node.reward_program_id,
+        "expected_info_gain": node.expected_info_gain,
+        "blockage_score": node.blockage_score,
+        "retry_count": node.retry_count,
+        "max_retries": node.max_retries,
+        "created_at": node.created_at,
+        "updated_at": node.updated_at,
+    }
+
+
+def _node_from_row(row: sqlite3.Row) -> NodeModel:
+    return NodeModel(
+        node_id=row["node_id"],
+        task_id=row["task_id"],
+        title=row["title"],
+        node_type=row["node_type"],
+        status=NodeStatus(row["status"]),
+        capability_requirements=json.loads(row["capability_requirements"]),
+        model_requirements=json.loads(row["model_requirements"]),
+        reward_program_id=row["reward_program_id"],
+        expected_info_gain=row["expected_info_gain"],
+        blockage_score=row["blockage_score"],
+        retry_count=row["retry_count"],
+        max_retries=row["max_retries"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.models import NodeModel, NodeStatus, TaskModel, TaskStatus
+from openbad.tasks.store import TaskStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> TaskStore:
+    conn = initialize_state_db(tmp_path / "state.db")
+    return TaskStore(conn)
+
+
+# ---------------------------------------------------------------------------
+# Task CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_task_create_and_read(store: TaskStore) -> None:
+    task = TaskModel.new("Buy milk")
+    store.create_task(task)
+
+    fetched = store.get_task(task.task_id)
+    assert fetched is not None
+    assert fetched.task_id == task.task_id
+    assert fetched.title == "Buy milk"
+    assert fetched.status == TaskStatus.PENDING
+
+
+def test_task_get_missing_returns_none(store: TaskStore) -> None:
+    assert store.get_task("does-not-exist") is None
+
+
+def test_task_update_status(store: TaskStore) -> None:
+    task = TaskModel.new("Write tests")
+    store.create_task(task)
+
+    store.update_task_status(task.task_id, TaskStatus.RUNNING)
+
+    fetched = store.get_task(task.task_id)
+    assert fetched is not None
+    assert fetched.status == TaskStatus.RUNNING
+
+
+def test_task_list_all(store: TaskStore) -> None:
+    for title in ("A", "B", "C"):
+        store.create_task(TaskModel.new(title))
+
+    tasks = store.list_tasks()
+    assert len(tasks) == 3
+
+
+def test_task_list_filtered_by_status(store: TaskStore) -> None:
+    t1 = TaskModel.new("Pending task")
+    t2 = TaskModel.new("Running task")
+    store.create_task(t1)
+    store.create_task(t2)
+    store.update_task_status(t2.task_id, TaskStatus.RUNNING)
+
+    pending = store.list_tasks(status=TaskStatus.PENDING)
+    running = store.list_tasks(status=TaskStatus.RUNNING)
+
+    assert len(pending) == 1
+    assert pending[0].task_id == t1.task_id
+    assert len(running) == 1
+    assert running[0].task_id == t2.task_id
+
+
+def test_task_list_pagination(store: TaskStore) -> None:
+    for i in range(5):
+        store.create_task(TaskModel.new(f"Task {i}"))
+
+    page1 = store.list_tasks(limit=3, offset=0)
+    page2 = store.list_tasks(limit=3, offset=3)
+
+    assert len(page1) == 3
+    assert len(page2) == 2
+    ids_page1 = {t.task_id for t in page1}
+    ids_page2 = {t.task_id for t in page2}
+    assert ids_page1.isdisjoint(ids_page2)
+
+
+# ---------------------------------------------------------------------------
+# Node CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_node_create_and_read(store: TaskStore) -> None:
+    task = TaskModel.new("Parent")
+    store.create_task(task)
+
+    node = NodeModel.new(task.task_id, "Reason step")
+    store.create_node(node)
+
+    fetched = store.get_node(node.node_id)
+    assert fetched is not None
+    assert fetched.node_id == node.node_id
+    assert fetched.task_id == task.task_id
+    assert fetched.status == NodeStatus.PENDING
+
+
+def test_node_get_missing_returns_none(store: TaskStore) -> None:
+    assert store.get_node("no-such-node") is None
+
+
+def test_node_update_status(store: TaskStore) -> None:
+    task = TaskModel.new("Task with node")
+    store.create_task(task)
+    node = NodeModel.new(task.task_id, "Step")
+    store.create_node(node)
+
+    store.update_node_status(node.node_id, NodeStatus.RUNNING)
+
+    fetched = store.get_node(node.node_id)
+    assert fetched is not None
+    assert fetched.status == NodeStatus.RUNNING
+
+
+def test_node_list_by_task(store: TaskStore) -> None:
+    task = TaskModel.new("Multi-node task")
+    store.create_task(task)
+
+    for label in ("step-1", "step-2", "step-3"):
+        store.create_node(NodeModel.new(task.task_id, label))
+
+    nodes = store.list_nodes(task.task_id)
+    assert len(nodes) == 3
+    assert all(n.task_id == task.task_id for n in nodes)
+
+
+# ---------------------------------------------------------------------------
+# Event ordering (append-only)
+# ---------------------------------------------------------------------------
+
+
+def test_event_append_and_ordering(store: TaskStore) -> None:
+    task = TaskModel.new("Event task")
+    store.create_task(task)
+
+    # Insert events with slight time separation to guarantee ordering
+    for i, etype in enumerate(("created", "started", "finished")):
+        store.append_event(task.task_id, etype, payload={"seq": i})
+        time.sleep(0.01)
+
+    events = store.list_events(task.task_id)
+
+    assert len(events) == 3
+    assert [e["event_type"] for e in events] == ["created", "started", "finished"]
+    assert events[0]["payload"] == {"seq": 0}
+    assert events[2]["payload"] == {"seq": 2}
+
+
+def test_event_append_preserves_payload(store: TaskStore) -> None:
+    task = TaskModel.new("Payload task")
+    store.create_task(task)
+
+    payload = {"key": "value", "nums": [1, 2, 3]}
+    store.append_event(task.task_id, "test_event", payload=payload)
+
+    events = store.list_events(task.task_id)
+    assert events[0]["payload"] == payload
+
+
+def test_event_node_id_optional(store: TaskStore) -> None:
+    task = TaskModel.new("Node-less event")
+    store.create_task(task)
+
+    store.append_event(task.task_id, "task_level_event")
+
+    events = store.list_events(task.task_id)
+    assert len(events) == 1
+    assert events[0]["node_id"] is None


### PR DESCRIPTION
Closes #339

## Summary
- Created `src/openbad/tasks/store.py` with `TaskStore` class backed by a SQLite connection:
  - **Task CRUD**: `create_task`, `get_task`, `update_task_status`, `list_tasks` (with optional status filter, `limit`/`offset` pagination)
  - **Node CRUD**: `create_node`, `get_node`, `update_node_status`, `list_nodes`
  - **Event append**: `append_event` (UUID-keyed, preserves insertion order), `list_events`
- Row ↔ model helpers serialize/deserialize JSON list fields and enum values
- Exported `TaskStore` from `openbad.tasks`

## How to test
```
pytest tests/test_task_store.py -q   # 13 passed
```