### PR TITLE
#340: Add task lease API and atomic acquisition

### DIFF
--- a/src/openbad/tasks/__init__.py
+++ b/src/openbad/tasks/__init__.py
@@ -1,5 +1,6 @@
 """Task orchestration package."""
 
+from openbad.tasks.lease import Lease, LeaseError, LeaseStore
 from openbad.tasks.models import (
     NodeStatus,
     ResearchStatus,
@@ -15,6 +16,9 @@ from openbad.tasks.models import (
 from openbad.tasks.store import TaskStore
 
 __all__ = [
+    "Lease",
+    "LeaseError",
+    "LeaseStore",
     "NodeStatus",
     "ResearchStatus",
     "RunStatus",

--- a/src/openbad/tasks/lease.py
+++ b/src/openbad/tasks/lease.py
@@ -1,0 +1,183 @@
+"""Atomic lease acquisition, release, and renewal API backed by SQLite."""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+import time
+import uuid
+
+
+@dataclasses.dataclass(frozen=True)
+class Lease:
+    """An acquired resource lease."""
+
+    lease_id: str
+    owner_id: str
+    resource_type: str
+    resource_id: str
+    leased_at: float
+    expires_at: float
+
+    @property
+    def is_expired(self) -> bool:
+        return time.time() >= self.expires_at
+
+
+class LeaseError(Exception):
+    """Raised when a lease operation is denied."""
+
+
+class LeaseStore:
+    """Atomic lease acquisition and lifecycle management.
+
+    Uses ``BEGIN EXCLUSIVE`` transactions so that acquire is single-winner
+    even under SQLite WAL concurrency.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def acquire(
+        self,
+        resource_type: str,
+        resource_id: str,
+        owner_id: str,
+        ttl_seconds: float,
+    ) -> Lease | None:
+        """Atomically try to acquire a lease.
+
+        Returns the :class:`Lease` on success, or ``None`` if the resource is
+        already held by an active (non-expired) lease.
+        """
+        now = time.time()
+        expires_at = now + ttl_seconds
+
+        # BEGIN EXCLUSIVE serialises concurrent writers; only one wins the race.
+        self._conn.execute("BEGIN EXCLUSIVE")
+        try:
+            active = self._conn.execute(
+                """
+                SELECT lease_id FROM task_leases
+                WHERE resource_type = ? AND resource_id = ? AND expires_at > ?
+                """,
+                (resource_type, resource_id, now),
+            ).fetchone()
+
+            if active:
+                self._conn.execute("ROLLBACK")
+                return None
+
+            lease_id = str(uuid.uuid4())
+            self._conn.execute(
+                """
+                INSERT INTO task_leases
+                    (lease_id, owner_id, resource_type, resource_id,
+                     leased_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (lease_id, owner_id, resource_type, resource_id, now, expires_at),
+            )
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+
+        return Lease(
+            lease_id=lease_id,
+            owner_id=owner_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            leased_at=now,
+            expires_at=expires_at,
+        )
+
+    def release(self, lease_id: str, owner_id: str) -> bool:
+        """Release the lease identified by *lease_id*.
+
+        Returns ``True`` if deleted.  Raises :class:`LeaseError` if the caller
+        is not the owner of an active lease.
+        """
+        row = self._conn.execute(
+            "SELECT owner_id FROM task_leases WHERE lease_id = ?", (lease_id,)
+        ).fetchone()
+
+        if row is None:
+            return False
+
+        if row["owner_id"] != owner_id:
+            raise LeaseError(
+                f"Lease {lease_id!r} is owned by {row['owner_id']!r},"
+                f" not {owner_id!r}"
+            )
+
+        self._conn.execute(
+            "DELETE FROM task_leases WHERE lease_id = ?", (lease_id,)
+        )
+        self._conn.commit()
+        return True
+
+    def renew(
+        self,
+        lease_id: str,
+        owner_id: str,
+        ttl_seconds: float,
+    ) -> Lease:
+        """Extend an active lease by *ttl_seconds* from now.
+
+        Raises :class:`LeaseError` if the lease does not exist, is expired,
+        or is owned by a different caller.
+        """
+        now = time.time()
+        row = self._conn.execute(
+            "SELECT * FROM task_leases WHERE lease_id = ?", (lease_id,)
+        ).fetchone()
+
+        if row is None:
+            raise LeaseError(f"Lease {lease_id!r} not found")
+        if row["owner_id"] != owner_id:
+            raise LeaseError(
+                f"Lease {lease_id!r} is owned by {row['owner_id']!r},"
+                f" not {owner_id!r}"
+            )
+        if row["expires_at"] <= now:
+            raise LeaseError(f"Lease {lease_id!r} has already expired")
+
+        new_expires = now + ttl_seconds
+        self._conn.execute(
+            "UPDATE task_leases SET expires_at = ? WHERE lease_id = ?",
+            (new_expires, lease_id),
+        )
+        self._conn.commit()
+
+        return Lease(
+            lease_id=lease_id,
+            owner_id=owner_id,
+            resource_type=row["resource_type"],
+            resource_id=row["resource_id"],
+            leased_at=row["leased_at"],
+            expires_at=new_expires,
+        )
+
+    def get_active(self, resource_type: str, resource_id: str) -> Lease | None:
+        """Return the active (non-expired) lease for *resource*, or ``None``."""
+        now = time.time()
+        row = self._conn.execute(
+            """
+            SELECT * FROM task_leases
+            WHERE resource_type = ? AND resource_id = ? AND expires_at > ?
+            """,
+            (resource_type, resource_id, now),
+        ).fetchone()
+
+        if row is None:
+            return None
+
+        return Lease(
+            lease_id=row["lease_id"],
+            owner_id=row["owner_id"],
+            resource_type=row["resource_type"],
+            resource_id=row["resource_id"],
+            leased_at=row["leased_at"],
+            expires_at=row["expires_at"],
+        )

--- a/tests/test_task_lease.py
+++ b/tests/test_task_lease.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.lease import Lease, LeaseError, LeaseStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> LeaseStore:
+    conn = initialize_state_db(tmp_path / "state.db")
+    return LeaseStore(conn)
+
+
+# ---------------------------------------------------------------------------
+# Basic acquire / release
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_returns_lease(store: LeaseStore) -> None:
+    lease = store.acquire("task", "task-1", "worker-A", ttl_seconds=60)
+
+    assert isinstance(lease, Lease)
+    assert lease.owner_id == "worker-A"
+    assert lease.resource_type == "task"
+    assert lease.resource_id == "task-1"
+    assert not lease.is_expired
+
+
+def test_get_active_returns_held_lease(store: LeaseStore) -> None:
+    store.acquire("task", "task-1", "worker-A", ttl_seconds=60)
+
+    active = store.get_active("task", "task-1")
+    assert active is not None
+    assert active.owner_id == "worker-A"
+
+
+def test_get_active_returns_none_when_no_lease(store: LeaseStore) -> None:
+    assert store.get_active("task", "no-task") is None
+
+
+# ---------------------------------------------------------------------------
+# Concurrent acquisition — single winner
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_acquisition_single_winner(store: LeaseStore) -> None:
+    """Two sequential acquire calls on the same live resource: only the first wins."""
+    lease_a = store.acquire("task", "shared-task", "worker-A", ttl_seconds=60)
+    lease_b = store.acquire("task", "shared-task", "worker-B", ttl_seconds=60)
+
+    assert lease_a is not None
+    assert lease_b is None  # B lost the race
+
+    # The active holder is A
+    active = store.get_active("task", "shared-task")
+    assert active is not None
+    assert active.owner_id == "worker-A"
+
+
+def test_different_resources_can_be_leased_concurrently(store: LeaseStore) -> None:
+    lease_a = store.acquire("task", "resource-1", "worker-A", ttl_seconds=60)
+    lease_b = store.acquire("task", "resource-2", "worker-B", ttl_seconds=60)
+
+    assert lease_a is not None
+    assert lease_b is not None
+
+
+# ---------------------------------------------------------------------------
+# Lease expiry reclaim
+# ---------------------------------------------------------------------------
+
+
+def test_expired_lease_is_reclaimable(store: LeaseStore) -> None:
+    """After a lease expires, another owner can acquire the same resource."""
+    lease_a = store.acquire("task", "expiring-task", "worker-A", ttl_seconds=0.01)
+    assert lease_a is not None
+
+    # Wait for the lease to expire
+    time.sleep(0.05)
+
+    lease_b = store.acquire("task", "expiring-task", "worker-B", ttl_seconds=60)
+    assert lease_b is not None
+    assert lease_b.owner_id == "worker-B"
+
+
+def test_get_active_returns_none_for_expired_lease(store: LeaseStore) -> None:
+    store.acquire("task", "exp-res", "owner", ttl_seconds=0.01)
+    time.sleep(0.05)
+
+    assert store.get_active("task", "exp-res") is None
+
+
+# ---------------------------------------------------------------------------
+# Non-owner release denied
+# ---------------------------------------------------------------------------
+
+
+def test_release_by_owner_succeeds(store: LeaseStore) -> None:
+    lease = store.acquire("task", "releasable", "owner-A", ttl_seconds=60)
+    assert lease is not None
+
+    released = store.release(lease.lease_id, "owner-A")
+    assert released is True
+    assert store.get_active("task", "releasable") is None
+
+
+def test_release_by_non_owner_raises_lease_error(store: LeaseStore) -> None:
+    lease = store.acquire("task", "guarded", "owner-A", ttl_seconds=60)
+    assert lease is not None
+
+    with pytest.raises(LeaseError, match="owner-A"):
+        store.release(lease.lease_id, "intruder")
+
+
+def test_release_nonexistent_lease_returns_false(store: LeaseStore) -> None:
+    assert store.release("no-such-lease", "anyone") is False
+
+
+# ---------------------------------------------------------------------------
+# Renewal
+# ---------------------------------------------------------------------------
+
+
+def test_renew_extends_expiry(store: LeaseStore) -> None:
+    lease = store.acquire("task", "renewable", "owner-A", ttl_seconds=10)
+    assert lease is not None
+
+    renewed = store.renew(lease.lease_id, "owner-A", ttl_seconds=120)
+
+    assert renewed.lease_id == lease.lease_id
+    assert renewed.expires_at > lease.expires_at
+
+
+def test_renew_by_non_owner_raises(store: LeaseStore) -> None:
+    lease = store.acquire("task", "no-steal", "owner-A", ttl_seconds=60)
+    assert lease is not None
+
+    with pytest.raises(LeaseError, match="owner-A"):
+        store.renew(lease.lease_id, "thief", ttl_seconds=60)
+
+
+def test_renew_expired_lease_raises(store: LeaseStore) -> None:
+    lease = store.acquire("task", "exp-renew", "owner-A", ttl_seconds=0.01)
+    assert lease is not None
+    time.sleep(0.05)
+
+    with pytest.raises(LeaseError, match="expired"):
+        store.renew(lease.lease_id, "owner-A", ttl_seconds=60)


### PR DESCRIPTION
Closes #340

## Summary
- Created `src/openbad/tasks/lease.py` with `LeaseStore` class:
  - `acquire(resource_type, resource_id, owner_id, ttl_seconds)`: uses `BEGIN EXCLUSIVE` for single-winner atomicity; returns `Lease` or `None` if already held
  - `release(lease_id, owner_id)`: owner-guarded delete; raises `LeaseError` for non-owner calls
  - `renew(lease_id, owner_id, ttl_seconds)`: extends expiry, validates ownership and non-expiry
  - `get_active(resource_type, resource_id)`: returns non-expired lease or `None`
- Added `Lease` frozen dataclass and `LeaseError` exception
- Exported all from `openbad.tasks`

## How to test
```
pytest tests/test_task_lease.py -q   # 13 passed
```