### PR TITLE
#341: Add Phase 9 topic constants to nervous system

### DIFF
--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -130,6 +130,41 @@ SLEEP_ALL = "agent/sleep/+"
 PROPRIOCEPTION_HEARTBEAT = "agent/proprioception/{tool_id}/heartbeat"
 PROPRIOCEPTION_ALL = "agent/proprioception/#"
 
+# ---------------------------------------------------------------------------
+# Task orchestration (Phase 9)
+# ---------------------------------------------------------------------------
+TASK_CREATED = "agent/task/{task_id}/created"
+TASK_UPDATED = "agent/task/{task_id}/updated"
+TASK_STATUS = "agent/task/{task_id}/status"
+TASK_NODE_STATUS = "agent/task/{task_id}/node/{node_id}/status"
+TASK_COMPLETED = "agent/task/{task_id}/completed"
+TASK_FAILED = "agent/task/{task_id}/failed"
+
+# Wildcard: all task events
+TASK_ALL = "agent/task/#"
+
+# ---------------------------------------------------------------------------
+# Research queue (Phase 9)
+# ---------------------------------------------------------------------------
+RESEARCH_QUEUED = "agent/research/queued"
+RESEARCH_STARTED = "agent/research/{research_id}/started"
+RESEARCH_COMPLETED = "agent/research/{research_id}/completed"
+RESEARCH_FINDING = "agent/research/{research_id}/finding"
+
+# Wildcard: all research events
+RESEARCH_ALL = "agent/research/#"
+
+# ---------------------------------------------------------------------------
+# Scheduler (Phase 9)
+# ---------------------------------------------------------------------------
+SCHEDULER_TICK = "agent/scheduler/tick"
+SCHEDULER_WINDOW_START = "agent/scheduler/window/start"
+SCHEDULER_WINDOW_END = "agent/scheduler/window/end"
+SCHEDULER_DISPATCH = "agent/scheduler/dispatch"
+
+# Wildcard: all scheduler events
+SCHEDULER_ALL = "agent/scheduler/+"
+
 
 # ---------------------------------------------------------------------------
 # Helper: resolve topic templates
@@ -167,6 +202,12 @@ STATIC_TOPICS: tuple[str, ...] = (
     MEMORY_LTM_CONSOLIDATE,
     SENSORY_AUDIO_TTS_COMPLETE,
     SENSORY_ATTENTION_TRIGGER,
+    # Phase 9
+    RESEARCH_QUEUED,
+    SCHEDULER_TICK,
+    SCHEDULER_WINDOW_START,
+    SCHEDULER_WINDOW_END,
+    SCHEDULER_DISPATCH,
 )
 
 TEMPLATE_TOPICS: tuple[str, ...] = (
@@ -178,6 +219,16 @@ TEMPLATE_TOPICS: tuple[str, ...] = (
     ENDOCRINE,
     SLEEP,
     PROPRIOCEPTION_HEARTBEAT,
+    # Phase 9
+    TASK_CREATED,
+    TASK_UPDATED,
+    TASK_STATUS,
+    TASK_NODE_STATUS,
+    TASK_COMPLETED,
+    TASK_FAILED,
+    RESEARCH_STARTED,
+    RESEARCH_COMPLETED,
+    RESEARCH_FINDING,
 )
 
 WILDCARD_TOPICS: tuple[str, ...] = (
@@ -191,4 +242,8 @@ WILDCARD_TOPICS: tuple[str, ...] = (
     MEMORY_ALL,
     SLEEP_ALL,
     PROPRIOCEPTION_ALL,
+    # Phase 9
+    TASK_ALL,
+    RESEARCH_ALL,
+    SCHEDULER_ALL,
 )

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -143,3 +143,70 @@ class TestImportability:
             TELEMETRY_TOKENS,
         ):
             assert isinstance(name, str)
+
+
+# ---------------------------------------------------------------------------
+# Phase 9: task / research / scheduler topic constants — Issue #341
+# ---------------------------------------------------------------------------
+
+
+class TestPhase9TopicConstants:
+    """New Phase 9 topics must have correct static values and set membership."""
+
+    # --- constant values ---
+
+    def test_task_all_wildcard_value(self) -> None:
+        assert topics.TASK_ALL == "agent/task/#"
+
+    def test_research_all_wildcard_value(self) -> None:
+        assert topics.RESEARCH_ALL == "agent/research/#"
+
+    def test_scheduler_all_wildcard_value(self) -> None:
+        assert topics.SCHEDULER_ALL == "agent/scheduler/+"
+
+    def test_scheduler_tick_static_value(self) -> None:
+        assert topics.SCHEDULER_TICK == "agent/scheduler/tick"
+
+    def test_research_queued_static_value(self) -> None:
+        assert topics.RESEARCH_QUEUED == "agent/research/queued"
+
+    # --- wildcard set membership ---
+
+    def test_task_all_in_wildcard_topics(self) -> None:
+        assert topics.TASK_ALL in topics.WILDCARD_TOPICS
+
+    def test_research_all_in_wildcard_topics(self) -> None:
+        assert topics.RESEARCH_ALL in topics.WILDCARD_TOPICS
+
+    def test_scheduler_all_in_wildcard_topics(self) -> None:
+        assert topics.SCHEDULER_ALL in topics.WILDCARD_TOPICS
+
+    # --- static set membership ---
+
+    def test_scheduler_constants_in_static_topics(self) -> None:
+        for constant in (
+            topics.SCHEDULER_TICK,
+            topics.SCHEDULER_WINDOW_START,
+            topics.SCHEDULER_WINDOW_END,
+            topics.SCHEDULER_DISPATCH,
+        ):
+            assert constant in topics.STATIC_TOPICS, f"{constant!r} missing from STATIC_TOPICS"
+
+    def test_research_queued_in_static_topics(self) -> None:
+        assert topics.RESEARCH_QUEUED in topics.STATIC_TOPICS
+
+    # --- template resolution ---
+
+    def test_task_status_template(self) -> None:
+        result = topics.topic_for(topics.TASK_STATUS, task_id="abc-123")
+        assert result == "agent/task/abc-123/status"
+
+    def test_task_node_status_template(self) -> None:
+        result = topics.topic_for(
+            topics.TASK_NODE_STATUS, task_id="t-1", node_id="n-1"
+        )
+        assert result == "agent/task/t-1/node/n-1/status"
+
+    def test_research_finding_template(self) -> None:
+        result = topics.topic_for(topics.RESEARCH_FINDING, research_id="r-99")
+        assert result == "agent/research/r-99/finding"


### PR DESCRIPTION
Closes #341

## Summary
- Added Phase 9 topics to `src/openbad/nervous_system/topics.py`:
  - **Task**: `TASK_CREATED/UPDATED/STATUS/NODE_STATUS/COMPLETED/FAILED` (templates), `TASK_ALL` wildcard
  - **Research**: `RESEARCH_QUEUED` (static), `RESEARCH_STARTED/COMPLETED/FINDING` (templates), `RESEARCH_ALL` wildcard
  - **Scheduler**: `SCHEDULER_TICK/WINDOW_START/WINDOW_END/DISPATCH` (static), `SCHEDULER_ALL` wildcard
- Updated `STATIC_TOPICS`, `TEMPLATE_TOPICS`, and `WILDCARD_TOPICS` tuples to include all new constants
- Added `TestPhase9TopicConstants` to `tests/test_topics.py` with 13 tests covering constant values, wildcard set membership, and template resolution

## How to test
```
pytest tests/test_topics.py -q   # 428 passed
```