### PR TITLE
#342: Persist heartbeat scheduler state in SQLite

### DIFF
--- a/src/openbad/proprioception/heartbeat_state.py
+++ b/src/openbad/proprioception/heartbeat_state.py
@@ -1,0 +1,149 @@
+"""Heartbeat scheduler state persistence backed by the SQLite state DB.
+
+The ``heartbeat_state`` table always contains exactly one row (id = 1).
+:class:`HeartbeatStateStore` provides typed read/write helpers to keep that row
+current across scheduler loop iterations.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+import time
+
+
+@dataclasses.dataclass
+class HeartbeatState:
+    """Snapshot of the heartbeat state row."""
+
+    last_heartbeat_at: float | None
+    last_triage_at: float | None
+    last_context_required_dispatch_at: float | None
+    last_research_review_at: float | None
+    last_sleep_cycle_at: float | None
+    last_maintenance_at: float | None
+    silent_skip_count: int
+
+
+_EMPTY = HeartbeatState(
+    last_heartbeat_at=None,
+    last_triage_at=None,
+    last_context_required_dispatch_at=None,
+    last_research_review_at=None,
+    last_sleep_cycle_at=None,
+    last_maintenance_at=None,
+    silent_skip_count=0,
+)
+
+
+class HeartbeatStateStore:
+    """Read and write the singleton ``heartbeat_state`` row.
+
+    The table uses ``id = 1`` as its only row (enforced by a CHECK constraint).
+    On first read, if the row does not yet exist it is inserted with all
+    timestamps as NULL.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_row(self) -> None:
+        self._conn.execute(
+            "INSERT OR IGNORE INTO heartbeat_state (id) VALUES (1)"
+        )
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def load(self) -> HeartbeatState:
+        """Return the current heartbeat state, bootstrapping the row as needed."""
+        self._ensure_row()
+        row = self._conn.execute("SELECT * FROM heartbeat_state WHERE id = 1").fetchone()
+        return HeartbeatState(
+            last_heartbeat_at=row["last_heartbeat_at"],
+            last_triage_at=row["last_triage_at"],
+            last_context_required_dispatch_at=row["last_context_required_dispatch_at"],
+            last_research_review_at=row["last_research_review_at"],
+            last_sleep_cycle_at=row["last_sleep_cycle_at"],
+            last_maintenance_at=row["last_maintenance_at"],
+            silent_skip_count=row["silent_skip_count"],
+        )
+
+    # ------------------------------------------------------------------
+    # Write — individual fields
+    # ------------------------------------------------------------------
+
+    def record_heartbeat(self) -> None:
+        """Update ``last_heartbeat_at`` to now and reset the silent-skip counter."""
+        self._ensure_row()
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_heartbeat_at = ?, silent_skip_count = 0"
+            " WHERE id = 1",
+            (time.time(),),
+        )
+        self._conn.commit()
+
+    def record_triage(self) -> None:
+        """Update ``last_triage_at`` to now."""
+        self._ensure_row()
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_triage_at = ? WHERE id = 1",
+            (time.time(),),
+        )
+        self._conn.commit()
+
+    def record_context_dispatch(self) -> None:
+        """Update ``last_context_required_dispatch_at`` to now."""
+        self._ensure_row()
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_context_required_dispatch_at = ?"
+            " WHERE id = 1",
+            (time.time(),),
+        )
+        self._conn.commit()
+
+    def record_research_review(self) -> None:
+        """Update ``last_research_review_at`` to now."""
+        self._ensure_row()
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_research_review_at = ? WHERE id = 1",
+            (time.time(),),
+        )
+        self._conn.commit()
+
+    def record_sleep_cycle(self) -> None:
+        """Update ``last_sleep_cycle_at`` to now."""
+        self._ensure_row()
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_sleep_cycle_at = ? WHERE id = 1",
+            (time.time(),),
+        )
+        self._conn.commit()
+
+    def record_maintenance(self) -> None:
+        """Update ``last_maintenance_at`` to now."""
+        self._ensure_row()
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_maintenance_at = ? WHERE id = 1",
+            (time.time(),),
+        )
+        self._conn.commit()
+
+    def increment_silent_skip(self) -> int:
+        """Increment the silent-skip counter and return the new count."""
+        self._ensure_row()
+        self._conn.execute(
+            "UPDATE heartbeat_state SET silent_skip_count = silent_skip_count + 1"
+            " WHERE id = 1",
+        )
+        self._conn.commit()
+        row = self._conn.execute(
+            "SELECT silent_skip_count FROM heartbeat_state WHERE id = 1"
+        ).fetchone()
+        return int(row["silent_skip_count"])

--- a/tests/test_heartbeat_state.py
+++ b/tests/test_heartbeat_state.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from openbad.proprioception.heartbeat_state import HeartbeatState, HeartbeatStateStore
+from openbad.state.db import initialize_state_db
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> HeartbeatStateStore:
+    conn = initialize_state_db(tmp_path / "state.db")
+    return HeartbeatStateStore(conn)
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat state persistence
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_load_returns_defaults(store: HeartbeatStateStore) -> None:
+    state = store.load()
+
+    assert isinstance(state, HeartbeatState)
+    assert state.last_heartbeat_at is None
+    assert state.silent_skip_count == 0
+
+
+def test_load_is_idempotent(store: HeartbeatStateStore) -> None:
+    first = store.load()
+    second = store.load()
+
+    assert first.silent_skip_count == second.silent_skip_count
+
+
+def test_heartbeat_persists_across_reload(tmp_path: Path) -> None:
+    """State survives opening a new connection to the same file."""
+    db_path = tmp_path / "state.db"
+
+    conn1 = initialize_state_db(db_path)
+    s1 = HeartbeatStateStore(conn1)
+    s1.record_heartbeat()
+    conn1.close()
+
+    conn2 = initialize_state_db(db_path)
+    s2 = HeartbeatStateStore(conn2)
+    state = s2.load()
+    conn2.close()
+
+    assert state.last_heartbeat_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Silent skip counter
+# ---------------------------------------------------------------------------
+
+
+def test_silent_skip_increments_correctly(store: HeartbeatStateStore) -> None:
+    count1 = store.increment_silent_skip()
+    count2 = store.increment_silent_skip()
+    count3 = store.increment_silent_skip()
+
+    assert count1 == 1
+    assert count2 == 2
+    assert count3 == 3
+
+
+def test_record_heartbeat_resets_silent_skip(store: HeartbeatStateStore) -> None:
+    store.increment_silent_skip()
+    store.increment_silent_skip()
+
+    store.record_heartbeat()
+
+    state = store.load()
+    assert state.silent_skip_count == 0
+
+
+def test_silent_skip_reflected_in_load(store: HeartbeatStateStore) -> None:
+    store.increment_silent_skip()
+    store.increment_silent_skip()
+
+    state = store.load()
+    assert state.silent_skip_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Dispatch timestamps update on publish
+# ---------------------------------------------------------------------------
+
+
+def test_record_triage_updates_timestamp(store: HeartbeatStateStore) -> None:
+    before = time.time()
+    store.record_triage()
+    state = store.load()
+
+    assert state.last_triage_at is not None
+    assert state.last_triage_at >= before
+
+
+def test_record_context_dispatch_updates_timestamp(store: HeartbeatStateStore) -> None:
+    before = time.time()
+    store.record_context_dispatch()
+    state = store.load()
+
+    assert state.last_context_required_dispatch_at is not None
+    assert state.last_context_required_dispatch_at >= before
+
+
+def test_record_research_review_updates_timestamp(store: HeartbeatStateStore) -> None:
+    before = time.time()
+    store.record_research_review()
+    state = store.load()
+
+    assert state.last_research_review_at is not None
+    assert state.last_research_review_at >= before
+
+
+def test_record_sleep_cycle_updates_timestamp(store: HeartbeatStateStore) -> None:
+    before = time.time()
+    store.record_sleep_cycle()
+    state = store.load()
+
+    assert state.last_sleep_cycle_at is not None
+    assert state.last_sleep_cycle_at >= before
+
+
+def test_record_maintenance_updates_timestamp(store: HeartbeatStateStore) -> None:
+    before = time.time()
+    store.record_maintenance()
+    state = store.load()
+
+    assert state.last_maintenance_at is not None
+    assert state.last_maintenance_at >= before


### PR DESCRIPTION
Closes #342

## Summary
- Created `src/openbad/proprioception/heartbeat_state.py` with `HeartbeatStateStore` and `HeartbeatState` dataclass
- The `heartbeat_state` table (singleton row id=1) is bootstrapped on first access via `INSERT OR IGNORE`
- Methods: `load()`, `record_heartbeat()` (resets silent-skip), `record_triage/context_dispatch/research_review/sleep_cycle/maintenance()`, `increment_silent_skip()`

## How to test
```
pytest tests/test_heartbeat_state.py -q   # 11 passed
```