### PR TITLE
#325: Implement task store and task service CRUD layer

### DIFF
--- a/src/openbad/tasks/__init__.py
+++ b/src/openbad/tasks/__init__.py
@@ -13,6 +13,7 @@ from openbad.tasks.models import (
     is_valid_node_transition,
     is_valid_task_transition,
 )
+from openbad.tasks.service import TaskService
 from openbad.tasks.store import TaskStore
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "RunStatus",
     "TaskKind",
     "TaskPriority",
+    "TaskService",
     "TaskStatus",
     "TaskStore",
     "assert_valid_node_transition",

--- a/src/openbad/tasks/service.py
+++ b/src/openbad/tasks/service.py
@@ -1,0 +1,194 @@
+"""High-level task service layer.
+
+:class:`TaskService` wraps :class:`~openbad.tasks.store.TaskStore`,
+:class:`~openbad.tasks.lease.LeaseStore`, and the model transition helpers
+into a single coherent API that is independent from the WUI, scheduler, and
+any MQTT transport.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+
+from openbad.tasks.lease import Lease, LeaseStore
+from openbad.tasks.models import (
+    NodeModel,
+    NodeStatus,
+    TaskModel,
+    TaskStatus,
+    assert_valid_node_transition,
+    assert_valid_task_transition,
+)
+from openbad.tasks.store import TaskStore
+
+
+class TaskService:
+    """Unified task service that coordinates the store and lease layers."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._store = TaskStore(conn)
+        self._leases = LeaseStore(conn)
+
+    # ------------------------------------------------------------------
+    # Task lifecycle
+    # ------------------------------------------------------------------
+
+    def create_task(
+        self,
+        title: str,
+        *,
+        description: str = "",
+        owner: str = "system",
+        parent_task_id: str | None = None,
+    ) -> TaskModel:
+        """Create a new task in PENDING status and return it."""
+        task = TaskModel.new(
+            title,
+            description=description,
+            owner=owner,
+            parent_task_id=parent_task_id,
+        )
+        return self._store.create_task(task)
+
+    def get_task(self, task_id: str) -> TaskModel | None:
+        """Return the task or ``None``."""
+        return self._store.get_task(task_id)
+
+    def list_tasks(
+        self,
+        *,
+        status: TaskStatus | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[TaskModel]:
+        """Return tasks with optional status filter and pagination."""
+        return self._store.list_tasks(status=status, limit=limit, offset=offset)
+
+    def transition_task(self, task_id: str, next_status: TaskStatus) -> TaskModel:
+        """Apply a validated status transition to a task.
+
+        Raises :class:`ValueError` if the transition is illegal.
+        Raises :class:`KeyError` if *task_id* is not found.
+        """
+        task = self._store.get_task(task_id)
+        if task is None:
+            raise KeyError(f"Task {task_id!r} not found")
+        assert_valid_task_transition(task.status, next_status)
+        self._store.update_task_status(task_id, next_status)
+        self._store.append_event(
+            task_id,
+            "task_status_changed",
+            payload={"from": task.status.value, "to": next_status.value},
+        )
+        updated = self._store.get_task(task_id)
+        assert updated is not None
+        return updated
+
+    def cancel_task(self, task_id: str) -> TaskModel:
+        """Convenience wrapper to cancel a task."""
+        return self.transition_task(task_id, TaskStatus.CANCELLED)
+
+    # ------------------------------------------------------------------
+    # Node lifecycle
+    # ------------------------------------------------------------------
+
+    def create_node(
+        self,
+        task_id: str,
+        title: str,
+        *,
+        node_type: str = "reason",
+        max_retries: int = 0,
+    ) -> NodeModel:
+        """Create a node attached to *task_id* and return it."""
+        node = NodeModel.new(
+            task_id, title, node_type=node_type, max_retries=max_retries
+        )
+        return self._store.create_node(node)
+
+    def get_node(self, node_id: str) -> NodeModel | None:
+        """Return the node or ``None``."""
+        return self._store.get_node(node_id)
+
+    def list_nodes(self, task_id: str) -> list[NodeModel]:
+        """Return all nodes for a task in creation order."""
+        return self._store.list_nodes(task_id)
+
+    def transition_node(self, node_id: str, next_status: NodeStatus) -> NodeModel:
+        """Apply a validated status transition to a node.
+
+        Raises :class:`ValueError` if the transition is illegal.
+        Raises :class:`KeyError` if *node_id* is not found.
+        """
+        node = self._store.get_node(node_id)
+        if node is None:
+            raise KeyError(f"Node {node_id!r} not found")
+        assert_valid_node_transition(node.status, next_status)
+        self._store.update_node_status(node_id, next_status)
+        self._store.append_event(
+            node.task_id,
+            "node_status_changed",
+            node_id=node_id,
+            payload={"from": node.status.value, "to": next_status.value},
+        )
+        updated = self._store.get_node(node_id)
+        assert updated is not None
+        return updated
+
+    # ------------------------------------------------------------------
+    # Event recording
+    # ------------------------------------------------------------------
+
+    def append_event(
+        self,
+        task_id: str,
+        event_type: str,
+        *,
+        node_id: str | None = None,
+        payload: dict | None = None,
+    ) -> str:
+        """Append an event and return its *event_id*."""
+        return self._store.append_event(
+            task_id, event_type, node_id=node_id, payload=payload
+        )
+
+    def list_events(self, task_id: str) -> list[dict]:
+        """Return all events for *task_id* in creation order."""
+        return self._store.list_events(task_id)
+
+    # ------------------------------------------------------------------
+    # Lease helpers
+    # ------------------------------------------------------------------
+
+    def acquire_task_lease(
+        self,
+        task_id: str,
+        owner_id: str,
+        ttl_seconds: float = 300,
+    ) -> Lease | None:
+        """Atomically acquire a lease on *task_id* for *owner_id*.
+
+        Returns the :class:`Lease` on success, ``None`` if already held.
+        """
+        return self._leases.acquire("task", task_id, owner_id, ttl_seconds)
+
+    def release_task_lease(self, lease_id: str, owner_id: str) -> bool:
+        """Release a task lease owned by *owner_id*."""
+        return self._leases.release(lease_id, owner_id)
+
+    def generate_run_id(self) -> str:
+        """Generate a unique run ID for a task execution record."""
+        return str(uuid.uuid4())
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+
+    def task_to_dict(self, task: TaskModel) -> dict:
+        """Serialise a task model for WUI / API use."""
+        return task.to_dict()
+
+    def node_to_dict(self, node: NodeModel) -> dict:
+        """Serialise a node model for WUI / API use."""
+        return node.to_dict()

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.models import NodeStatus, TaskStatus
+from openbad.tasks.service import TaskService
+
+
+@pytest.fixture()
+def svc(tmp_path: Path) -> TaskService:
+    conn = initialize_state_db(tmp_path / "state.db")
+    return TaskService(conn)
+
+
+# ---------------------------------------------------------------------------
+# Create and retrieve task
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_retrieve_task(svc: TaskService) -> None:
+    task = svc.create_task("Write unit tests", description="High priority")
+
+    fetched = svc.get_task(task.task_id)
+    assert fetched is not None
+    assert fetched.title == "Write unit tests"
+    assert fetched.description == "High priority"
+    assert fetched.status == TaskStatus.PENDING
+
+
+def test_get_nonexistent_task_returns_none(svc: TaskService) -> None:
+    assert svc.get_task("ghost") is None
+
+
+def test_list_tasks_returns_all(svc: TaskService) -> None:
+    svc.create_task("A")
+    svc.create_task("B")
+
+    tasks = svc.list_tasks()
+    assert len(tasks) == 2
+
+
+def test_list_tasks_filtered_by_status(svc: TaskService) -> None:
+    t1 = svc.create_task("Pending")
+    t2 = svc.create_task("Running")
+    svc.transition_task(t2.task_id, TaskStatus.RUNNING)
+
+    pending = svc.list_tasks(status=TaskStatus.PENDING)
+    running = svc.list_tasks(status=TaskStatus.RUNNING)
+
+    assert len(pending) == 1 and pending[0].task_id == t1.task_id
+    assert len(running) == 1 and running[0].task_id == t2.task_id
+
+
+# ---------------------------------------------------------------------------
+# Task status transitions
+# ---------------------------------------------------------------------------
+
+
+def test_task_valid_transition(svc: TaskService) -> None:
+    task = svc.create_task("Transitioning task")
+    updated = svc.transition_task(task.task_id, TaskStatus.RUNNING)
+
+    assert updated.status == TaskStatus.RUNNING
+
+
+def test_task_invalid_transition_raises(svc: TaskService) -> None:
+    task = svc.create_task("Will fail")
+    svc.transition_task(task.task_id, TaskStatus.RUNNING)
+    svc.transition_task(task.task_id, TaskStatus.DONE)
+
+    with pytest.raises(ValueError, match="Illegal task transition"):
+        svc.transition_task(task.task_id, TaskStatus.RUNNING)
+
+
+def test_cancel_task(svc: TaskService) -> None:
+    task = svc.create_task("Doomed task")
+    cancelled = svc.cancel_task(task.task_id)
+
+    assert cancelled.status == TaskStatus.CANCELLED
+
+
+def test_transition_nonexistent_task_raises(svc: TaskService) -> None:
+    with pytest.raises(KeyError):
+        svc.transition_task("no-such-id", TaskStatus.RUNNING)
+
+
+# ---------------------------------------------------------------------------
+# Node creation and lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_retrieve_node(svc: TaskService) -> None:
+    task = svc.create_task("Parent")
+    node = svc.create_node(task.task_id, "Step 1")
+
+    fetched = svc.get_node(node.node_id)
+    assert fetched is not None
+    assert fetched.task_id == task.task_id
+    assert fetched.status == NodeStatus.PENDING
+
+
+def test_list_nodes_for_task(svc: TaskService) -> None:
+    task = svc.create_task("Multi-step")
+    svc.create_node(task.task_id, "A")
+    svc.create_node(task.task_id, "B")
+
+    nodes = svc.list_nodes(task.task_id)
+    assert len(nodes) == 2
+
+
+def test_node_valid_transition(svc: TaskService) -> None:
+    task = svc.create_task("Task")
+    node = svc.create_node(task.task_id, "Node")
+
+    updated = svc.transition_node(node.node_id, NodeStatus.RUNNING)
+    assert updated.status == NodeStatus.RUNNING
+
+
+def test_node_invalid_transition_raises(svc: TaskService) -> None:
+    task = svc.create_task("Task")
+    node = svc.create_node(task.task_id, "Node")
+
+    with pytest.raises(ValueError, match="Illegal node transition"):
+        svc.transition_node(node.node_id, NodeStatus.DONE)  # pending -> done is illegal
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+def test_transition_records_event(svc: TaskService) -> None:
+    task = svc.create_task("Evented task")
+    svc.transition_task(task.task_id, TaskStatus.RUNNING)
+
+    events = svc.list_events(task.task_id)
+    assert any(e["event_type"] == "task_status_changed" for e in events)
+
+
+def test_append_and_list_events(svc: TaskService) -> None:
+    task = svc.create_task("Events task")
+    svc.append_event(task.task_id, "custom_event", payload={"key": "val"})
+
+    events = svc.list_events(task.task_id)
+    custom = [e for e in events if e["event_type"] == "custom_event"]
+    assert len(custom) == 1
+    assert custom[0]["payload"] == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# Lease helpers
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_task_lease(svc: TaskService) -> None:
+    task = svc.create_task("Leased task")
+    lease = svc.acquire_task_lease(task.task_id, "worker-1")
+
+    assert lease is not None
+    assert lease.owner_id == "worker-1"
+
+
+def test_lease_prevents_duplicate_acquisition(svc: TaskService) -> None:
+    task = svc.create_task("Guarded task")
+    lease_a = svc.acquire_task_lease(task.task_id, "worker-A")
+    lease_b = svc.acquire_task_lease(task.task_id, "worker-B")
+
+    assert lease_a is not None
+    assert lease_b is None
+
+
+def test_release_task_lease(svc: TaskService) -> None:
+    task = svc.create_task("Releasable task")
+    lease = svc.acquire_task_lease(task.task_id, "worker-A")
+    assert lease is not None
+
+    released = svc.release_task_lease(lease.lease_id, "worker-A")
+    assert released is True
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def test_task_to_dict_round_trip(svc: TaskService) -> None:
+    task = svc.create_task("Serializable")
+    d = svc.task_to_dict(task)
+
+    assert d["title"] == "Serializable"
+    assert d["status"] == "pending"
+    assert isinstance(d["task_id"], str)
+
+
+def test_node_to_dict_round_trip(svc: TaskService) -> None:
+    task = svc.create_task("Node parent")
+    node = svc.create_node(task.task_id, "Node child")
+    d = svc.node_to_dict(node)
+
+    assert d["title"] == "Node child"
+    assert d["status"] == "pending"


### PR DESCRIPTION
Closes #325

## Summary
Built on the models (#338), store (#339), and lease (#340) sub-issues, this PR adds `src/openbad/tasks/service.py` — a unified `TaskService` that provides:
- `create_task / get_task / list_tasks`: full lifecycle with status filtering and pagination
- `transition_task / cancel_task`: validated transitions via `assert_valid_task_transition`; emits `task_status_changed` events
- `create_node / get_node / list_nodes / transition_node`: node lifecycle with validated transitions and event recording
- `append_event / list_events`: append-only event log
- `acquire_task_lease / release_task_lease`: atomic ownership-aware lease API
- `task_to_dict / node_to_dict`: serialization helpers for WUI/API use

Also exports `TaskService` from `openbad.tasks`.

## How to test
```
pytest tests/test_task_service.py -q   # 19 passed
```