### PR TITLE
#343: Implement lease-aware scheduler dispatch loop

### DIFF
--- a/src/openbad/tasks/scheduler.py
+++ b/src/openbad/tasks/scheduler.py
@@ -1,0 +1,143 @@
+"""Lease-aware scheduler dispatch loop for Phase 9 task orchestration.
+
+:class:`TaskScheduler` polls due tasks, acquires leases atomically, and
+dispatches them to a caller-supplied callback.  It respects configured
+quiet-hour windows so that non-urgent work is suppressed during maintenance
+or low-activity periods.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+import time
+from typing import Protocol
+
+from openbad.tasks.lease import LeaseStore
+from openbad.tasks.models import TaskModel, TaskStatus
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class QuietHoursWindow:
+    """A time-of-day window (24-hour clock) during which non-urgent tasks are
+    suppressed.
+
+    ``start_hour`` and ``end_hour`` are both in [0, 23].  An ``end_hour``
+    less than ``start_hour`` denotes an overnight window (e.g. 23–06).
+    """
+
+    start_hour: int
+    end_hour: int
+
+    def is_active(self, hour: int | None = None) -> bool:
+        """Return True if *hour* (local time, 0–23) falls inside this window."""
+        h = hour if hour is not None else time.localtime().tm_hour
+        if self.start_hour <= self.end_hour:
+            return self.start_hour <= h <= self.end_hour
+        # Overnight window
+        return h >= self.start_hour or h <= self.end_hour
+
+
+@dataclasses.dataclass
+class SchedulerConfig:
+    """Runtime configuration for :class:`TaskScheduler`."""
+
+    lease_ttl_seconds: float = 300.0
+    poll_limit: int = 10
+    quiet_hours: list[QuietHoursWindow] = dataclasses.field(default_factory=list)
+
+    def is_quiet_hour(self) -> bool:
+        """Return True if any configured quiet-hours window is currently active."""
+        return any(w.is_active() for w in self.quiet_hours)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch protocol
+# ---------------------------------------------------------------------------
+
+
+class DispatchCallback(Protocol):
+    """Protocol for the callable that handles a dispatched task."""
+
+    def __call__(self, task: TaskModel, lease_id: str) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Scheduler
+# ---------------------------------------------------------------------------
+
+
+class TaskScheduler:
+    """Polls due tasks, acquires leases, and dispatches to a callback.
+
+    Only tasks in ``PENDING`` status with a ``due_at <= now`` (or no ``due_at``)
+    are considered.  Non-urgent dispatch is skipped during quiet hours.
+
+    The scheduler is designed to be called from a heartbeat loop rather than
+    run as a continuous background thread, giving the caller full control over
+    tick frequency and error handling.
+    """
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        worker_id: str,
+        callback: DispatchCallback,
+        config: SchedulerConfig | None = None,
+    ) -> None:
+        self._store = TaskStore(conn)
+        self._leases = LeaseStore(conn)
+        self._worker_id = worker_id
+        self._callback = callback
+        self._config = config or SchedulerConfig()
+
+    # ------------------------------------------------------------------
+
+    def tick(self, *, urgent: bool = False) -> list[str]:
+        """Run one dispatch iteration.
+
+        Parameters
+        ----------
+        urgent:
+            When ``True``, quiet-hours suppression is bypassed.
+
+        Returns
+        -------
+        list[str]
+            The task IDs that were successfully dispatched in this tick.
+        """
+        if not urgent and self._config.is_quiet_hour():
+            return []
+
+        now = time.time()
+        dispatched: list[str] = []
+
+        candidates = self._store.list_tasks(
+            status=TaskStatus.PENDING,
+            limit=self._config.poll_limit,
+        )
+
+        for task in candidates:
+            # Skip tasks that are not yet due
+            if task.due_at is not None and task.due_at > now:
+                continue
+
+            lease = self._leases.acquire(
+                "task",
+                task.task_id,
+                self._worker_id,
+                self._config.lease_ttl_seconds,
+            )
+            if lease is None:
+                # Another worker already holds this task
+                continue
+
+            self._callback(task, lease.lease_id)
+            dispatched.append(task.task_id)
+
+        return dispatched

--- a/tests/test_task_scheduler.py
+++ b/tests/test_task_scheduler.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.models import TaskModel
+from openbad.tasks.scheduler import QuietHoursWindow, SchedulerConfig, TaskScheduler
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def scheduler_and_store(tmp_path: Path):
+    conn = initialize_state_db(tmp_path / "state.db")
+    store = TaskStore(conn)
+    dispatched: list[tuple[str, str]] = []
+
+    def callback(task: TaskModel, lease_id: str) -> None:
+        dispatched.append((task.task_id, lease_id))
+
+    sched = TaskScheduler(conn, "worker-1", callback)
+    return sched, store, dispatched
+
+
+# ---------------------------------------------------------------------------
+# Single dispatch under concurrent wake
+# ---------------------------------------------------------------------------
+
+
+def test_single_dispatch_per_task(scheduler_and_store) -> None:
+    """A task is dispatched exactly once even if tick is called twice."""
+    sched, store, dispatched = scheduler_and_store
+
+    task = TaskModel.new("Due task")
+    store.create_task(task)
+
+    sched.tick()
+    sched.tick()  # second tick: lease still held → no duplicate
+
+    task_ids = [t for t, _ in dispatched]
+    assert task_ids.count(task.task_id) == 1
+
+
+def test_undispatchable_task_not_dispatched_twice_across_workers(
+    tmp_path: Path,
+) -> None:
+    """Two schedulers racing for the same task: only one wins."""
+    conn = initialize_state_db(tmp_path / "state.db")
+    store = TaskStore(conn)
+
+    task = TaskModel.new("Shared task")
+    store.create_task(task)
+
+    wins: list[str] = []
+
+    def make_callback(worker_id: str):
+        def cb(t: TaskModel, _lid: str) -> None:
+            wins.append(worker_id)
+
+        return cb
+
+    sched_a = TaskScheduler(conn, "worker-A", make_callback("A"))
+    sched_b = TaskScheduler(conn, "worker-B", make_callback("B"))
+
+    sched_a.tick()
+    sched_b.tick()
+
+    assert len(wins) == 1  # only one winner
+
+
+# ---------------------------------------------------------------------------
+# Quiet-hours suppression
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_hours_suppresses_non_urgent(tmp_path: Path) -> None:
+    conn = initialize_state_db(tmp_path / "state.db")
+    store = TaskStore(conn)
+    dispatched: list[str] = []
+
+    def callback(task: TaskModel, _lid: str) -> None:
+        dispatched.append(task.task_id)
+
+    task = TaskModel.new("Suppressed task")
+    store.create_task(task)
+
+    # Configure an all-day quiet window (hour 0 to 23)
+    config = SchedulerConfig(quiet_hours=[QuietHoursWindow(0, 23)])
+    sched = TaskScheduler(conn, "worker-1", callback, config)
+
+    result = sched.tick(urgent=False)
+
+    assert result == []
+    assert dispatched == []
+
+
+def test_quiet_hours_bypassed_when_urgent(tmp_path: Path) -> None:
+    conn = initialize_state_db(tmp_path / "state.db")
+    store = TaskStore(conn)
+    dispatched: list[str] = []
+
+    def callback(task: TaskModel, _lid: str) -> None:
+        dispatched.append(task.task_id)
+
+    task = TaskModel.new("Urgent task")
+    store.create_task(task)
+
+    # All-day quiet window
+    config = SchedulerConfig(quiet_hours=[QuietHoursWindow(0, 23)])
+    sched = TaskScheduler(conn, "worker-1", callback, config)
+
+    result = sched.tick(urgent=True)  # bypass quiet hours
+
+    assert len(result) == 1
+    assert dispatched == [task.task_id]
+
+
+def test_quiet_hours_window_overnight() -> None:
+    window = QuietHoursWindow(22, 6)
+    assert window.is_active(23)
+    assert window.is_active(0)
+    assert window.is_active(5)
+    assert not window.is_active(12)
+
+
+def test_quiet_hours_window_daytime() -> None:
+    window = QuietHoursWindow(8, 18)
+    assert window.is_active(12)
+    assert not window.is_active(7)
+    assert not window.is_active(19)
+
+
+# ---------------------------------------------------------------------------
+# Lease prevents duplicate dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_lease_prevents_duplicate_dispatch(tmp_path: Path) -> None:
+    conn = initialize_state_db(tmp_path / "state.db")
+    store = TaskStore(conn)
+    dispatched: list[str] = []
+
+    def callback(task: TaskModel, _lid: str) -> None:
+        dispatched.append(task.task_id)
+
+    task = TaskModel.new("Leased task")
+    store.create_task(task)
+
+    # First scheduler dispatches and holds the lease
+    sched_a = TaskScheduler(conn, "worker-A", callback, SchedulerConfig(lease_ttl_seconds=60))
+    sched_b = TaskScheduler(conn, "worker-B", callback, SchedulerConfig(lease_ttl_seconds=60))
+
+    sched_a.tick()
+    sched_b.tick()  # B cannot acquire the held lease
+
+    assert dispatched.count(task.task_id) == 1
+
+
+def test_not_due_task_skipped(scheduler_and_store) -> None:
+    sched, store, dispatched = scheduler_and_store
+
+    future = time.time() + 3600  # 1 hour from now
+    task = TaskModel.new("Future task", due_at=future)
+    store.create_task(task)
+
+    sched.tick()
+
+    assert dispatched == []
+
+
+def test_due_task_is_dispatched(scheduler_and_store) -> None:
+    sched, store, dispatched = scheduler_and_store
+
+    past = time.time() - 1  # 1 second ago
+    task = TaskModel.new("Past due task", due_at=past)
+    store.create_task(task)
+
+    sched.tick()
+
+    assert len(dispatched) == 1
+    assert dispatched[0][0] == task.task_id


### PR DESCRIPTION
Closes #343

## Summary
- Created `src/openbad/tasks/scheduler.py` with `TaskScheduler`, `SchedulerConfig`, and `QuietHoursWindow`:
  - `TaskScheduler.tick(urgent=False)`: polls PENDING tasks, skips not-yet-due tasks, acquires leases atomically via `BEGIN EXCLUSIVE` (single winner), calls dispatch callback, returns list of dispatched task IDs
  - Quiet-hours suppression via configurable `QuietHoursWindow(start_hour, end_hour)` — supports overnight windows; can be bypassed with `urgent=True`
  - No duplicate dispatch: if a lease is already held, the task is skipped

## How to test
```
pytest tests/test_task_scheduler.py -q   # 9 passed
```