### PR TITLE
#344: Implement deterministic task DAG planner

### DIFF
--- a/src/openbad/tasks/planner.py
+++ b/src/openbad/tasks/planner.py
@@ -1,0 +1,133 @@
+"""Deterministic task DAG planner for Phase 9 task orchestration.
+
+:func:`plan_task` generates a set of :class:`~openbad.tasks.models.NodeModel`
+objects and a list of directed edges that together form a linear-chain DAG for
+a given task.  The shape of the DAG is determined by the task's
+:class:`~openbad.tasks.models.TaskKind` and a mapping of *templates*.
+
+The planner is **deterministic**: every call with the same *task* produces the
+same logical node sequence, using freshly generated UUIDs only for node IDs.
+
+Planner output is persisted immediately via :class:`~openbad.tasks.store.TaskStore`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from openbad.tasks.models import NodeModel, TaskKind, TaskModel
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Node templates
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class NodeTemplate:
+    """Blueprint for a single DAG node."""
+
+    title: str
+    node_type: str
+    max_retries: int = 1
+    reward_program_id: str | None = None
+
+
+# Built-in templates keyed by TaskKind.  Subclasses / callers may supply their
+# own template registry via the ``templates`` parameter of :func:`plan_task`.
+DEFAULT_TEMPLATES: dict[str, list[NodeTemplate]] = {
+    TaskKind.USER_REQUESTED: [
+        NodeTemplate("Clarify", "clarify", max_retries=0),
+        NodeTemplate("Plan", "plan", max_retries=1),
+        NodeTemplate("Execute", "execute", max_retries=2),
+        NodeTemplate("Review", "review", max_retries=0),
+    ],
+    TaskKind.RESEARCH: [
+        NodeTemplate("Gather", "gather", max_retries=2),
+        NodeTemplate("Analyse", "analyse", max_retries=1),
+        NodeTemplate("Summarise", "summarise", max_retries=0),
+    ],
+    TaskKind.SYSTEM: [
+        NodeTemplate("Execute", "execute", max_retries=1),
+    ],
+    TaskKind.SCHEDULED: [
+        NodeTemplate("Execute", "execute", max_retries=1),
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Planner output
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class PlanResult:
+    """The output of :func:`plan_task`."""
+
+    nodes: list[NodeModel]
+    edges: list[tuple[str, str]]  # (from_node_id, to_node_id)
+
+
+# ---------------------------------------------------------------------------
+# Core function
+# ---------------------------------------------------------------------------
+
+
+def plan_task(
+    task: TaskModel,
+    store: TaskStore,
+    *,
+    templates: dict[str, list[NodeTemplate]] | None = None,
+) -> PlanResult:
+    """Generate a DAG for *task* and persist it via *store*.
+
+    Parameters
+    ----------
+    task:
+        The parent task.  Its ``task_id`` and ``kind`` are used to look up
+        the correct template and set node ownership.
+    store:
+        A :class:`~openbad.tasks.store.TaskStore` backed by an open
+        ``sqlite3.Connection``.  All nodes and edges are written here.
+    templates:
+        Optional override for :data:`DEFAULT_TEMPLATES`.
+
+    Returns
+    -------
+    PlanResult
+        Immutable container of the created :class:`~openbad.tasks.models.NodeModel`
+        objects and their edges.
+
+    Raises
+    ------
+    ValueError
+        If no template is registered for ``task.kind``.
+    """
+    registry = templates if templates is not None else DEFAULT_TEMPLATES
+    node_templates = registry.get(task.kind)
+    if node_templates is None:
+        raise ValueError(f"No DAG template registered for task kind {task.kind!r}")
+
+    # Build nodes
+    nodes: list[NodeModel] = []
+    for tmpl in node_templates:
+        node = NodeModel.new(
+            task_id=task.task_id,
+            title=tmpl.title,
+            node_type=tmpl.node_type,
+            max_retries=tmpl.max_retries,
+        )
+        node = dataclasses.replace(node, reward_program_id=tmpl.reward_program_id)
+        store.create_node(node)
+        nodes.append(node)
+
+    # Build linear-chain edges: node[i] → node[i+1]
+    edges: list[tuple[str, str]] = []
+    for i in range(len(nodes) - 1):
+        from_id = nodes[i].node_id
+        to_id = nodes[i + 1].node_id
+        store.create_edge(task.task_id, from_id, to_id)
+        edges.append((from_id, to_id))
+
+    return PlanResult(nodes=nodes, edges=edges)

--- a/src/openbad/tasks/store.py
+++ b/src/openbad/tasks/store.py
@@ -178,6 +178,30 @@ class TaskStore:
             )
         return result
 
+    # ------------------------------------------------------------------
+    # Edges
+    # ------------------------------------------------------------------
+
+    def create_edge(self, task_id: str, from_node_id: str, to_node_id: str) -> None:
+        """Insert a directed edge (from_node_id → to_node_id) for *task_id*.
+
+        Silently does nothing if the edge already exists.
+        """
+        self._conn.execute(
+            "INSERT OR IGNORE INTO task_edges (task_id, from_node_id, to_node_id)"
+            " VALUES (?, ?, ?)",
+            (task_id, from_node_id, to_node_id),
+        )
+        self._conn.commit()
+
+    def list_edges(self, task_id: str) -> list[tuple[str, str]]:
+        """Return all edges for *task_id* as (from_node_id, to_node_id) pairs."""
+        rows = self._conn.execute(
+            "SELECT from_node_id, to_node_id FROM task_edges WHERE task_id = ?",
+            (task_id,),
+        ).fetchall()
+        return [(row["from_node_id"], row["to_node_id"]) for row in rows]
+
 
 # ---------------------------------------------------------------------------
 # Row ↔ model helpers

--- a/tests/test_task_planner.py
+++ b/tests/test_task_planner.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.models import TaskKind, TaskModel
+from openbad.tasks.planner import DEFAULT_TEMPLATES, NodeTemplate, PlanResult, plan_task
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> TaskStore:
+    conn = initialize_state_db(tmp_path / "state.db")
+    return TaskStore(conn)
+
+
+def make_task(kind: TaskKind = TaskKind.USER_REQUESTED) -> TaskModel:
+    return TaskModel.new(f"{kind} task", kind=kind)
+
+
+# ---------------------------------------------------------------------------
+# DAG shape for representative task kind
+# ---------------------------------------------------------------------------
+
+
+def test_user_requested_dag_shape(store: TaskStore) -> None:
+    task = make_task(TaskKind.USER_REQUESTED)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+
+    node_types = [n.node_type for n in result.nodes]
+    assert node_types == ["clarify", "plan", "execute", "review"]
+
+
+def test_research_dag_shape(store: TaskStore) -> None:
+    task = make_task(TaskKind.RESEARCH)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+
+    node_types = [n.node_type for n in result.nodes]
+    assert node_types == ["gather", "analyse", "summarise"]
+
+
+def test_system_dag_shape(store: TaskStore) -> None:
+    task = make_task(TaskKind.SYSTEM)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+
+    assert len(result.nodes) == 1
+    assert result.nodes[0].node_type == "execute"
+    assert result.edges == []
+
+
+def test_scheduled_dag_shape(store: TaskStore) -> None:
+    task = make_task(TaskKind.SCHEDULED)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+
+    assert len(result.nodes) == 1
+    assert result.nodes[0].node_type == "execute"
+
+
+# ---------------------------------------------------------------------------
+# Edge dependency validation
+# ---------------------------------------------------------------------------
+
+
+def test_edges_form_linear_chain(store: TaskStore) -> None:
+    task = make_task(TaskKind.USER_REQUESTED)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+
+    # 4 nodes → 3 edges
+    assert len(result.edges) == len(result.nodes) - 1
+    for i, (from_id, to_id) in enumerate(result.edges):
+        assert from_id == result.nodes[i].node_id
+        assert to_id == result.nodes[i + 1].node_id
+
+
+def test_edges_reference_valid_nodes(store: TaskStore) -> None:
+    task = make_task(TaskKind.RESEARCH)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+    node_ids = {n.node_id for n in result.nodes}
+
+    for from_id, to_id in result.edges:
+        assert from_id in node_ids
+        assert to_id in node_ids
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def test_nodes_persisted(store: TaskStore) -> None:
+    task = make_task(TaskKind.USER_REQUESTED)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+
+    persisted = store.list_nodes(task.task_id)
+    assert len(persisted) == len(result.nodes)
+    assert {n.node_id for n in persisted} == {n.node_id for n in result.nodes}
+
+
+def test_edges_persisted(store: TaskStore) -> None:
+    task = make_task(TaskKind.USER_REQUESTED)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+
+    persisted_edges = store.list_edges(task.task_id)
+    assert set(persisted_edges) == set(result.edges)
+
+
+def test_plan_result_is_frozen(store: TaskStore) -> None:
+    task = make_task(TaskKind.SYSTEM)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+
+    assert isinstance(result, PlanResult)
+    with pytest.raises((TypeError, AttributeError)):
+        result.nodes = []  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Retry and reward fields
+# ---------------------------------------------------------------------------
+
+
+def test_max_retries_from_template(store: TaskStore) -> None:
+    task = make_task(TaskKind.USER_REQUESTED)
+    store.create_task(task)
+
+    result = plan_task(task, store)
+
+    # Matches DEFAULT_TEMPLATES[USER_REQUESTED]
+    expected_retries = [t.max_retries for t in DEFAULT_TEMPLATES[TaskKind.USER_REQUESTED]]
+    actual_retries = [n.max_retries for n in result.nodes]
+    assert actual_retries == expected_retries
+
+
+def test_reward_program_id_from_template(store: TaskStore) -> None:
+    custom = {
+        TaskKind.SYSTEM: [
+            NodeTemplate("Execute", "execute", max_retries=1, reward_program_id="prog-1"),
+        ]
+    }
+    task = make_task(TaskKind.SYSTEM)
+    store.create_task(task)
+
+    result = plan_task(task, store, templates=custom)
+
+    assert result.nodes[0].reward_program_id == "prog-1"
+
+
+# ---------------------------------------------------------------------------
+# Unknown kind raises
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_kind_raises(store: TaskStore) -> None:
+    task = make_task(TaskKind.USER_REQUESTED)
+    store.create_task(task)
+
+    with pytest.raises(ValueError, match="No DAG template"):
+        plan_task(task, store, templates={})
+
+
+# ---------------------------------------------------------------------------
+# Custom templates
+# ---------------------------------------------------------------------------
+
+
+def test_custom_template_overrides_default(store: TaskStore) -> None:
+    custom = {
+        TaskKind.USER_REQUESTED: [
+            NodeTemplate("A", "step-a"),
+            NodeTemplate("B", "step-b"),
+        ]
+    }
+    task = make_task(TaskKind.USER_REQUESTED)
+    store.create_task(task)
+
+    result = plan_task(task, store, templates=custom)
+
+    assert [n.node_type for n in result.nodes] == ["step-a", "step-b"]
+    assert len(result.edges) == 1


### PR DESCRIPTION
Closes #344

## Summary
- Added `create_edge`/`list_edges` to `TaskStore`
- Created `src/openbad/tasks/planner.py` with `NodeTemplate`, `DEFAULT_TEMPLATES`, `PlanResult`, and `plan_task()`:
  - Deterministic linear-chain DAG per `TaskKind` template
  - Emits nodes with retry counts and optional reward program references
  - Persists nodes + edges immediately via `TaskStore`
  - Raises `ValueError` for unregistered task kinds
- 13 tests covering DAG shape, edge validation, persistence, retry/reward fields, custom templates

## How to test
```
pytest tests/test_task_planner.py -q  # 13 passed
```