### PR TITLE
#345: Add node executor run lifecycle persistence

### DIFF
--- a/src/openbad/tasks/executor.py
+++ b/src/openbad/tasks/executor.py
@@ -1,0 +1,262 @@
+"""Node executor run lifecycle persistence for Phase 9 task orchestration.
+
+:class:`NodeExecutor` records the start and finish of each node execution
+attempt as a ``task_runs`` row, transitions the owning node (and task) through
+the correct lifecycle state, and persists structured failure summaries when a
+run ends in error.
+
+Design
+------
+* ``start_run()`` – inserts a ``task_runs`` row with ``status='running'`` and
+  transitions the node to ``NodeStatus.RUNNING``.
+* ``finish_run()`` – marks the run ``done`` or ``failed``, sets ``finished_at``,
+  transitions the node accordingly, and (on failure) appends a
+  ``node_failed`` event with a structured summary payload.
+
+Failure summaries are written to ``task_events`` so they are queryable
+alongside all other task lifecycle events.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+import time
+import uuid
+
+from openbad.tasks.models import NodeStatus, RunStatus, TaskStatus
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Run record
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class RunRecord:
+    """In-memory representation of a ``task_runs`` row."""
+
+    run_id: str
+    task_id: str
+    node_id: str | None
+    status: RunStatus
+    actor: str
+    routing_provider: str | None
+    routing_model: str | None
+    started_at: float
+    finished_at: float | None = None
+
+    def to_dict(self) -> dict:
+        d = dataclasses.asdict(self)
+        d["status"] = self.status.value
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict) -> RunRecord:
+        d = dict(data)
+        d["status"] = RunStatus(d["status"])
+        return cls(**d)
+
+
+# ---------------------------------------------------------------------------
+# Executor
+# ---------------------------------------------------------------------------
+
+
+class NodeExecutor:
+    """Manages ``task_runs`` lifecycle and propagates state to nodes/tasks.
+
+    Parameters
+    ----------
+    conn:
+        An open ``sqlite3.Connection`` to the state database.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._store = TaskStore(conn)
+
+    # ------------------------------------------------------------------
+
+    def start_run(
+        self,
+        task_id: str,
+        *,
+        node_id: str | None = None,
+        actor: str = "system",
+        routing_provider: str | None = None,
+        routing_model: str | None = None,
+    ) -> RunRecord:
+        """Begin a new execution run for *task_id* / *node_id*.
+
+        Inserts a ``task_runs`` row and transitions the node (if given) to
+        ``RUNNING`` and the task to ``RUNNING``.
+
+        Returns
+        -------
+        RunRecord
+            The newly created run record.
+        """
+        run_id = str(uuid.uuid4())
+        now = time.time()
+
+        self._conn.execute(
+            "INSERT INTO task_runs (run_id, task_id, node_id, status, actor,"
+            " routing_provider, routing_model, started_at)"
+            " VALUES (?, ?, ?, 'running', ?, ?, ?, ?)",
+            (run_id, task_id, node_id, actor, routing_provider, routing_model, now),
+        )
+        self._conn.commit()
+
+        # Transition task → RUNNING if it's currently PENDING
+        task = self._store.get_task(task_id)
+        if task is not None and task.status == TaskStatus.PENDING:
+            self._store.update_task_status(task_id, TaskStatus.RUNNING)
+
+        # Transition node → RUNNING
+        if node_id is not None:
+            node = self._store.get_node(node_id)
+            if node is not None and node.status == NodeStatus.PENDING:
+                self._store.update_node_status(node_id, NodeStatus.RUNNING)
+
+        return RunRecord(
+            run_id=run_id,
+            task_id=task_id,
+            node_id=node_id,
+            status=RunStatus.RUNNING,
+            actor=actor,
+            routing_provider=routing_provider,
+            routing_model=routing_model,
+            started_at=now,
+        )
+
+    def finish_run(
+        self,
+        run_id: str,
+        *,
+        success: bool = True,
+        failure_summary: str | None = None,
+        failure_details: dict | None = None,
+    ) -> RunRecord:
+        """Complete an execution run.
+
+        Parameters
+        ----------
+        run_id:
+            The ID returned by :meth:`start_run`.
+        success:
+            ``True`` → run is marked ``done``; ``False`` → ``failed``.
+        failure_summary:
+            Short human-readable reason for the failure.  Only meaningful when
+            ``success=False``.
+        failure_details:
+            Optional machine-readable failure data. Stored in the
+            ``node_failed`` event payload.
+
+        Returns
+        -------
+        RunRecord
+            The updated run record.
+
+        Raises
+        ------
+        ValueError
+            If no run with *run_id* exists.
+        """
+        row = self._conn.execute(
+            "SELECT run_id, task_id, node_id, status, actor, routing_provider,"
+            " routing_model, started_at, finished_at FROM task_runs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"No run found: {run_id!r}")
+
+        new_status = RunStatus.DONE if success else RunStatus.FAILED
+        now = time.time()
+
+        self._conn.execute(
+            "UPDATE task_runs SET status = ?, finished_at = ? WHERE run_id = ?",
+            (new_status.value, now, run_id),
+        )
+        self._conn.commit()
+
+        task_id: str = row["task_id"]
+        node_id: str | None = row["node_id"]
+
+        # Transition node
+        if node_id is not None:
+            next_node_status = NodeStatus.DONE if success else NodeStatus.FAILED
+            node = self._store.get_node(node_id)
+            if node is not None and node.status == NodeStatus.RUNNING:
+                self._store.update_node_status(node_id, next_node_status)
+
+        # Persist failure summary as a task event
+        if not success:
+
+            payload = {"run_id": run_id, "node_id": node_id}
+            if failure_summary:
+                payload["summary"] = failure_summary
+            if failure_details:
+                payload.update(failure_details)
+            self._store.append_event(
+                task_id,
+                "node_failed",
+                node_id=node_id,
+                payload=payload,
+            )
+
+        return RunRecord(
+            run_id=run_id,
+            task_id=task_id,
+            node_id=node_id,
+            status=new_status,
+            actor=row["actor"],
+            routing_provider=row["routing_provider"],
+            routing_model=row["routing_model"],
+            started_at=row["started_at"],
+            finished_at=now,
+        )
+
+    def get_run(self, run_id: str) -> RunRecord | None:
+        """Return a :class:`RunRecord` by ID, or ``None`` if not found."""
+        row = self._conn.execute(
+            "SELECT run_id, task_id, node_id, status, actor, routing_provider,"
+            " routing_model, started_at, finished_at FROM task_runs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return RunRecord(
+            run_id=row["run_id"],
+            task_id=row["task_id"],
+            node_id=row["node_id"],
+            status=RunStatus(row["status"]),
+            actor=row["actor"],
+            routing_provider=row["routing_provider"],
+            routing_model=row["routing_model"],
+            started_at=row["started_at"],
+            finished_at=row["finished_at"],
+        )
+
+    def list_runs(self, task_id: str) -> list[RunRecord]:
+        """Return all runs for *task_id* ordered by ``started_at``."""
+        rows = self._conn.execute(
+            "SELECT run_id, task_id, node_id, status, actor, routing_provider,"
+            " routing_model, started_at, finished_at"
+            " FROM task_runs WHERE task_id = ? ORDER BY started_at ASC",
+            (task_id,),
+        ).fetchall()
+        return [
+            RunRecord(
+                run_id=r["run_id"],
+                task_id=r["task_id"],
+                node_id=r["node_id"],
+                status=RunStatus(r["status"]),
+                actor=r["actor"],
+                routing_provider=r["routing_provider"],
+                routing_model=r["routing_model"],
+                started_at=r["started_at"],
+                finished_at=r["finished_at"],
+            )
+            for r in rows
+        ]

--- a/tests/test_node_executor.py
+++ b/tests/test_node_executor.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.executor import NodeExecutor, RunRecord
+from openbad.tasks.models import NodeModel, NodeStatus, RunStatus, TaskModel, TaskStatus
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    return initialize_state_db(tmp_path / "state.db")
+
+
+@pytest.fixture()
+def executor(db):
+    return NodeExecutor(db)
+
+
+@pytest.fixture()
+def store(db):
+    return TaskStore(db)
+
+
+def make_task_and_node(store: TaskStore) -> tuple[TaskModel, NodeModel]:
+    task = TaskModel.new("Test task")
+    store.create_task(task)
+    node = NodeModel.new(task.task_id, "Test node")
+    store.create_node(node)
+    return task, node
+
+
+# ---------------------------------------------------------------------------
+# Run lifecycle transitions
+# ---------------------------------------------------------------------------
+
+
+def test_start_run_creates_record(executor: NodeExecutor, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+
+    run = executor.start_run(task.task_id, node_id=node.node_id)
+
+    assert run.run_id is not None
+    assert run.task_id == task.task_id
+    assert run.node_id == node.node_id
+    assert run.status == RunStatus.RUNNING
+    assert run.started_at > 0
+
+
+def test_start_run_transitions_task_to_running(executor: NodeExecutor, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+
+    executor.start_run(task.task_id, node_id=node.node_id)
+
+    updated_task = store.get_task(task.task_id)
+    assert updated_task is not None
+    assert updated_task.status == TaskStatus.RUNNING
+
+
+def test_start_run_transitions_node_to_running(executor: NodeExecutor, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+
+    executor.start_run(task.task_id, node_id=node.node_id)
+
+    updated_node = store.get_node(node.node_id)
+    assert updated_node is not None
+    assert updated_node.status == NodeStatus.RUNNING
+
+
+def test_finish_run_success(executor: NodeExecutor, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    run = executor.start_run(task.task_id, node_id=node.node_id)
+
+    result = executor.finish_run(run.run_id, success=True)
+
+    assert result.status == RunStatus.DONE
+    assert result.finished_at is not None
+
+
+def test_finish_run_success_transitions_node_done(
+    executor: NodeExecutor, store: TaskStore
+) -> None:
+    task, node = make_task_and_node(store)
+    run = executor.start_run(task.task_id, node_id=node.node_id)
+
+    executor.finish_run(run.run_id, success=True)
+
+    updated = store.get_node(node.node_id)
+    assert updated is not None
+    assert updated.status == NodeStatus.DONE
+
+
+def test_finish_run_failure(executor: NodeExecutor, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    run = executor.start_run(task.task_id, node_id=node.node_id)
+
+    result = executor.finish_run(run.run_id, success=False, failure_summary="timed out")
+
+    assert result.status == RunStatus.FAILED
+    assert result.finished_at is not None
+
+
+def test_finish_run_failure_transitions_node_failed(
+    executor: NodeExecutor, store: TaskStore
+) -> None:
+    task, node = make_task_and_node(store)
+    run = executor.start_run(task.task_id, node_id=node.node_id)
+
+    executor.finish_run(run.run_id, success=False)
+
+    updated = store.get_node(node.node_id)
+    assert updated is not None
+    assert updated.status == NodeStatus.FAILED
+
+
+def test_finish_run_unknown_id_raises(executor: NodeExecutor) -> None:
+    with pytest.raises(ValueError, match="No run found"):
+        executor.finish_run("no-such-run")
+
+
+# ---------------------------------------------------------------------------
+# Failure summary persistence
+# ---------------------------------------------------------------------------
+
+
+def test_failure_summary_written_as_event(executor: NodeExecutor, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    run = executor.start_run(task.task_id, node_id=node.node_id)
+
+    executor.finish_run(run.run_id, success=False, failure_summary="quota exceeded")
+
+    events = store.list_events(task.task_id)
+    failed_events = [e for e in events if e["event_type"] == "node_failed"]
+    assert len(failed_events) == 1
+    assert failed_events[0]["payload"]["summary"] == "quota exceeded"
+
+
+def test_failure_details_in_event_payload(executor: NodeExecutor, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    run = executor.start_run(task.task_id, node_id=node.node_id)
+
+    executor.finish_run(
+        run.run_id,
+        success=False,
+        failure_summary="error",
+        failure_details={"code": 500, "retries": 3},
+    )
+
+    events = store.list_events(task.task_id)
+    payload = events[-1]["payload"]
+    assert payload["code"] == 500
+    assert payload["retries"] == 3
+
+
+def test_no_failure_event_on_success(executor: NodeExecutor, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    run = executor.start_run(task.task_id, node_id=node.node_id)
+
+    executor.finish_run(run.run_id, success=True)
+
+    events = store.list_events(task.task_id)
+    failed_events = [e for e in events if e["event_type"] == "node_failed"]
+    assert failed_events == []
+
+
+# ---------------------------------------------------------------------------
+# Run record retrieval
+# ---------------------------------------------------------------------------
+
+
+def test_get_run_returns_record(executor: NodeExecutor, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    run = executor.start_run(task.task_id, node_id=node.node_id)
+
+    fetched = executor.get_run(run.run_id)
+
+    assert fetched is not None
+    assert fetched.run_id == run.run_id
+    assert fetched.status == RunStatus.RUNNING
+
+
+def test_get_run_unknown_returns_none(executor: NodeExecutor) -> None:
+    assert executor.get_run("missing") is None
+
+
+def test_list_runs_ordered_by_start(executor: NodeExecutor, store: TaskStore) -> None:
+    task, _ = make_task_and_node(store)
+
+    r1 = executor.start_run(task.task_id)
+    r2 = executor.start_run(task.task_id)
+
+    runs = executor.list_runs(task.task_id)
+    assert len(runs) == 2
+    assert runs[0].run_id == r1.run_id
+    assert runs[1].run_id == r2.run_id
+
+
+def test_run_record_to_dict_round_trip() -> None:
+    r = RunRecord(
+        run_id="r1",
+        task_id="t1",
+        node_id="n1",
+        status=RunStatus.DONE,
+        actor="system",
+        routing_provider=None,
+        routing_model=None,
+        started_at=1.0,
+        finished_at=2.0,
+    )
+    assert RunRecord.from_dict(r.to_dict()) == r
+
+
+def test_start_run_without_node(executor: NodeExecutor, store: TaskStore) -> None:
+    task = TaskModel.new("Task only")
+    store.create_task(task)
+
+    run = executor.start_run(task.task_id, actor="cron")
+
+    assert run.node_id is None
+    assert run.actor == "cron"
+    assert run.status == RunStatus.RUNNING


### PR DESCRIPTION
Closes #345

## Summary
- Created `src/openbad/tasks/executor.py` with:
  - `RunRecord` dataclass (to_dict/from_dict round-trip)
  - `NodeExecutor`: start_run, finish_run, get_run, list_runs
  - `start_run` inserts task_runs row, transitions PENDING task → RUNNING, PENDING node → RUNNING
  - `finish_run` updates status/finished_at, transitions node to DONE/FAILED, persists structured failure summaries as `node_failed` task_events

## How to test
```
pytest tests/test_node_executor.py -q  # 16 passed
```