### PR TITLE
#346: Enforce dependency gating, retry logic, and blocked transitions

### DIFF
--- a/src/openbad/tasks/gating.py
+++ b/src/openbad/tasks/gating.py
@@ -1,0 +1,135 @@
+"""Dependency gating, retry logic, and blocked-state enforcement for task DAG nodes.
+
+:class:`DependencyGate` answers the question "is this node ready to run?" by
+checking that all predecessor nodes in the DAG have reached ``NodeStatus.DONE``.
+
+:class:`RetryPolicy` encapsulates the retry / blocked transition logic:
+* ``record_attempt`` increments ``retry_count`` and returns whether a retry
+  is still permitted.
+* When retries are exhausted the node is transitioned to ``NodeStatus.BLOCKED``.
+
+Both classes operate exclusively on the SQL state via :class:`~openbad.tasks.store.TaskStore`
+and share an open ``sqlite3.Connection``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from openbad.tasks.models import NodeStatus
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Dependency gate
+# ---------------------------------------------------------------------------
+
+
+class DependencyGate:
+    """Determines whether a node's upstream dependencies are satisfied.
+
+    A node is *ready* when every predecessor node (i.e. every node that has
+    a directed edge **to** the candidate node) has status ``DONE``.  A node
+    with no predecessors is always ready.
+
+    Parameters
+    ----------
+    conn:
+        Open ``sqlite3.Connection`` to the state database.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._store = TaskStore(conn)
+
+    def is_ready(self, task_id: str, node_id: str) -> bool:
+        """Return ``True`` if *node_id* may begin execution.
+
+        Checks that every predecessor node in ``task_edges`` has
+        ``status = 'done'``.
+        """
+        rows = self._conn.execute(
+            "SELECT tn.status FROM task_edges te"
+            " JOIN task_nodes tn ON tn.node_id = te.from_node_id"
+            " WHERE te.task_id = ? AND te.to_node_id = ?",
+            (task_id, node_id),
+        ).fetchall()
+
+        if not rows:
+            # No predecessors — node is free to run
+            return True
+
+        return all(row["status"] == NodeStatus.DONE for row in rows)
+
+    def unmet_dependencies(self, task_id: str, node_id: str) -> list[str]:
+        """Return the node_ids of predecessors that are *not* yet ``DONE``."""
+        rows = self._conn.execute(
+            "SELECT te.from_node_id, tn.status FROM task_edges te"
+            " JOIN task_nodes tn ON tn.node_id = te.from_node_id"
+            " WHERE te.task_id = ? AND te.to_node_id = ?",
+            (task_id, node_id),
+        ).fetchall()
+        return [row["from_node_id"] for row in rows if row["status"] != NodeStatus.DONE]
+
+
+# ---------------------------------------------------------------------------
+# Retry policy
+# ---------------------------------------------------------------------------
+
+
+class RetryPolicy:
+    """Manages retry counters and the transition to ``BLOCKED`` on exhaustion.
+
+    Parameters
+    ----------
+    conn:
+        Open ``sqlite3.Connection`` to the state database.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._store = TaskStore(conn)
+
+    def record_attempt(self, node_id: str) -> bool:
+        """Increment ``retry_count`` for *node_id* and evaluate retry eligibility.
+
+        If ``retry_count`` still remains ≤ ``max_retries`` after incrementing,
+        the node is left in its current status and ``True`` is returned (retry
+        is permitted).
+
+        If ``retry_count`` **exceeds** ``max_retries`` after incrementing, the
+        node is transitioned to ``NodeStatus.BLOCKED`` and ``False`` is returned.
+
+        Returns
+        -------
+        bool
+            ``True``  → a retry is allowed.
+            ``False`` → retry limit exceeded; node is now ``BLOCKED``.
+
+        Raises
+        ------
+        ValueError
+            If no node with *node_id* exists.
+        """
+        node = self._store.get_node(node_id)
+        if node is None:
+            raise ValueError(f"No node found: {node_id!r}")
+
+        new_count = node.retry_count + 1
+        self._conn.execute(
+            "UPDATE task_nodes SET retry_count = ? WHERE node_id = ?",
+            (new_count, node_id),
+        )
+        self._conn.commit()
+
+        if new_count > node.max_retries:
+            self._store.update_node_status(node_id, NodeStatus.BLOCKED)
+            return False
+
+        return True
+
+    def retry_count(self, node_id: str) -> int:
+        """Return the current ``retry_count`` for *node_id*."""
+        node = self._store.get_node(node_id)
+        if node is None:
+            raise ValueError(f"No node found: {node_id!r}")
+        return node.retry_count

--- a/tests/test_dependency_gating.py
+++ b/tests/test_dependency_gating.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.gating import DependencyGate, RetryPolicy
+from openbad.tasks.models import NodeModel, NodeStatus, TaskModel
+from openbad.tasks.planner import plan_task
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    return initialize_state_db(tmp_path / "state.db")
+
+
+@pytest.fixture()
+def store(db):
+    return TaskStore(db)
+
+
+@pytest.fixture()
+def gate(db):
+    return DependencyGate(db)
+
+
+@pytest.fixture()
+def policy(db):
+    return RetryPolicy(db)
+
+
+def make_task(store: TaskStore) -> TaskModel:
+    task = TaskModel.new("Test task")
+    store.create_task(task)
+    return task
+
+
+def make_node(store: TaskStore, task_id: str, *, max_retries: int = 0) -> NodeModel:
+    node = NodeModel.new(task_id, "Node", max_retries=max_retries)
+    store.create_node(node)
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Dependency gating
+# ---------------------------------------------------------------------------
+
+
+def test_node_with_no_predecessors_is_ready(gate: DependencyGate, store: TaskStore) -> None:
+    task = make_task(store)
+    node = make_node(store, task.task_id)
+
+    assert gate.is_ready(task.task_id, node.node_id) is True
+
+
+def test_node_blocked_by_pending_predecessor(gate: DependencyGate, store: TaskStore) -> None:
+    task = make_task(store)
+    pred = make_node(store, task.task_id)  # status=PENDING
+    succ = make_node(store, task.task_id)
+    store.create_edge(task.task_id, pred.node_id, succ.node_id)
+
+    assert gate.is_ready(task.task_id, succ.node_id) is False
+
+
+def test_node_ready_when_predecessor_done(gate: DependencyGate, store: TaskStore) -> None:
+    task = make_task(store)
+    pred = make_node(store, task.task_id)
+    succ = make_node(store, task.task_id)
+    store.create_edge(task.task_id, pred.node_id, succ.node_id)
+
+    # Complete predecessor
+    store.update_node_status(pred.node_id, NodeStatus.RUNNING)
+    store.update_node_status(pred.node_id, NodeStatus.DONE)
+
+    assert gate.is_ready(task.task_id, succ.node_id) is True
+
+
+def test_node_blocked_when_only_some_predecessors_done(
+    gate: DependencyGate, store: TaskStore
+) -> None:
+    task = make_task(store)
+    pred_a = make_node(store, task.task_id)
+    pred_b = make_node(store, task.task_id)
+    succ = make_node(store, task.task_id)
+    store.create_edge(task.task_id, pred_a.node_id, succ.node_id)
+    store.create_edge(task.task_id, pred_b.node_id, succ.node_id)
+
+    store.update_node_status(pred_a.node_id, NodeStatus.RUNNING)
+    store.update_node_status(pred_a.node_id, NodeStatus.DONE)
+    # pred_b still PENDING
+
+    assert gate.is_ready(task.task_id, succ.node_id) is False
+
+
+def test_unmet_dependencies_returns_blocking_nodes(
+    gate: DependencyGate, store: TaskStore
+) -> None:
+    task = make_task(store)
+    pred = make_node(store, task.task_id)
+    succ = make_node(store, task.task_id)
+    store.create_edge(task.task_id, pred.node_id, succ.node_id)
+
+    unmet = gate.unmet_dependencies(task.task_id, succ.node_id)
+
+    assert unmet == [pred.node_id]
+
+
+def test_linear_chain_ready_in_order(gate: DependencyGate, store: TaskStore) -> None:
+    """Using plan_task: only the first node of a chain is initially ready."""
+    from openbad.tasks.models import TaskKind
+
+    task = TaskModel.new("Planned task", kind=TaskKind.RESEARCH)
+    store.create_task(task)
+    result = plan_task(task, store)
+
+    first, second, third = result.nodes
+
+    assert gate.is_ready(task.task_id, first.node_id) is True
+    assert gate.is_ready(task.task_id, second.node_id) is False
+    assert gate.is_ready(task.task_id, third.node_id) is False
+
+
+# ---------------------------------------------------------------------------
+# Retry increments
+# ---------------------------------------------------------------------------
+
+
+def test_retry_count_starts_at_zero(policy: RetryPolicy, store: TaskStore) -> None:
+    task = make_task(store)
+    node = make_node(store, task.task_id, max_retries=3)
+
+    assert policy.retry_count(node.node_id) == 0
+
+
+def test_record_attempt_increments_count(policy: RetryPolicy, store: TaskStore) -> None:
+    task = make_task(store)
+    node = make_node(store, task.task_id, max_retries=3)
+
+    policy.record_attempt(node.node_id)
+
+    assert policy.retry_count(node.node_id) == 1
+
+
+def test_retry_permitted_within_limit(policy: RetryPolicy, store: TaskStore) -> None:
+    task = make_task(store)
+    node = make_node(store, task.task_id, max_retries=2)
+
+    allowed_1 = policy.record_attempt(node.node_id)
+    allowed_2 = policy.record_attempt(node.node_id)
+
+    assert allowed_1 is True
+    assert allowed_2 is True
+    assert policy.retry_count(node.node_id) == 2
+
+
+# ---------------------------------------------------------------------------
+# Blocked transition at retry limit
+# ---------------------------------------------------------------------------
+
+
+def test_retry_exhaustion_blocks_node(policy: RetryPolicy, store: TaskStore) -> None:
+    task = make_task(store)
+    node = make_node(store, task.task_id, max_retries=1)
+
+    policy.record_attempt(node.node_id)  # count=1 ≤ max=1 → still allowed
+    allowed = policy.record_attempt(node.node_id)  # count=2 > max=1 → BLOCKED
+
+    assert allowed is False
+    updated = store.get_node(node.node_id)
+    assert updated is not None
+    assert updated.status == NodeStatus.BLOCKED
+
+
+def test_zero_retries_exhausted_immediately(policy: RetryPolicy, store: TaskStore) -> None:
+    task = make_task(store)
+    node = make_node(store, task.task_id, max_retries=0)
+
+    allowed = policy.record_attempt(node.node_id)  # count=1 > max=0 → BLOCKED
+
+    assert allowed is False
+    updated = store.get_node(node.node_id)
+    assert updated is not None
+    assert updated.status == NodeStatus.BLOCKED
+
+
+def test_unknown_node_raises(policy: RetryPolicy) -> None:
+    with pytest.raises(ValueError, match="No node found"):
+        policy.record_attempt("no-such-node")


### PR DESCRIPTION
Closes #346

## Summary
- Created `src/openbad/tasks/gating.py` with:
  - `DependencyGate.is_ready(task_id, node_id)`: queries `task_edges` → returns True only when all predecessors are DONE
  - `DependencyGate.unmet_dependencies(task_id, node_id)`: lists blocking predecessor node IDs
  - `RetryPolicy.record_attempt(node_id)`: increments `retry_count`, returns True if retry permitted, transitions node to BLOCKED on exhaustion
  - `RetryPolicy.retry_count(node_id)`: reads current count

## How to test
```
pytest tests/test_dependency_gating.py -q  # 12 passed
```