### PR TITLE
#347: Add task note schema and persistence APIs

### DIFF
--- a/src/openbad/tasks/notes.py
+++ b/src/openbad/tasks/notes.py
@@ -1,0 +1,152 @@
+"""Task note persistence APIs for Phase 9 context capture.
+
+:class:`NoteStore` persists and queries structured notes linked to tasks and
+optionally to individual nodes.  Each note carries:
+
+* ``note_text`` — free-form prose or a log entry.
+* ``summary_json`` — optional structured payload containing extracted facts,
+  implications, and artifact references.
+
+Notes are append-only; they are never updated in place.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import sqlite3
+import time
+
+# ---------------------------------------------------------------------------
+# Note model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class TaskNote:
+    """In-memory representation of a ``task_notes`` row."""
+
+    note_id: int | None
+    task_id: str
+    note_text: str
+    created_at: float
+    summary: dict = dataclasses.field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        d = dataclasses.asdict(self)
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict) -> TaskNote:
+        return cls(**data)
+
+
+# ---------------------------------------------------------------------------
+# NoteStore
+# ---------------------------------------------------------------------------
+
+
+class NoteStore:
+    """Append-only note storage keyed by task_id.
+
+    Parameters
+    ----------
+    conn:
+        Open ``sqlite3.Connection`` to the state database.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def add_note(
+        self,
+        task_id: str,
+        note_text: str,
+        *,
+        facts: list[str] | None = None,
+        implications: list[str] | None = None,
+        artifact_refs: list[str] | None = None,
+        extra: dict | None = None,
+    ) -> TaskNote:
+        """Append a note for *task_id*.
+
+        Parameters
+        ----------
+        task_id:
+            The owning task.
+        note_text:
+            Human-readable prose for the note.
+        facts:
+            Extracted facts (list of strings).
+        implications:
+            Derived implications (list of strings).
+        artifact_refs:
+            Paths or URIs to associated artifacts.
+        extra:
+            Additional structured fields merged into ``summary_json``.
+
+        Returns
+        -------
+        TaskNote
+            The freshly inserted note (with ``note_id`` populated).
+        """
+        summary: dict = {}
+        if facts is not None:
+            summary["facts"] = facts
+        if implications is not None:
+            summary["implications"] = implications
+        if artifact_refs is not None:
+            summary["artifact_refs"] = artifact_refs
+        if extra:
+            summary.update(extra)
+
+        now = time.time()
+        cursor = self._conn.execute(
+            "INSERT INTO task_notes (task_id, created_at, note_text, summary_json)"
+            " VALUES (?, ?, ?, ?)",
+            (task_id, now, note_text, json.dumps(summary)),
+        )
+        self._conn.commit()
+
+        return TaskNote(
+            note_id=cursor.lastrowid,
+            task_id=task_id,
+            note_text=note_text,
+            created_at=now,
+            summary=summary,
+        )
+
+    def list_notes(self, task_id: str) -> list[TaskNote]:
+        """Return all notes for *task_id* in insertion order."""
+        rows = self._conn.execute(
+            "SELECT note_id, task_id, note_text, summary_json, created_at"
+            " FROM task_notes WHERE task_id = ? ORDER BY note_id ASC",
+            (task_id,),
+        ).fetchall()
+        return [
+            TaskNote(
+                note_id=row["note_id"],
+                task_id=row["task_id"],
+                note_text=row["note_text"],
+                created_at=row["created_at"],
+                summary=json.loads(row["summary_json"]) if row["summary_json"] else {},
+            )
+            for row in rows
+        ]
+
+    def get_note(self, note_id: int) -> TaskNote | None:
+        """Return a single note by primary key, or ``None``."""
+        row = self._conn.execute(
+            "SELECT note_id, task_id, note_text, summary_json, created_at"
+            " FROM task_notes WHERE note_id = ?",
+            (note_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return TaskNote(
+            note_id=row["note_id"],
+            task_id=row["task_id"],
+            note_text=row["note_text"],
+            created_at=row["created_at"],
+            summary=json.loads(row["summary_json"]) if row["summary_json"] else {},
+        )

--- a/tests/test_task_notes.py
+++ b/tests/test_task_notes.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.models import TaskModel
+from openbad.tasks.notes import NoteStore, TaskNote
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    return initialize_state_db(tmp_path / "state.db")
+
+
+@pytest.fixture()
+def note_store(db) -> NoteStore:
+    return NoteStore(db)
+
+
+@pytest.fixture()
+def task_id(db) -> str:
+    """Insert a real task and return its ID (satisfies FK constraint)."""
+    store = TaskStore(db)
+    task = TaskModel.new("Note test task")
+    store.create_task(task)
+    return task.task_id
+
+
+# ---------------------------------------------------------------------------
+# Note write / read
+# ---------------------------------------------------------------------------
+
+
+def test_add_note_returns_note_with_id(note_store: NoteStore, task_id: str) -> None:
+    note = note_store.add_note(task_id, "First note")
+
+    assert note.note_id is not None
+    assert note.note_text == "First note"
+    assert note.task_id == task_id
+
+
+def test_add_note_with_all_structured_fields(note_store: NoteStore, task_id: str) -> None:
+    note = note_store.add_note(
+        task_id,
+        "Rich note",
+        facts=["f1", "f2"],
+        implications=["i1"],
+        artifact_refs=["data/tasks/task-1/out.json"],
+        extra={"custom_key": 42},
+    )
+
+    assert note.summary["facts"] == ["f1", "f2"]
+    assert note.summary["implications"] == ["i1"]
+    assert note.summary["artifact_refs"] == ["data/tasks/task-1/out.json"]
+    assert note.summary["custom_key"] == 42
+
+
+def test_note_persists_across_get(note_store: NoteStore, task_id: str) -> None:
+    note = note_store.add_note(task_id, "Persisted", facts=["x"])
+
+    fetched = note_store.get_note(note.note_id)  # type: ignore[arg-type]
+
+    assert fetched is not None
+    assert fetched.note_id == note.note_id
+    assert fetched.note_text == "Persisted"
+    assert fetched.summary["facts"] == ["x"]
+
+
+def test_get_note_unknown_returns_none(note_store: NoteStore) -> None:
+    assert note_store.get_note(9999) is None
+
+
+# ---------------------------------------------------------------------------
+# Note listing / filtering
+# ---------------------------------------------------------------------------
+
+
+def test_list_notes_returns_all_in_order(note_store: NoteStore, task_id: str) -> None:
+    note_store.add_note(task_id, "Note A")
+    note_store.add_note(task_id, "Note B")
+    note_store.add_note(task_id, "Note C")
+
+    notes = note_store.list_notes(task_id)
+
+    assert len(notes) == 3
+    assert [n.note_text for n in notes] == ["Note A", "Note B", "Note C"]
+
+
+def test_list_notes_empty_for_unknown_task(note_store: NoteStore) -> None:
+    assert note_store.list_notes("no-task") == []
+
+
+def test_list_notes_scoped_to_task(db, note_store: NoteStore) -> None:
+    store = TaskStore(db)
+    task_a = TaskModel.new("Task A")
+    task_b = TaskModel.new("Task B")
+    store.create_task(task_a)
+    store.create_task(task_b)
+
+    note_store.add_note(task_a.task_id, "A note")
+    note_store.add_note(task_b.task_id, "B note")
+
+    a_notes = note_store.list_notes(task_a.task_id)
+    b_notes = note_store.list_notes(task_b.task_id)
+
+    assert len(a_notes) == 1
+    assert a_notes[0].task_id == task_a.task_id
+    assert len(b_notes) == 1
+    assert b_notes[0].task_id == task_b.task_id
+
+
+# ---------------------------------------------------------------------------
+# Round-trip serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_task_note_round_trip() -> None:
+    note = TaskNote(
+        note_id=1,
+        task_id="t1",
+        note_text="hello",
+        created_at=1.0,
+        summary={"facts": ["a"]},
+    )
+    assert TaskNote.from_dict(note.to_dict()) == note
+
+
+def test_empty_summary_is_empty_dict(note_store: NoteStore, task_id: str) -> None:
+    note = note_store.add_note(task_id, "No summary")
+
+    fetched = note_store.get_note(note.note_id)  # type: ignore[arg-type]
+    assert fetched is not None
+    assert fetched.summary == {}


### PR DESCRIPTION
Closes #347

## Summary
- Created `src/openbad/tasks/notes.py` with `TaskNote` dataclass and `NoteStore`:
  - `add_note(task_id, note_text, *, facts, implications, artifact_refs, extra)` → append-only insert to `task_notes`
  - `list_notes(task_id)` → insertion-ordered list
  - `get_note(note_id)` → single lookup
  - Structured fields persist in `summary_json` (facts, implications, artifact_refs, custom keys)

## How to test
```
pytest tests/test_task_notes.py -q  # 9 passed
```