### PR TITLE
#348: Implement post-node raw output compaction step

### DIFF
--- a/src/openbad/tasks/compaction.py
+++ b/src/openbad/tasks/compaction.py
@@ -1,0 +1,118 @@
+"""Post-node raw output compaction for Phase 9 task orchestration.
+
+After a node completes, raw payloads in ``task_events`` may be large and are
+no longer needed in full.  :func:`compact_node_output` replaces the raw
+payload of the node's completion event with a lightweight ``{"compacted": true}``
+marker, preserving only the structured summary (written via :class:`NoteStore`)
+for downstream context reconstruction.
+
+The compaction step is intentionally a single-purpose hook: it writes a note
+(if a summary is provided) and then clears the raw payload from the most
+recent ``node_output`` event for the given node.  It does nothing if no such
+event exists, making it safe to call unconditionally after each node finishes.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from openbad.tasks.notes import NoteStore
+
+# ---------------------------------------------------------------------------
+# Compaction result
+# ---------------------------------------------------------------------------
+
+
+class CompactionResult:
+    """Outcome of a :func:`compact_node_output` call."""
+
+    def __init__(
+        self,
+        *,
+        compacted: bool,
+        note_id: int | None,
+        event_id: str | None,
+    ) -> None:
+        self.compacted = compacted
+        """``True`` if a raw payload was replaced."""
+        self.note_id = note_id
+        """The newly written note ID, or ``None`` if no summary was provided."""
+        self.event_id = event_id
+        """The event whose payload was cleared, or ``None`` if none found."""
+
+    def __repr__(self) -> str:
+        return (
+            f"CompactionResult(compacted={self.compacted!r},"
+            f" note_id={self.note_id!r}, event_id={self.event_id!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compact_node_output(
+    conn: sqlite3.Connection,
+    task_id: str,
+    node_id: str,
+    *,
+    summary_text: str | None = None,
+    facts: list[str] | None = None,
+    implications: list[str] | None = None,
+    artifact_refs: list[str] | None = None,
+) -> CompactionResult:
+    """Replace the raw ``node_output`` event payload with a compact marker.
+
+    Parameters
+    ----------
+    conn:
+        Open ``sqlite3.Connection`` to the state database.
+    task_id:
+        The owning task.
+    node_id:
+        The completed node.
+    summary_text:
+        Prose summary retained as a :class:`~openbad.tasks.notes.TaskNote`.
+        If ``None`` no note is written.
+    facts / implications / artifact_refs:
+        Structured fields forwarded to :meth:`~openbad.tasks.notes.NoteStore.add_note`.
+
+    Returns
+    -------
+    CompactionResult
+        Describes what was written and whether compaction occurred.
+    """
+    # Optionally write a structured note
+    note_id: int | None = None
+    if summary_text is not None:
+        ns = NoteStore(conn)
+        note = ns.add_note(
+            task_id,
+            summary_text,
+            facts=facts,
+            implications=implications,
+            artifact_refs=artifact_refs,
+        )
+        note_id = note.note_id
+
+    # Find the latest node_output event for this node
+    row = conn.execute(
+        "SELECT event_id FROM task_events"
+        " WHERE task_id = ? AND node_id = ? AND event_type = 'node_output'"
+        " ORDER BY created_at DESC LIMIT 1",
+        (task_id, node_id),
+    ).fetchone()
+
+    if row is None:
+        return CompactionResult(compacted=False, note_id=note_id, event_id=None)
+
+    event_id: str = row["event_id"]
+    conn.execute(
+        "UPDATE task_events SET payload_json = ? WHERE event_id = ?",
+        (json.dumps({"compacted": True}), event_id),
+    )
+    conn.commit()
+
+    return CompactionResult(compacted=True, note_id=note_id, event_id=event_id)

--- a/tests/test_node_compaction.py
+++ b/tests/test_node_compaction.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.compaction import compact_node_output
+from openbad.tasks.models import NodeModel, TaskModel
+from openbad.tasks.notes import NoteStore
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    return initialize_state_db(tmp_path / "state.db")
+
+
+@pytest.fixture()
+def store(db):
+    return TaskStore(db)
+
+
+def make_task_and_node(store: TaskStore) -> tuple[TaskModel, NodeModel]:
+    task = TaskModel.new("Compaction task")
+    store.create_task(task)
+    node = NodeModel.new(task.task_id, "Work node")
+    store.create_node(node)
+    return task, node
+
+
+def add_node_output_event(store: TaskStore, task_id: str, node_id: str, payload: dict) -> str:
+    """Helper: append a node_output event and return its event_id."""
+    return store.append_event(task_id, "node_output", node_id=node_id, payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# Raw payload removal
+# ---------------------------------------------------------------------------
+
+
+def test_raw_payload_replaced_with_compact_marker(db, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    add_node_output_event(store, task.task_id, node.node_id, {"raw": "big blob"})
+
+    result = compact_node_output(db, task.task_id, node.node_id)
+
+    assert result.compacted is True
+    events = store.list_events(task.task_id)
+    output_events = [e for e in events if e["event_type"] == "node_output"]
+    assert output_events[0]["payload"] == {"compacted": True}
+
+
+def test_raw_content_no_longer_present_after_compaction(db, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    add_node_output_event(store, task.task_id, node.node_id, {"raw": "secret data", "tokens": 999})
+
+    compact_node_output(db, task.task_id, node.node_id)
+
+    events = store.list_events(task.task_id)
+    payload = events[0]["payload"]
+    assert "raw" not in payload
+    assert "tokens" not in payload
+
+
+def test_no_event_skips_compaction(db, store: TaskStore) -> None:
+    """Compact with no node_output event is a no-op."""
+    task, node = make_task_and_node(store)
+
+    result = compact_node_output(db, task.task_id, node.node_id)
+
+    assert result.compacted is False
+    assert result.event_id is None
+
+
+# ---------------------------------------------------------------------------
+# Structured summary retention
+# ---------------------------------------------------------------------------
+
+
+def test_summary_note_written_when_provided(db, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    add_node_output_event(store, task.task_id, node.node_id, {"raw": "data"})
+
+    result = compact_node_output(
+        db,
+        task.task_id,
+        node.node_id,
+        summary_text="Node completed successfully",
+        facts=["found X", "confirmed Y"],
+    )
+
+    assert result.note_id is not None
+    ns = NoteStore(db)
+    note = ns.get_note(result.note_id)
+    assert note is not None
+    assert note.note_text == "Node completed successfully"
+    assert note.summary["facts"] == ["found X", "confirmed Y"]
+
+
+def test_no_note_when_no_summary(db, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    add_node_output_event(store, task.task_id, node.node_id, {"raw": "x"})
+
+    result = compact_node_output(db, task.task_id, node.node_id)
+
+    assert result.note_id is None
+    ns = NoteStore(db)
+    assert ns.list_notes(task.task_id) == []
+
+
+def test_summary_retained_after_compaction(db, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    add_node_output_event(store, task.task_id, node.node_id, {"raw": "verbose"})
+
+    compact_node_output(
+        db,
+        task.task_id,
+        node.node_id,
+        summary_text="Summary",
+        implications=["Z follows"],
+    )
+
+    ns = NoteStore(db)
+    notes = ns.list_notes(task.task_id)
+    assert len(notes) == 1
+    assert notes[0].summary["implications"] == ["Z follows"]
+
+
+# ---------------------------------------------------------------------------
+# Only most-recent node_output is compacted
+# ---------------------------------------------------------------------------
+
+
+def test_only_latest_output_event_compacted(db, store: TaskStore) -> None:
+    task, node = make_task_and_node(store)
+    add_node_output_event(store, task.task_id, node.node_id, {"run": 1})
+    add_node_output_event(store, task.task_id, node.node_id, {"run": 2})
+
+    result = compact_node_output(db, task.task_id, node.node_id)
+
+    assert result.compacted is True
+    events = store.list_events(task.task_id)
+    output_events = [e for e in events if e["event_type"] == "node_output"]
+    payloads = [e["payload"] for e in output_events]
+    # First event unchanged, second replaced
+    assert payloads[0] == {"run": 1}
+    assert payloads[1] == {"compacted": True}


### PR DESCRIPTION
Closes #348

## Summary
- Created `src/openbad/tasks/compaction.py` with `compact_node_output()`:
  - Replaces the raw `node_output` event payload with `{"compacted": true}`
  - Optionally writes a structured `TaskNote` (summary, facts, implications, artifact_refs) for continuity
  - No-op if no `node_output` event exists; safe to call unconditionally

## How to test
```
pytest tests/test_node_compaction.py -q  # 7 passed
```