### PR TITLE
#349: Add task artifact storage and resume linkage

### DIFF
--- a/src/openbad/tasks/artifacts.py
+++ b/src/openbad/tasks/artifacts.py
@@ -1,0 +1,117 @@
+"""Task artifact storage and resume-linkage for Phase 9 context persistence.
+
+:class:`ArtifactStore` writes structured artifact files under
+``data/tasks/<task_id>/`` and records their paths in task notes so that a
+resume path can reconstruct the working context from disk rather than
+re-running completed nodes.
+
+Artifact files are JSON by default; the caller supplies the content as a dict.
+References are stored in the ``artifact_refs`` field of the corresponding
+:class:`~openbad.tasks.notes.TaskNote`.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Artifact store
+# ---------------------------------------------------------------------------
+
+
+class ArtifactStore:
+    """Writes artifact files and links them to task notes.
+
+    Parameters
+    ----------
+    conn:
+        Open ``sqlite3.Connection`` to the state database.
+    base_dir:
+        Root directory under which per-task artifact directories are created.
+        Defaults to ``data/tasks`` relative to the current working directory.
+    """
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        base_dir: str | Path = "data/tasks",
+    ) -> None:
+        self._conn = conn
+        self._base_dir = Path(base_dir)
+
+    # ------------------------------------------------------------------
+
+    def write_artifact(
+        self,
+        task_id: str,
+        artifact_name: str,
+        content: dict,
+        *,
+        summary_text: str | None = None,
+        facts: list[str] | None = None,
+    ) -> Path:
+        """Write *content* to JSON and record the path in a task note.
+
+        Parameters
+        ----------
+        task_id:
+            Owning task.  The file is written to
+            ``<base_dir>/<task_id>/<artifact_name>``.
+        artifact_name:
+            File name (e.g. ``"output.json"``).
+        content:
+            Serialisable dict written as JSON.
+        summary_text:
+            Prose summary stored in the linked note.
+        facts:
+            Optional fact list stored in the linked note's ``summary_json``.
+
+        Returns
+        -------
+        Path
+            Absolute path of the written file.
+        """
+        artifact_dir = self._base_dir / task_id
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        artifact_path = artifact_dir / artifact_name
+        artifact_path.write_text(json.dumps(content, indent=2), encoding="utf-8")
+
+        # Record the artifact reference in a task note
+        from openbad.tasks.notes import NoteStore
+
+        ns = NoteStore(self._conn)
+        ns.add_note(
+            task_id,
+            summary_text or f"Artifact: {artifact_name}",
+            facts=facts,
+            artifact_refs=[str(artifact_path)],
+        )
+
+        return artifact_path
+
+    def load_artifacts(self, task_id: str) -> list[dict]:
+        """Load all artifact files referenced in notes for *task_id*.
+
+        Returns a list of dicts, one per artifact.  Files that no longer exist
+        are silently skipped so that resume is robust to partial storage.
+
+        Returns
+        -------
+        list[dict]
+            Loaded artifact contents in note-insertion order.
+        """
+        from openbad.tasks.notes import NoteStore
+
+        ns = NoteStore(self._conn)
+        notes = ns.list_notes(task_id)
+
+        results: list[dict] = []
+        for note in notes:
+            for ref in note.summary.get("artifact_refs", []):
+                p = Path(ref)
+                if p.exists():
+                    results.append(json.loads(p.read_text(encoding="utf-8")))
+
+        return results

--- a/tests/test_task_artifacts.py
+++ b/tests/test_task_artifacts.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.artifacts import ArtifactStore
+from openbad.tasks.models import TaskModel
+from openbad.tasks.notes import NoteStore
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    return initialize_state_db(tmp_path / "state.db")
+
+
+@pytest.fixture()
+def artifact_store(db, tmp_path: Path) -> ArtifactStore:
+    return ArtifactStore(db, base_dir=tmp_path / "data" / "tasks")
+
+
+@pytest.fixture()
+def task_id(db) -> str:
+    store = TaskStore(db)
+    task = TaskModel.new("Artifact task")
+    store.create_task(task)
+    return task.task_id
+
+
+# ---------------------------------------------------------------------------
+# Artifact write path
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_file_created(artifact_store: ArtifactStore, task_id: str) -> None:
+    path = artifact_store.write_artifact(task_id, "result.json", {"answer": 42})
+
+    assert path.exists()
+    assert path.name == "result.json"
+    assert path.parent.name == task_id
+
+
+def test_artifact_content_correct(artifact_store: ArtifactStore, task_id: str) -> None:
+    import json
+
+    artifact_store.write_artifact(task_id, "out.json", {"key": "value", "n": 7})
+
+    stored_path = artifact_store._base_dir / task_id / "out.json"
+    data = json.loads(stored_path.read_text())
+    assert data == {"key": "value", "n": 7}
+
+
+def test_artifact_directory_created(
+    artifact_store: ArtifactStore, task_id: str
+) -> None:
+    artifact_store.write_artifact(task_id, "x.json", {})
+
+    assert (artifact_store._base_dir / task_id).is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Note reference validity
+# ---------------------------------------------------------------------------
+
+
+def test_note_references_artifact_path(
+    db, artifact_store: ArtifactStore, task_id: str
+) -> None:
+    path = artifact_store.write_artifact(task_id, "data.json", {"x": 1})
+
+    ns = NoteStore(db)
+    notes = ns.list_notes(task_id)
+
+    assert len(notes) == 1
+    assert str(path) in notes[0].summary["artifact_refs"]
+
+
+def test_note_stores_custom_summary(
+    db, artifact_store: ArtifactStore, task_id: str
+) -> None:
+    artifact_store.write_artifact(
+        task_id, "run.json", {}, summary_text="Run finished", facts=["done"]
+    )
+
+    ns = NoteStore(db)
+    notes = ns.list_notes(task_id)
+    assert notes[0].note_text == "Run finished"
+    assert notes[0].summary["facts"] == ["done"]
+
+
+def test_multiple_artifacts_have_separate_notes(
+    db, artifact_store: ArtifactStore, task_id: str
+) -> None:
+    artifact_store.write_artifact(task_id, "a.json", {"n": 1})
+    artifact_store.write_artifact(task_id, "b.json", {"n": 2})
+
+    ns = NoteStore(db)
+    notes = ns.list_notes(task_id)
+    assert len(notes) == 2
+
+
+# ---------------------------------------------------------------------------
+# Resume from artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_load_artifacts_returns_content(artifact_store: ArtifactStore, task_id: str) -> None:
+    artifact_store.write_artifact(task_id, "r1.json", {"result": "alpha"})
+    artifact_store.write_artifact(task_id, "r2.json", {"result": "beta"})
+
+    loaded = artifact_store.load_artifacts(task_id)
+
+    assert len(loaded) == 2
+    results = {d["result"] for d in loaded}
+    assert results == {"alpha", "beta"}
+
+
+def test_load_artifacts_empty_for_no_notes(artifact_store: ArtifactStore, task_id: str) -> None:
+    assert artifact_store.load_artifacts(task_id) == []
+
+
+def test_load_artifacts_skips_missing_files(
+    db, artifact_store: ArtifactStore, task_id: str
+) -> None:
+    """If an artifact file is deleted after being recorded, load is robust."""
+    path = artifact_store.write_artifact(task_id, "gone.json", {"x": 1})
+    path.unlink()  # simulate missing file
+
+    loaded = artifact_store.load_artifacts(task_id)
+    assert loaded == []


### PR DESCRIPTION
Closes #349

## Summary
- Created `src/openbad/tasks/artifacts.py` with `ArtifactStore`:
  - `write_artifact(task_id, name, content)` → writes JSON to `data/tasks/<task_id>/<name>`, records path in a task note
  - `load_artifacts(task_id)` → loads all artifact files referenced in notes; skips missing files (resume-robust)

## How to test
```
pytest tests/test_task_artifacts.py -q  # 9 passed
```