### PR TITLE
#350: Implement capability manifest schema and parser

### DIFF
--- a/src/openbad/plugins/manifest.py
+++ b/src/openbad/plugins/manifest.py
@@ -1,0 +1,177 @@
+"""Capability manifest schema and parser for Phase 9 plugin management.
+
+An ``openbad.plugin.json`` file declares the capabilities exposed by a plugin.
+:func:`parse_manifest` validates and parses such files into :class:`CapabilityManifest`
+typed structures, failing closed on any validation error.
+
+Manifest schema
+---------------
+.. code-block:: json
+
+    {
+        "name": "my_plugin",
+        "version": "1.0.0",
+        "module": "openbad.plugins.my_plugin",
+        "description": "Optional description",
+        "capabilities": [
+            {
+                "id": "my_plugin.do_thing",
+                "description": "Does the thing",
+                "permissions": ["file.read"]
+            }
+        ]
+    }
+
+Required top-level fields: ``name``, ``version``, ``module``, ``capabilities``.
+Each capability entry requires ``id`` and ``permissions``; ``description`` is optional.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Typed structures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class CapabilityEntry:
+    """A single capability declared in a manifest."""
+
+    id: str
+    permissions: list[str]
+    description: str = ""
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> CapabilityEntry:
+        return cls(
+            id=data["id"],
+            permissions=list(data["permissions"]),
+            description=data.get("description", ""),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class CapabilityManifest:
+    """A parsed and validated ``openbad.plugin.json`` manifest."""
+
+    name: str
+    version: str
+    module: str
+    capabilities: list[CapabilityEntry]
+    description: str = ""
+
+    def to_dict(self) -> dict:
+        d = dataclasses.asdict(self)
+        d["capabilities"] = [c.to_dict() for c in self.capabilities]
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+class ManifestError(ValueError):
+    """Raised when a manifest fails validation."""
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+_REQUIRED_TOP: tuple[str, ...] = ("name", "version", "module", "capabilities")
+_REQUIRED_CAP: tuple[str, ...] = ("id", "permissions")
+
+
+def parse_manifest(source: str | bytes | dict | Path) -> CapabilityManifest:
+    """Parse and validate a capability manifest.
+
+    Parameters
+    ----------
+    source:
+        A JSON string, raw bytes, a ``dict``, or a :class:`~pathlib.Path` to a
+        JSON file.
+
+    Returns
+    -------
+    CapabilityManifest
+        The validated manifest.
+
+    Raises
+    ------
+    ManifestError
+        If the manifest is missing required fields, has wrong types, or
+        contains invalid capability entries.
+    """
+    if isinstance(source, Path):
+        try:
+            raw = source.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ManifestError(f"Cannot read manifest file: {exc}") from exc
+        data = _parse_json(raw)
+    elif isinstance(source, (str, bytes)):
+        data = _parse_json(source)
+    elif isinstance(source, dict):
+        data = source
+    else:
+        raise ManifestError(f"Unsupported manifest source type: {type(source).__name__!r}")
+
+    # Validate top-level required fields
+    for field in _REQUIRED_TOP:
+        if field not in data:
+            raise ManifestError(f"Manifest missing required field: {field!r}")
+
+    if not isinstance(data["name"], str) or not data["name"].strip():
+        raise ManifestError("Manifest 'name' must be a non-empty string")
+    if not isinstance(data["version"], str) or not data["version"].strip():
+        raise ManifestError("Manifest 'version' must be a non-empty string")
+    if not isinstance(data["module"], str) or not data["module"].strip():
+        raise ManifestError("Manifest 'module' must be a non-empty string")
+    if not isinstance(data["capabilities"], list):
+        raise ManifestError("Manifest 'capabilities' must be a list")
+
+    capabilities: list[CapabilityEntry] = []
+    for i, cap in enumerate(data["capabilities"]):
+        if not isinstance(cap, dict):
+            raise ManifestError(f"Capability at index {i} must be an object")
+        for field in _REQUIRED_CAP:
+            if field not in cap:
+                raise ManifestError(
+                    f"Capability at index {i} missing required field: {field!r}"
+                )
+        if not isinstance(cap["id"], str) or not cap["id"].strip():
+            raise ManifestError(f"Capability at index {i}: 'id' must be a non-empty string")
+        if not isinstance(cap["permissions"], list):
+            raise ManifestError(f"Capability at index {i}: 'permissions' must be a list")
+        for perm in cap["permissions"]:
+            if not isinstance(perm, str):
+                raise ManifestError(
+                    f"Capability {cap['id']!r}: permission {perm!r} must be a string"
+                )
+
+        capabilities.append(CapabilityEntry.from_dict(cap))
+
+    return CapabilityManifest(
+        name=data["name"].strip(),
+        version=data["version"].strip(),
+        module=data["module"].strip(),
+        description=data.get("description", ""),
+        capabilities=capabilities,
+    )
+
+
+def _parse_json(raw: str | bytes) -> dict:
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"Invalid JSON in manifest: {exc}") from exc
+    if not isinstance(result, dict):
+        raise ManifestError("Manifest must be a JSON object")
+    return result

--- a/tests/test_capability_manifest.py
+++ b/tests/test_capability_manifest.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openbad.plugins.manifest import (
+    CapabilityEntry,
+    ManifestError,
+    parse_manifest,
+)
+
+VALID_MANIFEST: dict = {
+    "name": "my_plugin",
+    "version": "1.0.0",
+    "module": "openbad.plugins.my_plugin",
+    "description": "A test plugin",
+    "capabilities": [
+        {
+            "id": "my_plugin.read_file",
+            "description": "Reads a file",
+            "permissions": ["file.read"],
+        },
+        {
+            "id": "my_plugin.write_db",
+            "permissions": ["db.insert", "db.update"],
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Valid manifest parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_valid_dict() -> None:
+    manifest = parse_manifest(VALID_MANIFEST)
+
+    assert manifest.name == "my_plugin"
+    assert manifest.version == "1.0.0"
+    assert manifest.module == "openbad.plugins.my_plugin"
+    assert manifest.description == "A test plugin"
+    assert len(manifest.capabilities) == 2
+
+
+def test_parse_valid_json_string() -> None:
+    manifest = parse_manifest(json.dumps(VALID_MANIFEST))
+
+    assert manifest.name == "my_plugin"
+
+
+def test_parse_valid_json_bytes() -> None:
+    manifest = parse_manifest(json.dumps(VALID_MANIFEST).encode())
+
+    assert manifest.name == "my_plugin"
+
+
+def test_parse_valid_json_file(tmp_path: Path) -> None:
+    f = tmp_path / "openbad.plugin.json"
+    f.write_text(json.dumps(VALID_MANIFEST))
+
+    manifest = parse_manifest(f)
+
+    assert manifest.name == "my_plugin"
+
+
+def test_capability_fields_populated() -> None:
+    manifest = parse_manifest(VALID_MANIFEST)
+
+    cap = manifest.capabilities[0]
+    assert cap.id == "my_plugin.read_file"
+    assert cap.permissions == ["file.read"]
+    assert cap.description == "Reads a file"
+
+
+def test_optional_description_defaults_to_empty() -> None:
+    manifest = parse_manifest(VALID_MANIFEST)
+
+    no_desc_cap = manifest.capabilities[1]
+    assert no_desc_cap.description == ""
+
+
+def test_manifest_is_frozen() -> None:
+    manifest = parse_manifest(VALID_MANIFEST)
+
+    with pytest.raises((TypeError, AttributeError)):
+        manifest.name = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Invalid manifests rejected with clear reasons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing_field", ["name", "version", "module", "capabilities"])
+def test_missing_top_level_field(missing_field: str) -> None:
+    data = {k: v for k, v in VALID_MANIFEST.items() if k != missing_field}
+
+    with pytest.raises(ManifestError, match=missing_field):
+        parse_manifest(data)
+
+
+def test_name_empty_string_rejected() -> None:
+    data = {**VALID_MANIFEST, "name": "   "}
+
+    with pytest.raises(ManifestError, match="name"):
+        parse_manifest(data)
+
+
+def test_module_empty_string_rejected() -> None:
+    data = {**VALID_MANIFEST, "module": ""}
+
+    with pytest.raises(ManifestError, match="module"):
+        parse_manifest(data)
+
+
+def test_capabilities_not_list_rejected() -> None:
+    data = {**VALID_MANIFEST, "capabilities": "not-a-list"}
+
+    with pytest.raises(ManifestError, match="capabilities"):
+        parse_manifest(data)
+
+
+def test_capability_missing_id_rejected() -> None:
+    data = {
+        **VALID_MANIFEST,
+        "capabilities": [{"permissions": ["file.read"]}],
+    }
+
+    with pytest.raises(ManifestError, match="'id'"):
+        parse_manifest(data)
+
+
+def test_capability_missing_permissions_rejected() -> None:
+    data = {
+        **VALID_MANIFEST,
+        "capabilities": [{"id": "x.y"}],
+    }
+
+    with pytest.raises(ManifestError, match="'permissions'"):
+        parse_manifest(data)
+
+
+def test_capability_permissions_not_list_rejected() -> None:
+    data = {
+        **VALID_MANIFEST,
+        "capabilities": [{"id": "x.y", "permissions": "file.read"}],
+    }
+
+    with pytest.raises(ManifestError, match="permissions"):
+        parse_manifest(data)
+
+
+def test_invalid_json_string_rejected() -> None:
+    with pytest.raises(ManifestError, match="Invalid JSON"):
+        parse_manifest("{not valid json")
+
+
+def test_json_array_rejected() -> None:
+    with pytest.raises(ManifestError, match="JSON object"):
+        parse_manifest("[]")
+
+
+def test_missing_file_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ManifestError, match="Cannot read manifest"):
+        parse_manifest(tmp_path / "nonexistent.json")
+
+
+def test_unsupported_source_type_rejected() -> None:
+    with pytest.raises(ManifestError, match="Unsupported manifest source"):
+        parse_manifest(123)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_capability_entry_round_trip() -> None:
+    cap = CapabilityEntry(id="a.b", permissions=["file.read"], description="desc")
+    assert CapabilityEntry.from_dict(cap.to_dict()) == cap


### PR DESCRIPTION
Closes #350

## Summary
- Created `src/openbad/plugins/manifest.py` with `CapabilityEntry`, `CapabilityManifest`, `ManifestError`, and `parse_manifest()`:
  - Accepts dict, JSON string/bytes, or Path to `openbad.plugin.json`
  - Validates required fields (name, version, module, capabilities) and capability sub-fields (id, permissions)
  - Fails closed with `ManifestError` on any validation error
  - Frozen dataclasses for immutable result

## How to test
```
pytest tests/test_capability_manifest.py -q  # 22 passed
```