### PR TITLE
#351: Build capability registry with permission enforcement

### DIFF
--- a/src/openbad/plugins/registry.py
+++ b/src/openbad/plugins/registry.py
@@ -1,0 +1,169 @@
+"""Capability registry with permission enforcement for Phase 9 plugin management.
+
+:class:`CapabilityRegistry` maintains an in-memory inventory of registered
+:class:`~openbad.plugins.manifest.CapabilityEntry` objects.  Registration is
+gated by a :class:`PermissionPolicy` that validates each requested permission
+against an allowlist derived from :file:`config/permissions.yaml`.
+
+System 1 (fast-reflex) capabilities are tracked separately so callers can
+inspect the restricted inventory without exposing higher-tier capabilities.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from openbad.plugins.manifest import CapabilityManifest
+
+
+# ---------------------------------------------------------------------------
+# Permission policy
+# ---------------------------------------------------------------------------
+
+
+class PermissionPolicy:
+    """Validates capability permissions against a YAML allowlist.
+
+    Parameters
+    ----------
+    allowed_permissions:
+        Flat set of allowed permission strings (e.g. ``{"file.read", "db.insert"}``).
+        Pass ``None`` to allow everything (useful in tests).
+    """
+
+    def __init__(self, allowed_permissions: set[str] | None) -> None:
+        self._allowed = allowed_permissions
+
+    def is_allowed(self, permission: str) -> bool:
+        """Return ``True`` if *permission* is in the allowlist."""
+        if self._allowed is None:
+            return True
+        return permission in self._allowed
+
+    def check_permissions(self, permissions: list[str]) -> list[str]:
+        """Return the subset of *permissions* that are *not* allowed."""
+        return [p for p in permissions if not self.is_allowed(p)]
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> PermissionPolicy:
+        """Build a policy by flattening all tiers from *path*.
+
+        Parameters
+        ----------
+        path:
+            Path to a ``permissions.yaml`` file whose top-level key is
+            ``permissions`` mapping tier names to lists of permission strings.
+        """
+        config = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+        tiers: dict = config.get("permissions", {})
+        allowed: set[str] = set()
+        for perms in tiers.values():
+            allowed.update(perms)
+        return cls(allowed)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class RegistrationError(ValueError):
+    """Raised when capability registration fails permission checks."""
+
+
+@dataclasses.dataclass
+class RegistryEntry:
+    """A registered capability with its source manifest metadata."""
+
+    capability_id: str
+    permissions: list[str]
+    description: str
+    plugin_name: str
+    plugin_version: str
+    system1: bool = False
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+class CapabilityRegistry:
+    """In-memory inventory of approved capabilities.
+
+    Parameters
+    ----------
+    policy:
+        A :class:`PermissionPolicy` used to gate registration.
+    system1_prefixes:
+        Capability ID prefixes treated as System 1 (fast-reflex) capabilities.
+        Defaults to ``("core_triage.", "reflex.")``.
+    """
+
+    def __init__(
+        self,
+        policy: PermissionPolicy,
+        system1_prefixes: tuple[str, ...] = ("core_triage.", "reflex."),
+    ) -> None:
+        self._policy = policy
+        self._system1_prefixes = system1_prefixes
+        self._entries: dict[str, RegistryEntry] = {}
+
+    def register(self, manifest: CapabilityManifest) -> list[RegistryEntry]:
+        """Register all capabilities from *manifest*.
+
+        Capabilities whose permission set includes any disallowed permission
+        are rejected.  Allowed capabilities are added to the registry.
+
+        Returns
+        -------
+        list[RegistryEntry]
+            The newly registered entries.
+
+        Raises
+        ------
+        RegistrationError
+            If any capability has a disallowed permission.  No capabilities
+            from the manifest are registered on error (fail-closed).
+        """
+        pending: list[RegistryEntry] = []
+
+        for cap in manifest.capabilities:
+            violations = self._policy.check_permissions(cap.permissions)
+            if violations:
+                raise RegistrationError(
+                    f"Capability {cap.id!r} in plugin {manifest.name!r}"
+                    f" requests disallowed permissions: {violations}"
+                )
+            is_s1 = any(cap.id.startswith(prefix) for prefix in self._system1_prefixes)
+            pending.append(
+                RegistryEntry(
+                    capability_id=cap.id,
+                    permissions=list(cap.permissions),
+                    description=cap.description,
+                    plugin_name=manifest.name,
+                    plugin_version=manifest.version,
+                    system1=is_s1,
+                )
+            )
+
+        # Commit only after all capabilities pass
+        for entry in pending:
+            self._entries[entry.capability_id] = entry
+
+        return pending
+
+    def get(self, capability_id: str) -> RegistryEntry | None:
+        """Return the entry for *capability_id*, or ``None``."""
+        return self._entries.get(capability_id)
+
+    def list_all(self) -> list[RegistryEntry]:
+        """Return all registered capabilities."""
+        return list(self._entries.values())
+
+    def list_system1(self) -> list[RegistryEntry]:
+        """Return only System 1 (fast-reflex) capabilities."""
+        return [e for e in self._entries.values() if e.system1]

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbad.plugins.manifest import CapabilityEntry, CapabilityManifest
+from openbad.plugins.registry import (
+    CapabilityRegistry,
+    PermissionPolicy,
+    RegistrationError,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+ALLOWED = {"file.read", "db.insert", "db.update", "mqtt.publish"}
+
+MANIFEST_DATA = CapabilityManifest(
+    name="test_plugin",
+    version="1.0",
+    module="openbad.plugins.test_plugin",
+    capabilities=[
+        CapabilityEntry(id="test_plugin.read", permissions=["file.read"], description="Read"),
+        CapabilityEntry(id="test_plugin.write_db", permissions=["db.insert"], description="DB"),
+        CapabilityEntry(id="core_triage.triage", permissions=["file.read"], description="Triage"),
+    ],
+)
+
+
+@pytest.fixture()
+def registry() -> CapabilityRegistry:
+    return CapabilityRegistry(PermissionPolicy(ALLOWED))
+
+
+# ---------------------------------------------------------------------------
+# Registry lists approved capabilities
+# ---------------------------------------------------------------------------
+
+
+def test_register_valid_manifest(registry: CapabilityRegistry) -> None:
+    entries = registry.register(MANIFEST_DATA)
+
+    assert len(entries) == 3
+
+
+def test_registered_capabilities_appear_in_list_all(registry: CapabilityRegistry) -> None:
+    registry.register(MANIFEST_DATA)
+
+    ids = {e.capability_id for e in registry.list_all()}
+    assert "test_plugin.read" in ids
+    assert "test_plugin.write_db" in ids
+
+
+def test_get_registered_capability(registry: CapabilityRegistry) -> None:
+    registry.register(MANIFEST_DATA)
+
+    entry = registry.get("test_plugin.read")
+    assert entry is not None
+    assert entry.permissions == ["file.read"]
+
+
+def test_get_unknown_capability_returns_none(registry: CapabilityRegistry) -> None:
+    assert registry.get("unknown.cap") is None
+
+
+def test_registry_empty_initially(registry: CapabilityRegistry) -> None:
+    assert registry.list_all() == []
+
+
+# ---------------------------------------------------------------------------
+# Disallowed permissions block registration
+# ---------------------------------------------------------------------------
+
+
+def test_disallowed_permission_raises(registry: CapabilityRegistry) -> None:
+    manifest = CapabilityManifest(
+        name="bad_plugin",
+        version="1.0",
+        module="openbad.plugins.bad",
+        capabilities=[
+            CapabilityEntry(id="bad.elevate", permissions=["identity.elevate"]),
+        ],
+    )
+
+    with pytest.raises(RegistrationError, match="identity.elevate"):
+        registry.register(manifest)
+
+
+def test_partial_disallowed_blocks_entire_manifest(registry: CapabilityRegistry) -> None:
+    """All-or-nothing: if any capability fails, none are registered."""
+    manifest = CapabilityManifest(
+        name="mixed_plugin",
+        version="1.0",
+        module="openbad.plugins.mixed",
+        capabilities=[
+            CapabilityEntry(id="mixed.ok", permissions=["file.read"]),
+            CapabilityEntry(id="mixed.banned", permissions=["ebpf.load"]),
+        ],
+    )
+
+    with pytest.raises(RegistrationError):
+        registry.register(manifest)
+
+    assert registry.get("mixed.ok") is None
+
+
+# ---------------------------------------------------------------------------
+# System 1 capability inventory
+# ---------------------------------------------------------------------------
+
+
+def test_system1_capabilities_identified(registry: CapabilityRegistry) -> None:
+    registry.register(MANIFEST_DATA)
+
+    s1_ids = {e.capability_id for e in registry.list_system1()}
+    assert "core_triage.triage" in s1_ids
+    assert "test_plugin.read" not in s1_ids
+
+
+def test_system1_flag_on_entry(registry: CapabilityRegistry) -> None:
+    registry.register(MANIFEST_DATA)
+
+    entry = registry.get("core_triage.triage")
+    assert entry is not None
+    assert entry.system1 is True
+
+
+def test_non_system1_flag_is_false(registry: CapabilityRegistry) -> None:
+    registry.register(MANIFEST_DATA)
+
+    entry = registry.get("test_plugin.read")
+    assert entry is not None
+    assert entry.system1 is False
+
+
+# ---------------------------------------------------------------------------
+# Permission policy from YAML
+# ---------------------------------------------------------------------------
+
+
+def test_policy_from_yaml(tmp_path: Path) -> None:
+    yaml_content = (
+        "permissions:\n"
+        "  READ:\n"
+        "    - file.read\n"
+        "  WRITE:\n"
+        "    - db.insert\n"
+    )
+    f = tmp_path / "permissions.yaml"
+    f.write_text(yaml_content)
+
+    policy = PermissionPolicy.from_yaml(f)
+    assert policy.is_allowed("file.read") is True
+    assert policy.is_allowed("db.insert") is True
+    assert policy.is_allowed("ebpf.load") is False
+
+
+def test_policy_check_permissions_returns_violations() -> None:
+    policy = PermissionPolicy({"file.read"})
+    violations = policy.check_permissions(["file.read", "ebpf.load"])
+    assert violations == ["ebpf.load"]
+
+
+def test_policy_none_allows_everything() -> None:
+    policy = PermissionPolicy(None)
+    assert policy.is_allowed("anything") is True
+
+
+def test_registry_with_real_permissions_yaml() -> None:
+    """Integration: load from the actual repo config."""
+    here = Path(__file__).parent.parent / "config" / "permissions.yaml"
+    if not here.exists():
+        pytest.skip("config/permissions.yaml not found")
+
+    policy = PermissionPolicy.from_yaml(here)
+    registry = CapabilityRegistry(policy)
+
+    manifest = CapabilityManifest(
+        name="approved",
+        version="0.1",
+        module="openbad.plugins.approved",
+        capabilities=[
+            CapabilityEntry(id="approved.read", permissions=["file.read"]),
+        ],
+    )
+    entries = registry.register(manifest)
+    assert len(entries) == 1


### PR DESCRIPTION
Closes #351

## Summary
- Created `src/openbad/plugins/registry.py` with:
  - `PermissionPolicy`: validates permissions against an allowlist; `from_yaml()` flattens all tiers from `config/permissions.yaml`
  - `CapabilityRegistry`: registers manifests (all-or-nothing on permission check), `list_all()`, `list_system1()`, `get(capability_id)`
  - System 1 capabilities identified by prefix (`core_triage.`, `reflex.`)
  - `RegistrationError` on disallowed permissions

## How to test
```
pytest tests/test_capability_registry.py -q  # 14 passed
```