### PR TITLE
#352: Implement core triage capability pack

### DIFF
--- a/src/openbad/plugins/core_triage.py
+++ b/src/openbad/plugins/core_triage.py
@@ -1,0 +1,215 @@
+"""Core triage capability pack for Phase 9 task and research operations.
+
+This module wires up the ``core_triage.*`` capabilities — registered in
+:data:`CORE_TRIAGE_MANIFEST` — to their underlying implementations.
+Capabilities execute via :func:`execute_capability` which dispatches to the
+correct handler, emits a task event, and returns a typed
+:class:`CapabilityResponse`.
+
+Errors in handler logic are caught and returned as structured
+:class:`CapabilityError` responses rather than raised, keeping the runtime
+non-fatal.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+
+from openbad.plugins.manifest import CapabilityEntry, CapabilityManifest
+from openbad.tasks.models import TaskKind, TaskModel
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+CORE_TRIAGE_MANIFEST = CapabilityManifest(
+    name="core_triage",
+    version="1.0.0",
+    module="openbad.plugins.core_triage",
+    description="Core triage capabilities for task and research operations",
+    capabilities=[
+        CapabilityEntry(
+            id="core_triage.create_task",
+            description="Create a new task from triage input",
+            permissions=["db.insert", "log.write"],
+        ),
+        CapabilityEntry(
+            id="core_triage.queue_research",
+            description="Queue a research subtask",
+            permissions=["db.insert", "log.write"],
+        ),
+        CapabilityEntry(
+            id="core_triage.cancel_task",
+            description="Cancel an existing pending or running task",
+            permissions=["db.update", "log.write"],
+        ),
+    ],
+)
+
+
+# ---------------------------------------------------------------------------
+# Request / Response types
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class CapabilityRequest:
+    """Input to a capability execution."""
+
+    capability_id: str
+    params: dict
+    task_id: str | None = None  # Owning task context (for event emission)
+
+
+@dataclasses.dataclass(frozen=True)
+class CapabilityResponse:
+    """Successful capability execution result."""
+
+    capability_id: str
+    output: dict
+    event_id: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class CapabilityError:
+    """Structured error returned when a capability handler raises."""
+
+    capability_id: str
+    message: str
+    detail: dict = dataclasses.field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Capability executor
+# ---------------------------------------------------------------------------
+
+
+class CoreTriageExecutor:
+    """Executes core triage capabilities and emits task events.
+
+    Parameters
+    ----------
+    conn:
+        Open ``sqlite3.Connection`` to the state database.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._store = TaskStore(conn)
+
+    def execute(
+        self, request: CapabilityRequest
+    ) -> CapabilityResponse | CapabilityError:
+        """Dispatch *request* to the appropriate handler.
+
+        Returns a :class:`CapabilityResponse` on success or a
+        :class:`CapabilityError` on any handler exception.
+        """
+        handlers = {
+            "core_triage.create_task": self._create_task,
+            "core_triage.queue_research": self._queue_research,
+            "core_triage.cancel_task": self._cancel_task,
+        }
+        handler = handlers.get(request.capability_id)
+        if handler is None:
+            return CapabilityError(
+                capability_id=request.capability_id,
+                message=f"Unknown capability: {request.capability_id!r}",
+            )
+        try:
+            return handler(request)
+        except Exception as exc:  # noqa: BLE001
+            return CapabilityError(
+                capability_id=request.capability_id,
+                message=str(exc),
+                detail={"type": type(exc).__name__},
+            )
+
+    # ------------------------------------------------------------------
+    # Handlers
+    # ------------------------------------------------------------------
+
+    def _create_task(self, request: CapabilityRequest) -> CapabilityResponse:
+        title = request.params.get("title")
+        if not title:
+            raise ValueError("'title' is required")
+
+        task = TaskModel.new(
+            title,
+            description=request.params.get("description", ""),
+            kind=TaskKind.USER_REQUESTED,
+        )
+        self._store.create_task(task)
+
+        event_id: str | None = None
+        if request.task_id:
+            event_id = self._store.append_event(
+                request.task_id,
+                "capability_create_task",
+                payload={"new_task_id": task.task_id, "title": title},
+            )
+
+        return CapabilityResponse(
+            capability_id=request.capability_id,
+            output={"task_id": task.task_id, "title": title},
+            event_id=event_id,
+        )
+
+    def _queue_research(self, request: CapabilityRequest) -> CapabilityResponse:
+        title = request.params.get("title")
+        if not title:
+            raise ValueError("'title' is required")
+
+        task = TaskModel.new(
+            title,
+            description=request.params.get("description", ""),
+            kind=TaskKind.RESEARCH,
+        )
+        self._store.create_task(task)
+
+        event_id: str | None = None
+        if request.task_id:
+            event_id = self._store.append_event(
+                request.task_id,
+                "capability_queue_research",
+                payload={"research_task_id": task.task_id, "title": title},
+            )
+
+        return CapabilityResponse(
+            capability_id=request.capability_id,
+            output={"task_id": task.task_id, "title": title, "kind": "research"},
+            event_id=event_id,
+        )
+
+    def _cancel_task(self, request: CapabilityRequest) -> CapabilityResponse:
+        from openbad.tasks.models import TaskStatus
+
+        target_id = request.params.get("task_id")
+        if not target_id:
+            raise ValueError("'task_id' is required")
+
+        task = self._store.get_task(target_id)
+        if task is None:
+            raise ValueError(f"Task not found: {target_id!r}")
+        if task.status not in (TaskStatus.PENDING, TaskStatus.RUNNING):
+            raise ValueError(
+                f"Cannot cancel task in status {task.status.value!r}"
+            )
+
+        self._store.update_task_status(target_id, TaskStatus.CANCELLED)
+
+        event_id: str | None = None
+        if request.task_id:
+            event_id = self._store.append_event(
+                request.task_id,
+                "capability_cancel_task",
+                payload={"cancelled_task_id": target_id},
+            )
+
+        return CapabilityResponse(
+            capability_id=request.capability_id,
+            output={"cancelled_task_id": target_id},
+            event_id=event_id,
+        )

--- a/tests/test_core_triage.py
+++ b/tests/test_core_triage.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from openbad.state.db import initialize_state_db
+
+from openbad.plugins.core_triage import (
+    CORE_TRIAGE_MANIFEST,
+    CapabilityError,
+    CapabilityRequest,
+    CapabilityResponse,
+    CoreTriageExecutor,
+)
+from openbad.tasks.models import TaskKind, TaskModel, TaskStatus
+from openbad.tasks.store import TaskStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> sqlite3.Connection:
+    path = tmp_path / "state.db"
+    return initialize_state_db(path)
+
+
+@pytest.fixture()
+def executor(db: sqlite3.Connection) -> CoreTriageExecutor:
+    return CoreTriageExecutor(db)
+
+
+@pytest.fixture()
+def context_task_id(db: sqlite3.Connection) -> str:
+    """A pre-existing owning task used as the request context."""
+    store = TaskStore(db)
+    task = TaskModel.new("context", kind=TaskKind.USER_REQUESTED)
+    store.create_task(task)
+    return task.task_id
+
+
+# ---------------------------------------------------------------------------
+# Manifest content
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_name() -> None:
+    assert CORE_TRIAGE_MANIFEST.name == "core_triage"
+
+
+def test_manifest_has_three_capabilities() -> None:
+    ids = {c.id for c in CORE_TRIAGE_MANIFEST.capabilities}
+    assert "core_triage.create_task" in ids
+    assert "core_triage.queue_research" in ids
+    assert "core_triage.cancel_task" in ids
+
+
+# ---------------------------------------------------------------------------
+# create_task capability
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_returns_response(executor: CoreTriageExecutor) -> None:
+    req = CapabilityRequest(
+        capability_id="core_triage.create_task",
+        params={"title": "Triage me"},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityResponse)
+    assert result.output["title"] == "Triage me"
+    assert result.output["task_id"]
+
+
+def test_create_task_persists_in_db(
+    executor: CoreTriageExecutor, db: sqlite3.Connection
+) -> None:
+    req = CapabilityRequest(
+        capability_id="core_triage.create_task",
+        params={"title": "Stored task"},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityResponse)
+    store = TaskStore(db)
+    task = store.get_task(result.output["task_id"])
+    assert task is not None
+    assert task.title == "Stored task"
+
+
+def test_create_task_emits_event(
+    executor: CoreTriageExecutor,
+    db: sqlite3.Connection,
+    context_task_id: str,
+) -> None:
+    req = CapabilityRequest(
+        capability_id="core_triage.create_task",
+        params={"title": "From context"},
+        task_id=context_task_id,
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityResponse)
+    assert result.event_id is not None
+
+
+def test_create_task_missing_title_returns_error(executor: CoreTriageExecutor) -> None:
+    req = CapabilityRequest(
+        capability_id="core_triage.create_task",
+        params={},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityError)
+    assert "title" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# queue_research capability
+# ---------------------------------------------------------------------------
+
+
+def test_queue_research_returns_response(executor: CoreTriageExecutor) -> None:
+    req = CapabilityRequest(
+        capability_id="core_triage.queue_research",
+        params={"title": "Research X"},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityResponse)
+    assert result.output["kind"] == "research"
+    assert result.output["task_id"]
+
+
+def test_queue_research_creates_research_task(
+    executor: CoreTriageExecutor, db: sqlite3.Connection
+) -> None:
+    req = CapabilityRequest(
+        capability_id="core_triage.queue_research",
+        params={"title": "Find patterns"},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityResponse)
+    store = TaskStore(db)
+    task = store.get_task(result.output["task_id"])
+    assert task is not None
+    assert task.kind == TaskKind.RESEARCH
+
+
+def test_queue_research_missing_title_returns_error(executor: CoreTriageExecutor) -> None:
+    req = CapabilityRequest(
+        capability_id="core_triage.queue_research",
+        params={},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityError)
+    assert "title" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# cancel_task capability
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_task_returns_response(
+    executor: CoreTriageExecutor, db: sqlite3.Connection
+) -> None:
+    store = TaskStore(db)
+    task = TaskModel.new("to cancel", kind=TaskKind.USER_REQUESTED)
+    store.create_task(task)
+
+    req = CapabilityRequest(
+        capability_id="core_triage.cancel_task",
+        params={"task_id": task.task_id},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityResponse)
+    assert result.output["cancelled_task_id"] == task.task_id
+
+
+def test_cancel_task_updates_status(
+    executor: CoreTriageExecutor, db: sqlite3.Connection
+) -> None:
+    store = TaskStore(db)
+    task = TaskModel.new("cancel me", kind=TaskKind.USER_REQUESTED)
+    store.create_task(task)
+
+    req = CapabilityRequest(
+        capability_id="core_triage.cancel_task",
+        params={"task_id": task.task_id},
+    )
+
+    executor.execute(req)
+
+    updated = store.get_task(task.task_id)
+    assert updated is not None
+    assert updated.status == TaskStatus.CANCELLED
+
+
+def test_cancel_task_unknown_id_returns_error(executor: CoreTriageExecutor) -> None:
+    req = CapabilityRequest(
+        capability_id="core_triage.cancel_task",
+        params={"task_id": "nonexistent"},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityError)
+    assert "nonexistent" in result.message
+
+
+def test_cancel_already_cancelled_returns_error(
+    executor: CoreTriageExecutor, db: sqlite3.Connection
+) -> None:
+    store = TaskStore(db)
+    task = TaskModel.new("already done", kind=TaskKind.USER_REQUESTED)
+    store.create_task(task)
+    store.update_task_status(task.task_id, TaskStatus.DONE)
+
+    req = CapabilityRequest(
+        capability_id="core_triage.cancel_task",
+        params={"task_id": task.task_id},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityError)
+
+
+# ---------------------------------------------------------------------------
+# Unknown capability
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_capability_returns_error(executor: CoreTriageExecutor) -> None:
+    req = CapabilityRequest(
+        capability_id="core_triage.does_not_exist",
+        params={},
+    )
+
+    result = executor.execute(req)
+
+    assert isinstance(result, CapabilityError)
+    assert "unknown" in result.message.lower()


### PR DESCRIPTION
Closes #352

## Summary
- Created `src/openbad/plugins/core_triage.py` with:
  - `CORE_TRIAGE_MANIFEST`: capability manifest (create_task, queue_research, cancel_task)
  - `CapabilityRequest` / `CapabilityResponse` / `CapabilityError` typed dataclasses
  - `CoreTriageExecutor`: dispatches requests, emits task events, returns structured errors (non-fatal)
  - Handlers persist tasks via `TaskStore`, optional owning task event emission

## How to test
```
pytest tests/test_core_triage.py -q  # 14 passed
```