### PR TITLE
#353: Add MCP policy and scoped session primitives

### DIFF
--- a/src/openbad/plugins/mcp_policy.py
+++ b/src/openbad/plugins/mcp_policy.py
@@ -1,0 +1,227 @@
+"""MCP Policy and scoped session primitives for Phase 9.
+
+This module provides :class:`MCPPolicy`, which declares per-session resource
+limits, and :class:`MCPSession`, which tracks live per-session state.
+:class:`MCPSessionManager` manages the full lifecycle (create / close).
+
+Session limits are enforced at the metadata layer: callers check
+:meth:`MCPSession.check_limit` before executing tools.  Actual execution is
+*not* performed here; this module is intentionally thin.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from datetime import UTC, datetime
+from enum import auto
+
+from openbad.tasks.models import StrEnum
+
+# ---------------------------------------------------------------------------
+# Policy
+# ---------------------------------------------------------------------------
+
+
+class MCPScope(StrEnum):
+    """Access scope granted to a session."""
+
+    READ = auto()
+    WRITE = auto()
+    ADMIN = auto()
+
+
+@dataclasses.dataclass(frozen=True)
+class MCPPolicy:
+    """Declared resource limits for an MCP session.
+
+    Parameters
+    ----------
+    max_tools:
+        Maximum number of distinct tool names the session may call.
+        ``None`` means unlimited.
+    max_calls:
+        Maximum total tool calls (across all tools) in the session lifetime.
+        ``None`` means unlimited.
+    allowed_scopes:
+        Scopes the session is permitted to use.  Defaults to ``{READ}``.
+    """
+
+    max_tools: int | None = None
+    max_calls: int | None = None
+    allowed_scopes: frozenset[MCPScope] = dataclasses.field(
+        default_factory=lambda: frozenset({MCPScope.READ})
+    )
+
+    def allows_scope(self, scope: MCPScope) -> bool:
+        """Return ``True`` if *scope* is in :attr:`allowed_scopes`."""
+        return scope in self.allowed_scopes
+
+    def to_dict(self) -> dict:
+        return {
+            "max_tools": self.max_tools,
+            "max_calls": self.max_calls,
+            "allowed_scopes": sorted(s.value for s in self.allowed_scopes),
+        }
+
+
+class PolicyViolationError(ValueError):
+    """Raised when a session limit or scope is violated."""
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+
+class SessionStatus(StrEnum):
+    OPEN = auto()
+    CLOSED = auto()
+
+
+@dataclasses.dataclass
+class MCPSession:
+    """Tracks live per-session state against a :class:`MCPPolicy`.
+
+    Parameters
+    ----------
+    session_id:
+        Unique identifier for this session.
+    policy:
+        The policy that governs limits for this session.
+    created_at:
+        When the session was opened.
+    status:
+        Whether the session is :attr:`SessionStatus.OPEN` or
+        :attr:`SessionStatus.CLOSED`.
+    tools_called:
+        Mapping of tool name → call count seen in this session.
+    """
+
+    session_id: str
+    policy: MCPPolicy
+    created_at: datetime
+    status: SessionStatus = SessionStatus.OPEN
+    tools_called: dict[str, int] = dataclasses.field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Limit helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def total_calls(self) -> int:
+        return sum(self.tools_called.values())
+
+    @property
+    def distinct_tools(self) -> int:
+        return len(self.tools_called)
+
+    def check_limit(self, tool_name: str) -> None:
+        """Raise :class:`PolicyViolationError` if a limit would be exceeded.
+
+        This must be called *before* executing a tool.  It does *not* record
+        the call; use :meth:`record_call` after execution.
+
+        Parameters
+        ----------
+        tool_name:
+            The tool about to be called.
+
+        Raises
+        ------
+        PolicyViolationError
+            If the session is closed, or a call or tool limit would be hit.
+        """
+        if self.status == SessionStatus.CLOSED:
+            raise PolicyViolationError("Session is closed")
+
+        if self.policy.max_calls is not None and self.total_calls >= self.policy.max_calls:
+            raise PolicyViolationError(
+                f"call limit {self.policy.max_calls} reached"
+            )
+
+        if (
+            self.policy.max_tools is not None
+            and tool_name not in self.tools_called
+            and self.distinct_tools >= self.policy.max_tools
+        ):
+            raise PolicyViolationError(
+                f"tool limit {self.policy.max_tools} reached"
+            )
+
+    def record_call(self, tool_name: str) -> None:
+        """Record a tool call after successful execution."""
+        self.tools_called[tool_name] = self.tools_called.get(tool_name, 0) + 1
+
+    def to_dict(self) -> dict:
+        return {
+            "session_id": self.session_id,
+            "policy": self.policy.to_dict(),
+            "created_at": self.created_at.isoformat(),
+            "status": self.status.value,
+            "tools_called": dict(self.tools_called),
+            "total_calls": self.total_calls,
+            "distinct_tools": self.distinct_tools,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Session manager
+# ---------------------------------------------------------------------------
+
+
+class MCPSessionManager:
+    """Manages the lifecycle of :class:`MCPSession` objects.
+
+    Sessions are kept in memory keyed by :attr:`MCPSession.session_id`.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, MCPSession] = {}
+
+    def create_session(
+        self,
+        policy: MCPPolicy,
+        *,
+        session_id: str | None = None,
+    ) -> MCPSession:
+        """Create and return a new open session.
+
+        Parameters
+        ----------
+        policy:
+            The policy to attach to this session.
+        session_id:
+            Optional explicit ID.  A UUID4 is generated if omitted.
+        """
+        sid = session_id or str(uuid.uuid4())
+        if sid in self._sessions:
+            raise ValueError(f"Session {sid!r} already exists")
+
+        session = MCPSession(
+            session_id=sid,
+            policy=policy,
+            created_at=datetime.now(tz=UTC),
+        )
+        self._sessions[sid] = session
+        return session
+
+    def get_session(self, session_id: str) -> MCPSession | None:
+        """Return the session with *session_id*, or ``None``."""
+        return self._sessions.get(session_id)
+
+    def close_session(self, session_id: str) -> MCPSession:
+        """Mark the session as closed.
+
+        Raises
+        ------
+        KeyError
+            If no session with *session_id* exists.
+        """
+        session = self._sessions[session_id]
+        session.status = SessionStatus.CLOSED
+        return session
+
+    def list_open(self) -> list[MCPSession]:
+        """Return all currently open sessions."""
+        return [s for s in self._sessions.values() if s.status == SessionStatus.OPEN]

--- a/tests/test_mcp_policy.py
+++ b/tests/test_mcp_policy.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import pytest
+
+from openbad.plugins.mcp_policy import (
+    MCPPolicy,
+    MCPScope,
+    MCPSession,
+    MCPSessionManager,
+    PolicyViolationError,
+    SessionStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def manager() -> MCPSessionManager:
+    return MCPSessionManager()
+
+
+@pytest.fixture()
+def read_policy() -> MCPPolicy:
+    return MCPPolicy(max_tools=3, max_calls=10)
+
+
+# ---------------------------------------------------------------------------
+# MCPPolicy
+# ---------------------------------------------------------------------------
+
+
+def test_policy_defaults() -> None:
+    policy = MCPPolicy()
+    assert policy.max_tools is None
+    assert policy.max_calls is None
+    assert MCPScope.READ in policy.allowed_scopes
+
+
+def test_policy_allows_scope() -> None:
+    policy = MCPPolicy(allowed_scopes=frozenset({MCPScope.READ, MCPScope.WRITE}))
+    assert policy.allows_scope(MCPScope.READ) is True
+    assert policy.allows_scope(MCPScope.WRITE) is True
+    assert policy.allows_scope(MCPScope.ADMIN) is False
+
+
+def test_policy_to_dict() -> None:
+    policy = MCPPolicy(max_calls=5, max_tools=2)
+    d = policy.to_dict()
+    assert d["max_calls"] == 5
+    assert d["max_tools"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_create_session_returns_open_session(
+    manager: MCPSessionManager, read_policy: MCPPolicy
+) -> None:
+    session = manager.create_session(read_policy)
+    assert session.status == SessionStatus.OPEN
+
+
+def test_create_session_with_explicit_id(
+    manager: MCPSessionManager, read_policy: MCPPolicy
+) -> None:
+    session = manager.create_session(read_policy, session_id="explicit-1")
+    assert session.session_id == "explicit-1"
+
+
+def test_duplicate_session_id_raises(manager: MCPSessionManager, read_policy: MCPPolicy) -> None:
+    manager.create_session(read_policy, session_id="dup")
+    with pytest.raises(ValueError, match="dup"):
+        manager.create_session(read_policy, session_id="dup")
+
+
+def test_get_session(manager: MCPSessionManager, read_policy: MCPPolicy) -> None:
+    session = manager.create_session(read_policy)
+    retrieved = manager.get_session(session.session_id)
+    assert retrieved is session
+
+
+def test_get_missing_session_returns_none(manager: MCPSessionManager) -> None:
+    assert manager.get_session("missing") is None
+
+
+def test_close_session(manager: MCPSessionManager, read_policy: MCPPolicy) -> None:
+    session = manager.create_session(read_policy)
+    manager.close_session(session.session_id)
+    assert session.status == SessionStatus.CLOSED
+
+
+def test_close_unknown_session_raises(manager: MCPSessionManager) -> None:
+    with pytest.raises(KeyError):
+        manager.close_session("unknown")
+
+
+def test_list_open_sessions(manager: MCPSessionManager, read_policy: MCPPolicy) -> None:
+    s1 = manager.create_session(read_policy)
+    s2 = manager.create_session(read_policy)
+    manager.close_session(s1.session_id)
+
+    open_sessions = manager.list_open()
+    ids = {s.session_id for s in open_sessions}
+    assert s2.session_id in ids
+    assert s1.session_id not in ids
+
+
+# ---------------------------------------------------------------------------
+# Session limit enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_check_limit_allows_within_call_budget() -> None:
+    policy = MCPPolicy(max_calls=3)
+    session = MCPSession(
+        session_id="s1",
+        policy=policy,
+        created_at=__import__("datetime").datetime.now(),
+    )
+    # 2 calls recorded — 1 remaining
+    session.record_call("tool_a")
+    session.record_call("tool_b")
+    session.check_limit("tool_c")  # should not raise
+
+
+def test_check_limit_raises_when_call_limit_hit() -> None:
+    policy = MCPPolicy(max_calls=2)
+    session = MCPSession(
+        session_id="s1",
+        policy=policy,
+        created_at=__import__("datetime").datetime.now(),
+    )
+    session.record_call("tool_a")
+    session.record_call("tool_b")
+
+    with pytest.raises(PolicyViolationError, match="call limit"):
+        session.check_limit("tool_c")
+
+
+def test_check_limit_raises_when_tool_limit_hit() -> None:
+    policy = MCPPolicy(max_tools=2)
+    session = MCPSession(
+        session_id="s1",
+        policy=policy,
+        created_at=__import__("datetime").datetime.now(),
+    )
+    session.record_call("tool_a")
+    session.record_call("tool_b")
+
+    with pytest.raises(PolicyViolationError, match="tool limit"):
+        session.check_limit("tool_c")
+
+
+def test_check_limit_allows_repeat_call_to_existing_tool() -> None:
+    policy = MCPPolicy(max_tools=1)
+    session = MCPSession(
+        session_id="s1",
+        policy=policy,
+        created_at=__import__("datetime").datetime.now(),
+    )
+    session.record_call("tool_a")
+    session.check_limit("tool_a")  # same tool — no new tool slot used
+
+
+def test_check_limit_raises_on_closed_session() -> None:
+    policy = MCPPolicy()
+    session = MCPSession(
+        session_id="s1",
+        policy=policy,
+        created_at=__import__("datetime").datetime.now(),
+        status=SessionStatus.CLOSED,
+    )
+    with pytest.raises(PolicyViolationError, match="closed"):
+        session.check_limit("tool_a")
+
+
+def test_record_call_increments_count() -> None:
+    policy = MCPPolicy()
+    session = MCPSession(
+        session_id="s1",
+        policy=policy,
+        created_at=__import__("datetime").datetime.now(),
+    )
+    session.record_call("tool_a")
+    session.record_call("tool_a")
+    assert session.tools_called["tool_a"] == 2
+    assert session.total_calls == 2
+
+
+def test_session_to_dict_includes_counts() -> None:
+    policy = MCPPolicy(max_calls=10)
+    session = MCPSession(
+        session_id="s1",
+        policy=policy,
+        created_at=__import__("datetime").datetime.now(),
+    )
+    session.record_call("tool_x")
+    d = session.to_dict()
+    assert d["total_calls"] == 1
+    assert d["session_id"] == "s1"


### PR DESCRIPTION
Closes #353

## Summary
- Created `src/openbad/plugins/mcp_policy.py` with:
  - `MCPPolicy`: max_tools / max_calls limits + allowed scopes (frozen dataclass)
  - `MCPScope`: READ / WRITE / ADMIN StrEnum
  - `MCPSession`: tracks tools_called per name; `check_limit()` enforces all limits before execution; `record_call()` after
  - `MCPSessionManager`: create_session / close_session / get_session / list_open
  - `PolicyViolationError` on limit or closed-session breaches

## How to test
```
pytest tests/test_mcp_policy.py -q  # 18 passed
```