### PR TITLE
#354: Enforce MCP access boundaries by execution context

### DIFF
--- a/src/openbad/plugins/mcp_guard.py
+++ b/src/openbad/plugins/mcp_guard.py
@@ -1,0 +1,109 @@
+"""MCP access boundary enforcement for Phase 9.
+
+Only ``TaskExecutor`` and ``Research`` execution contexts are permitted to
+open MCP sessions.  Heartbeat, background, and reflex contexts are explicitly
+denied.
+
+The :class:`MCPAccessGuard` is a thin check layer meant to be called at MCP
+bridge entry points before :class:`~openbad.plugins.mcp_policy.MCPSessionManager`
+is used.
+"""
+
+from __future__ import annotations
+
+from enum import auto
+
+from openbad.plugins.mcp_policy import MCPPolicy, MCPSession, MCPSessionManager
+from openbad.tasks.models import StrEnum
+
+# ---------------------------------------------------------------------------
+# Execution context taxonomy
+# ---------------------------------------------------------------------------
+
+
+class ExecutionContext(StrEnum):
+    """Runtime context in which an MCP session is requested."""
+
+    TASK = auto()
+    RESEARCH = auto()
+    HEARTBEAT = auto()
+    REFLEX = auto()
+    BACKGROUND = auto()
+
+
+# Contexts that may open MCP sessions
+_ALLOWED_CONTEXTS: frozenset[ExecutionContext] = frozenset(
+    {ExecutionContext.TASK, ExecutionContext.RESEARCH}
+)
+
+# Contexts explicitly denied (informational — _ALLOWED_CONTEXTS is the gate)
+_DENIED_CONTEXTS: frozenset[ExecutionContext] = frozenset(
+    {ExecutionContext.HEARTBEAT, ExecutionContext.REFLEX, ExecutionContext.BACKGROUND}
+)
+
+
+# ---------------------------------------------------------------------------
+# Error
+# ---------------------------------------------------------------------------
+
+
+class MCPAccessDeniedError(PermissionError):
+    """Raised when a disallowed execution context requests MCP access."""
+
+
+# ---------------------------------------------------------------------------
+# Guard
+# ---------------------------------------------------------------------------
+
+
+class MCPAccessGuard:
+    """Entry-point guard that enforces context-based MCP access boundaries.
+
+    Parameters
+    ----------
+    session_manager:
+        The :class:`~openbad.plugins.mcp_policy.MCPSessionManager` to delegate
+        session creation to when access is permitted.
+    """
+
+    def __init__(self, session_manager: MCPSessionManager) -> None:
+        self._manager = session_manager
+
+    def open_session(
+        self,
+        context: ExecutionContext,
+        policy: MCPPolicy,
+        *,
+        session_id: str | None = None,
+    ) -> MCPSession:
+        """Open an MCP session, enforcing context allow-list.
+
+        Parameters
+        ----------
+        context:
+            The execution context requesting access.
+        policy:
+            The session policy to apply.
+        session_id:
+            Optional explicit session identifier.
+
+        Returns
+        -------
+        MCPSession
+            The newly created session.
+
+        Raises
+        ------
+        MCPAccessDeniedError
+            If *context* is not in the allowed set.
+        """
+        if context not in _ALLOWED_CONTEXTS:
+            raise MCPAccessDeniedError(
+                f"Execution context {context.value!r} is not permitted to open MCP sessions"
+            )
+        return self._manager.create_session(policy, session_id=session_id)
+
+    @staticmethod
+    def is_allowed(context: ExecutionContext) -> bool:
+        """Return ``True`` if *context* may open MCP sessions."""
+        return context in _ALLOWED_CONTEXTS

--- a/tests/test_mcp_guard.py
+++ b/tests/test_mcp_guard.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from openbad.plugins.mcp_guard import (
+    ExecutionContext,
+    MCPAccessDeniedError,
+    MCPAccessGuard,
+)
+from openbad.plugins.mcp_policy import MCPPolicy, MCPSessionManager, SessionStatus
+
+
+@pytest.fixture()
+def guard() -> MCPAccessGuard:
+    return MCPAccessGuard(MCPSessionManager())
+
+
+@pytest.fixture()
+def policy() -> MCPPolicy:
+    return MCPPolicy()
+
+
+# ---------------------------------------------------------------------------
+# Allowed contexts
+# ---------------------------------------------------------------------------
+
+
+def test_task_context_allowed(guard: MCPAccessGuard, policy: MCPPolicy) -> None:
+    session = guard.open_session(ExecutionContext.TASK, policy)
+    assert session.status == SessionStatus.OPEN
+
+
+def test_research_context_allowed(guard: MCPAccessGuard, policy: MCPPolicy) -> None:
+    session = guard.open_session(ExecutionContext.RESEARCH, policy)
+    assert session.status == SessionStatus.OPEN
+
+
+def test_task_context_with_explicit_policy(guard: MCPAccessGuard) -> None:
+    pol = MCPPolicy(max_calls=5)
+    session = guard.open_session(ExecutionContext.TASK, pol)
+    assert session.policy.max_calls == 5
+
+
+# ---------------------------------------------------------------------------
+# Denied contexts
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_context_denied(guard: MCPAccessGuard, policy: MCPPolicy) -> None:
+    with pytest.raises(MCPAccessDeniedError, match="heartbeat"):
+        guard.open_session(ExecutionContext.HEARTBEAT, policy)
+
+
+def test_reflex_context_denied(guard: MCPAccessGuard, policy: MCPPolicy) -> None:
+    with pytest.raises(MCPAccessDeniedError, match="reflex"):
+        guard.open_session(ExecutionContext.REFLEX, policy)
+
+
+def test_background_context_denied(guard: MCPAccessGuard, policy: MCPPolicy) -> None:
+    with pytest.raises(MCPAccessDeniedError, match="background"):
+        guard.open_session(ExecutionContext.BACKGROUND, policy)
+
+
+# ---------------------------------------------------------------------------
+# is_allowed helper
+# ---------------------------------------------------------------------------
+
+
+def test_is_allowed_task() -> None:
+    assert MCPAccessGuard.is_allowed(ExecutionContext.TASK) is True
+
+
+def test_is_allowed_research() -> None:
+    assert MCPAccessGuard.is_allowed(ExecutionContext.RESEARCH) is True
+
+
+def test_is_allowed_heartbeat_false() -> None:
+    assert MCPAccessGuard.is_allowed(ExecutionContext.HEARTBEAT) is False
+
+
+def test_is_allowed_reflex_false() -> None:
+    assert MCPAccessGuard.is_allowed(ExecutionContext.REFLEX) is False
+
+
+def test_is_allowed_background_false() -> None:
+    assert MCPAccessGuard.is_allowed(ExecutionContext.BACKGROUND) is False


### PR DESCRIPTION
Closes #354

## Summary
- Created `src/openbad/plugins/mcp_guard.py`:
  - `ExecutionContext` StrEnum: TASK, RESEARCH (allowed), HEARTBEAT, REFLEX, BACKGROUND (denied)
  - `MCPAccessGuard.open_session(context, policy)`: allow-list gate before delegating to `MCPSessionManager`
  - `MCPAccessDeniedError` on disallowed context
  - `MCPAccessGuard.is_allowed(context)` static helper

## How to test
```
pytest tests/test_mcp_guard.py -q  # 11 passed
```