### PR TITLE
#355: Persist MCP audit records for every tool invocation

### DIFF
--- a/src/openbad/plugins/mcp_audit.py
+++ b/src/openbad/plugins/mcp_audit.py
@@ -1,0 +1,190 @@
+"""MCP audit record persistence for Phase 9.
+
+Every tool invocation through the MCP session layer produces an
+:class:`AuditRecord` stored in the ``mcp_audit`` table.  Audit entries are
+queryable by ``task_id`` and ``run_id``.
+
+Failed calls include a structured ``error_summary`` string so post-hoc
+analysis can distinguish successful tool calls from errors without decoding
+the full payload.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+
+# ---------------------------------------------------------------------------
+# Schema / initialization
+# ---------------------------------------------------------------------------
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS mcp_audit (
+    audit_id    TEXT PRIMARY KEY,
+    session_id  TEXT NOT NULL,
+    task_id     TEXT,
+    run_id      TEXT,
+    tool_name   TEXT NOT NULL,
+    success     INTEGER NOT NULL DEFAULT 1,
+    error_summary TEXT,
+    payload     TEXT,
+    recorded_at TEXT NOT NULL
+)
+"""
+
+_INSERT = """
+INSERT INTO mcp_audit
+    (audit_id, session_id, task_id, run_id, tool_name, success,
+     error_summary, payload, recorded_at)
+VALUES
+    (:audit_id, :session_id, :task_id, :run_id, :tool_name, :success,
+     :error_summary, :payload, :recorded_at)
+"""
+
+_SELECT_BY_TASK = "SELECT * FROM mcp_audit WHERE task_id = ? ORDER BY recorded_at"
+_SELECT_BY_RUN = "SELECT * FROM mcp_audit WHERE run_id = ? ORDER BY recorded_at"
+
+
+def initialize_audit_db(conn: sqlite3.Connection) -> None:
+    """Create the ``mcp_audit`` table if it does not exist."""
+    conn.execute(_CREATE_TABLE)
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class AuditRecord:
+    """An immutable record of a single MCP tool invocation."""
+
+    audit_id: str
+    session_id: str
+    tool_name: str
+    success: bool
+    recorded_at: datetime
+    task_id: str | None = None
+    run_id: str | None = None
+    error_summary: str | None = None
+    payload: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "audit_id": self.audit_id,
+            "session_id": self.session_id,
+            "task_id": self.task_id,
+            "run_id": self.run_id,
+            "tool_name": self.tool_name,
+            "success": self.success,
+            "error_summary": self.error_summary,
+            "payload": self.payload,
+            "recorded_at": self.recorded_at.isoformat(),
+        }
+
+    @classmethod
+    def _from_row(cls, row: sqlite3.Row) -> AuditRecord:
+        return cls(
+            audit_id=row["audit_id"],
+            session_id=row["session_id"],
+            task_id=row["task_id"],
+            run_id=row["run_id"],
+            tool_name=row["tool_name"],
+            success=bool(row["success"]),
+            error_summary=row["error_summary"],
+            payload=row["payload"],
+            recorded_at=datetime.fromisoformat(row["recorded_at"]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class MCPAuditStore:
+    """Persists and queries MCP tool invocation audit records.
+
+    Parameters
+    ----------
+    conn:
+        An open ``sqlite3.Connection`` with the ``mcp_audit`` table already
+        created (call :func:`initialize_audit_db` beforehand or pass a DB
+        that already has it).
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        conn.row_factory = sqlite3.Row
+        self._conn = conn
+
+    def record(
+        self,
+        session_id: str,
+        tool_name: str,
+        *,
+        success: bool = True,
+        task_id: str | None = None,
+        run_id: str | None = None,
+        error_summary: str | None = None,
+        payload: str | None = None,
+    ) -> AuditRecord:
+        """Persist a tool invocation audit record and return it.
+
+        Parameters
+        ----------
+        session_id:
+            The MCP session that made the call.
+        tool_name:
+            The tool that was invoked.
+        success:
+            Whether the call succeeded.
+        task_id:
+            Optional owning task ID for queryability.
+        run_id:
+            Optional run ID for queryability.
+        error_summary:
+            Human-readable error summary (only on failure).
+        payload:
+            Optional JSON string with extra call context.
+        """
+        now = datetime.now(tz=UTC)
+        audit_id = str(uuid.uuid4())
+        self._conn.execute(
+            _INSERT,
+            {
+                "audit_id": audit_id,
+                "session_id": session_id,
+                "task_id": task_id,
+                "run_id": run_id,
+                "tool_name": tool_name,
+                "success": int(success),
+                "error_summary": error_summary,
+                "payload": payload,
+                "recorded_at": now.isoformat(),
+            },
+        )
+        self._conn.commit()
+        return AuditRecord(
+            audit_id=audit_id,
+            session_id=session_id,
+            task_id=task_id,
+            run_id=run_id,
+            tool_name=tool_name,
+            success=success,
+            error_summary=error_summary,
+            payload=payload,
+            recorded_at=now,
+        )
+
+    def query_by_task(self, task_id: str) -> list[AuditRecord]:
+        """Return all audit records for *task_id*, oldest first."""
+        rows = self._conn.execute(_SELECT_BY_TASK, (task_id,)).fetchall()
+        return [AuditRecord._from_row(r) for r in rows]
+
+    def query_by_run(self, run_id: str) -> list[AuditRecord]:
+        """Return all audit records for *run_id*, oldest first."""
+        rows = self._conn.execute(_SELECT_BY_RUN, (run_id,)).fetchall()
+        return [AuditRecord._from_row(r) for r in rows]

--- a/tests/test_mcp_audit.py
+++ b/tests/test_mcp_audit.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from openbad.plugins.mcp_audit import AuditRecord, MCPAuditStore, initialize_audit_db
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "audit.db")
+    initialize_audit_db(conn)
+    return conn
+
+
+@pytest.fixture()
+def store(db: sqlite3.Connection) -> MCPAuditStore:
+    return MCPAuditStore(db)
+
+
+# ---------------------------------------------------------------------------
+# Success audit write
+# ---------------------------------------------------------------------------
+
+
+def test_record_success_returns_audit_record(store: MCPAuditStore) -> None:
+    rec = store.record(session_id="s1", tool_name="file.read")
+
+    assert isinstance(rec, AuditRecord)
+    assert rec.success is True
+    assert rec.tool_name == "file.read"
+    assert rec.audit_id
+
+
+def test_record_success_no_error_summary(store: MCPAuditStore) -> None:
+    rec = store.record(session_id="s1", tool_name="file.read")
+    assert rec.error_summary is None
+
+
+def test_record_success_with_task_and_run(store: MCPAuditStore) -> None:
+    rec = store.record(
+        session_id="s1",
+        tool_name="db.insert",
+        task_id="task-123",
+        run_id="run-456",
+    )
+    assert rec.task_id == "task-123"
+    assert rec.run_id == "run-456"
+
+
+# ---------------------------------------------------------------------------
+# Failure audit write
+# ---------------------------------------------------------------------------
+
+
+def test_record_failure_sets_success_false(store: MCPAuditStore) -> None:
+    rec = store.record(
+        session_id="s1",
+        tool_name="bad.tool",
+        success=False,
+        error_summary="permission denied",
+    )
+    assert rec.success is False
+    assert rec.error_summary == "permission denied"
+
+
+def test_record_failure_has_audit_id(store: MCPAuditStore) -> None:
+    rec = store.record(
+        session_id="s1", tool_name="bad.tool", success=False, error_summary="err"
+    )
+    assert rec.audit_id
+
+
+# ---------------------------------------------------------------------------
+# Audit query by task
+# ---------------------------------------------------------------------------
+
+
+def test_query_by_task_returns_records(store: MCPAuditStore) -> None:
+    store.record(session_id="s1", tool_name="file.read", task_id="t1")
+    store.record(session_id="s1", tool_name="db.insert", task_id="t1")
+
+    records = store.query_by_task("t1")
+    assert len(records) == 2
+
+
+def test_query_by_task_excludes_other_tasks(store: MCPAuditStore) -> None:
+    store.record(session_id="s1", tool_name="file.read", task_id="t1")
+    store.record(session_id="s2", tool_name="file.read", task_id="t2")
+
+    records = store.query_by_task("t1")
+    assert all(r.task_id == "t1" for r in records)
+
+
+def test_query_by_task_empty_result(store: MCPAuditStore) -> None:
+    assert store.query_by_task("no-such-task") == []
+
+
+# ---------------------------------------------------------------------------
+# Audit query by run
+# ---------------------------------------------------------------------------
+
+
+def test_query_by_run_returns_records(store: MCPAuditStore) -> None:
+    store.record(session_id="s1", tool_name="tool_a", run_id="r1")
+    store.record(session_id="s1", tool_name="tool_b", run_id="r1")
+    store.record(session_id="s1", tool_name="tool_c", run_id="r2")
+
+    records = store.query_by_run("r1")
+    assert len(records) == 2
+    assert all(r.run_id == "r1" for r in records)
+
+
+def test_query_by_run_empty_result(store: MCPAuditStore) -> None:
+    assert store.query_by_run("nonexistent-run") == []
+
+
+def test_audit_record_to_dict(store: MCPAuditStore) -> None:
+    rec = store.record(
+        session_id="s1",
+        tool_name="file.read",
+        task_id="t1",
+        success=True,
+    )
+    d = rec.to_dict()
+    assert d["tool_name"] == "file.read"
+    assert d["success"] is True
+    assert "recorded_at" in d


### PR DESCRIPTION
Closes #355

## Summary
- Created `src/openbad/plugins/mcp_audit.py`:
  - `MCPAuditStore`: stores every tool invocation in `mcp_audit` SQLite table
  - `record()`: writes success/failure entries with optional task_id/run_id
  - `query_by_task()` / `query_by_run()`: query audit entries
  - `AuditRecord`: frozen dataclass with `to_dict()` 
  - `initialize_audit_db(conn)`: creates table

## How to test
```
pytest tests/test_mcp_audit.py -q  # 11 passed
```