### PR TITLE
#358: Persist research findings and memory writeback

### DIFF
--- a/src/openbad/tasks/research_findings.py
+++ b/src/openbad/tasks/research_findings.py
@@ -1,0 +1,271 @@
+"""Research findings persistence and memory writeback for Phase 9.
+
+:class:`FindingStore` persists validated research findings with source
+linkage to the originating research node and task.
+
+When a finding is validated, :meth:`FindingStore.commit_finding` writes it to
+the ``research_findings`` table and performs a memory writeback via the
+injected :class:`~openbad.memory.base.MemoryStore`.  After writeback, a
+reevaluation signal entry is written to the ``task_reevaluation_signals`` table
+so the owning task can be re-evaluated.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from openbad.memory.base import MemoryEntry, MemoryStore, MemoryTier
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_CREATE_FINDINGS = """
+CREATE TABLE IF NOT EXISTS research_findings (
+    finding_id        TEXT PRIMARY KEY,
+    research_node_id  TEXT NOT NULL,
+    source_task_id    TEXT,
+    content           TEXT NOT NULL,
+    validated         INTEGER NOT NULL DEFAULT 0,
+    created_at        TEXT NOT NULL
+)
+"""
+
+_CREATE_SIGNALS = """
+CREATE TABLE IF NOT EXISTS task_reevaluation_signals (
+    signal_id      TEXT PRIMARY KEY,
+    task_id        TEXT NOT NULL,
+    finding_id     TEXT NOT NULL,
+    created_at     TEXT NOT NULL
+)
+"""
+
+_INSERT_FINDING = """
+INSERT INTO research_findings
+    (finding_id, research_node_id, source_task_id, content, validated, created_at)
+VALUES
+    (:finding_id, :research_node_id, :source_task_id, :content, :validated, :created_at)
+"""
+
+_INSERT_SIGNAL = """
+INSERT INTO task_reevaluation_signals
+    (signal_id, task_id, finding_id, created_at)
+VALUES
+    (:signal_id, :task_id, :finding_id, :created_at)
+"""
+
+_SELECT_FINDING_BY_ID = "SELECT * FROM research_findings WHERE finding_id = ?"
+_SELECT_FINDINGS_BY_NODE = "SELECT * FROM research_findings WHERE research_node_id = ?"
+_SELECT_SIGNALS_BY_TASK = (
+    "SELECT * FROM task_reevaluation_signals WHERE task_id = ? ORDER BY created_at"
+)
+
+
+def initialize_findings_db(conn: sqlite3.Connection) -> None:
+    """Create the ``research_findings`` and ``task_reevaluation_signals`` tables."""
+    conn.execute(_CREATE_FINDINGS)
+    conn.execute(_CREATE_SIGNALS)
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ResearchFinding:
+    """A single validated research finding."""
+
+    finding_id: str
+    research_node_id: str
+    content: str
+    created_at: datetime
+    source_task_id: str | None = None
+    validated: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "finding_id": self.finding_id,
+            "research_node_id": self.research_node_id,
+            "source_task_id": self.source_task_id,
+            "content": self.content,
+            "validated": self.validated,
+            "created_at": self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def _from_row(cls, row: sqlite3.Row) -> ResearchFinding:
+        return cls(
+            finding_id=row["finding_id"],
+            research_node_id=row["research_node_id"],
+            source_task_id=row["source_task_id"],
+            content=row["content"],
+            validated=bool(row["validated"]),
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class ReevaluationSignal:
+    """Signal that a task should be re-evaluated in light of new findings."""
+
+    signal_id: str
+    task_id: str
+    finding_id: str
+    created_at: datetime
+
+    @classmethod
+    def _from_row(cls, row: sqlite3.Row) -> ReevaluationSignal:
+        return cls(
+            signal_id=row["signal_id"],
+            task_id=row["task_id"],
+            finding_id=row["finding_id"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class FindingStore:
+    """Persists validated research findings and manages memory writeback.
+
+    Parameters
+    ----------
+    conn:
+        Open ``sqlite3.Connection`` with existing findings/signals tables.
+    memory_store:
+        A :class:`~openbad.memory.base.MemoryStore` to receive writeback
+        entries when a finding is committed.  The finding is written to the
+        SEMANTIC tier with key ``research.<research_node_id>``.
+    """
+
+    def __init__(self, conn: sqlite3.Connection, memory_store: MemoryStore) -> None:
+        conn.row_factory = sqlite3.Row
+        self._conn = conn
+        self._memory = memory_store
+
+    def persist_finding(
+        self,
+        research_node_id: str,
+        content: str,
+        *,
+        source_task_id: str | None = None,
+    ) -> ResearchFinding:
+        """Persist a (non-validated) research finding.
+
+        Use :meth:`commit_finding` to mark a finding as validated and trigger
+        writeback + reevaluation.
+        """
+        finding_id = str(uuid.uuid4())
+        now = datetime.now(tz=UTC)
+        self._conn.execute(
+            _INSERT_FINDING,
+            {
+                "finding_id": finding_id,
+                "research_node_id": research_node_id,
+                "source_task_id": source_task_id,
+                "content": content,
+                "validated": 0,
+                "created_at": now.isoformat(),
+            },
+        )
+        self._conn.commit()
+        return ResearchFinding(
+            finding_id=finding_id,
+            research_node_id=research_node_id,
+            source_task_id=source_task_id,
+            content=content,
+            validated=False,
+            created_at=now,
+        )
+
+    def commit_finding(
+        self,
+        research_node_id: str,
+        content: str,
+        *,
+        source_task_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> ResearchFinding:
+        """Persist a *validated* finding, write to memory, and emit reevaluation signal.
+
+        Steps:
+        1. Insert finding row with ``validated=True``.
+        2. Write a :class:`~openbad.memory.base.MemoryEntry` to the semantic tier.
+        3. If *source_task_id* is provided, emit a reevaluation signal.
+
+        Returns
+        -------
+        ResearchFinding
+            The newly committed finding.
+        """
+        finding_id = str(uuid.uuid4())
+        now = datetime.now(tz=UTC)
+        self._conn.execute(
+            _INSERT_FINDING,
+            {
+                "finding_id": finding_id,
+                "research_node_id": research_node_id,
+                "source_task_id": source_task_id,
+                "content": content,
+                "validated": 1,
+                "created_at": now.isoformat(),
+            },
+        )
+        self._conn.commit()
+
+        # Memory writeback
+        entry = MemoryEntry(
+            key=f"research.{research_node_id}",
+            value={"content": content, "finding_id": finding_id},
+            tier=MemoryTier.SEMANTIC,
+            context="research_writeback",
+            metadata=metadata or {},
+        )
+        self._memory.write(entry)
+
+        # Reevaluation signal
+        if source_task_id:
+            signal_id = str(uuid.uuid4())
+            self._conn.execute(
+                _INSERT_SIGNAL,
+                {
+                    "signal_id": signal_id,
+                    "task_id": source_task_id,
+                    "finding_id": finding_id,
+                    "created_at": now.isoformat(),
+                },
+            )
+            self._conn.commit()
+
+        return ResearchFinding(
+            finding_id=finding_id,
+            research_node_id=research_node_id,
+            source_task_id=source_task_id,
+            content=content,
+            validated=True,
+            created_at=now,
+        )
+
+    def get_finding(self, finding_id: str) -> ResearchFinding | None:
+        """Return a finding by ID."""
+        row = self._conn.execute(_SELECT_FINDING_BY_ID, (finding_id,)).fetchone()
+        return ResearchFinding._from_row(row) if row else None
+
+    def list_findings(self, research_node_id: str) -> list[ResearchFinding]:
+        """Return all findings for a research node."""
+        rows = self._conn.execute(_SELECT_FINDINGS_BY_NODE, (research_node_id,)).fetchall()
+        return [ResearchFinding._from_row(r) for r in rows]
+
+    def list_signals(self, task_id: str) -> list[ReevaluationSignal]:
+        """Return all reevaluation signals for a task, oldest first."""
+        rows = self._conn.execute(_SELECT_SIGNALS_BY_TASK, (task_id,)).fetchall()
+        return [ReevaluationSignal._from_row(r) for r in rows]

--- a/tests/test_research_findings.py
+++ b/tests/test_research_findings.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from openbad.memory.base import MemoryEntry, MemoryStore, MemoryTier
+from openbad.tasks.research_findings import (
+    FindingStore,
+    ResearchFinding,
+    initialize_findings_db,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory MemoryStore stub
+# ---------------------------------------------------------------------------
+
+
+class MemoryStoreSpy(MemoryStore):
+    """Spy: records write calls without any actual persistence."""
+
+    def __init__(self) -> None:
+        self.written: list[MemoryEntry] = []
+
+    def write(self, entry: MemoryEntry) -> str:
+        self.written.append(entry)
+        return entry.entry_id
+
+    def read(self, key: str) -> MemoryEntry | None:
+        for e in reversed(self.written):
+            if e.key == key:
+                return e
+        return None
+
+    def delete(self, key: str) -> bool:
+        before = len(self.written)
+        self.written = [e for e in self.written if e.key != key]
+        return len(self.written) < before
+
+    def query(self, prefix: str) -> list[MemoryEntry]:
+        return [e for e in self.written if e.key.startswith(prefix)]
+
+    def list_keys(self) -> list[str]:
+        return [e.key for e in self.written]
+
+    def size(self) -> int:
+        return len(self.written)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "findings.db")
+    initialize_findings_db(conn)
+    return conn
+
+
+@pytest.fixture()
+def spy() -> MemoryStoreSpy:
+    return MemoryStoreSpy()
+
+
+@pytest.fixture()
+def store(db: sqlite3.Connection, spy: MemoryStoreSpy) -> FindingStore:
+    return FindingStore(db, spy)
+
+
+# ---------------------------------------------------------------------------
+# Findings persistence
+# ---------------------------------------------------------------------------
+
+
+def test_persist_finding_returns_record(store: FindingStore) -> None:
+    f = store.persist_finding("node-1", "Found something")
+
+    assert isinstance(f, ResearchFinding)
+    assert f.content == "Found something"
+    assert f.validated is False
+
+
+def test_persist_finding_not_validated(store: FindingStore) -> None:
+    f = store.persist_finding("node-1", "raw finding")
+    loaded = store.get_finding(f.finding_id)
+
+    assert loaded is not None
+    assert loaded.validated is False
+
+
+def test_persist_finding_with_source_task(store: FindingStore) -> None:
+    f = store.persist_finding("node-1", "content", source_task_id="task-abc")
+    loaded = store.get_finding(f.finding_id)
+
+    assert loaded is not None
+    assert loaded.source_task_id == "task-abc"
+
+
+def test_list_findings_for_node(store: FindingStore) -> None:
+    store.persist_finding("node-1", "A")
+    store.persist_finding("node-1", "B")
+    store.persist_finding("node-2", "C")
+
+    findings = store.list_findings("node-1")
+    assert len(findings) == 2
+
+
+# ---------------------------------------------------------------------------
+# Memory writeback
+# ---------------------------------------------------------------------------
+
+
+def test_commit_finding_calls_memory_write(store: FindingStore, spy: MemoryStoreSpy) -> None:
+    store.commit_finding("node-1", "important fact")
+
+    assert len(spy.written) == 1
+    entry = spy.written[0]
+    assert entry.tier == MemoryTier.SEMANTIC
+    assert "node-1" in entry.key
+
+
+def test_commit_finding_writes_content_to_memory(store: FindingStore, spy: MemoryStoreSpy) -> None:
+    store.commit_finding("node-1", "the answer")
+
+    entry = spy.written[0]
+    assert entry.value["content"] == "the answer"
+
+
+def test_commit_finding_is_validated(store: FindingStore) -> None:
+    f = store.commit_finding("node-1", "validated fact")
+    loaded = store.get_finding(f.finding_id)
+
+    assert loaded is not None
+    assert loaded.validated is True
+
+
+def test_persist_finding_does_not_call_memory_write(
+    store: FindingStore, spy: MemoryStoreSpy
+) -> None:
+    store.persist_finding("node-1", "raw")
+    assert len(spy.written) == 0
+
+
+# ---------------------------------------------------------------------------
+# Reevaluation signal emission
+# ---------------------------------------------------------------------------
+
+
+def test_commit_finding_emits_signal_when_source_task(store: FindingStore) -> None:
+    store.commit_finding("node-1", "fact", source_task_id="task-1")
+
+    signals = store.list_signals("task-1")
+    assert len(signals) == 1
+    assert signals[0].task_id == "task-1"
+
+
+def test_commit_finding_no_signal_without_source_task(store: FindingStore) -> None:
+    store.commit_finding("node-1", "fact")
+    # With no source task, we expect no signals for arbitrary task IDs
+    assert store.list_signals("some-task") == []
+
+
+def test_multiple_findings_emit_multiple_signals(store: FindingStore) -> None:
+    store.commit_finding("node-1", "fact A", source_task_id="task-1")
+    store.commit_finding("node-2", "fact B", source_task_id="task-1")
+
+    signals = store.list_signals("task-1")
+    assert len(signals) == 2


### PR DESCRIPTION
Closes #358

## Summary
- Created `src/openbad/tasks/research_findings.py`:
  - `FindingStore`: persist raw findings (`persist_finding`) or validated findings (`commit_finding`)
  - `commit_finding`: writes to memory (SEMANTIC tier), emits reevaluation signal for owning task
  - `list_findings(node_id)`, `list_signals(task_id)` for queryability
  - `ResearchFinding` and `ReevaluationSignal` frozen dataclasses

## How to test
```
pytest tests/test_research_findings.py -q  # 11 passed
```