### PR TITLE
#359: Define reward trace and result models

### DIFF
--- a/src/openbad/tasks/reward_models.py
+++ b/src/openbad/tasks/reward_models.py
@@ -1,0 +1,174 @@
+"""Reward trace and result models for Phase 9.
+
+These types form the input/output contract for the reward template evaluator
+(#360).  All models are frozen dataclasses with explicit validation and full
+``to_dict`` / ``from_dict`` round-trip support.
+
+:class:`RewardTrace` captures the execution history of a task node: its
+outcome, duration, retry count, and optional structured context.
+:class:`RewardResult` is the scalar output of an evaluator operating on a
+trace.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from enum import auto
+from typing import Any
+
+from openbad.tasks.models import StrEnum
+
+# ---------------------------------------------------------------------------
+# Outcome taxonomy
+# ---------------------------------------------------------------------------
+
+
+class TraceOutcome(StrEnum):
+    """High-level outcome of a traced node execution."""
+
+    SUCCESS = auto()
+    FAILURE = auto()
+    TIMEOUT = auto()
+    CANCELLED = auto()
+
+
+# ---------------------------------------------------------------------------
+# RewardTrace
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_TRACE_FIELDS = frozenset(
+    {"node_id", "task_id", "outcome", "duration_ms", "retry_count"}
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class RewardTrace:
+    """Immutable execution trace for a single task node.
+
+    Parameters
+    ----------
+    node_id:
+        The node that was executed.
+    task_id:
+        The parent task.
+    outcome:
+        The execution outcome.
+    duration_ms:
+        Elapsed wall-clock milliseconds for the execution.
+    retry_count:
+        How many times this node was retried before the current trace.
+    context:
+        Optional additional context (e.g., model name, capability ID).
+    """
+
+    node_id: str
+    task_id: str
+    outcome: TraceOutcome
+    duration_ms: int
+    retry_count: int
+    context: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.duration_ms < 0:
+            raise ValueError("duration_ms must be non-negative")
+        if self.retry_count < 0:
+            raise ValueError("retry_count must be non-negative")
+
+    def to_dict(self) -> dict:
+        return {
+            "node_id": self.node_id,
+            "task_id": self.task_id,
+            "outcome": self.outcome.value,
+            "duration_ms": self.duration_ms,
+            "retry_count": self.retry_count,
+            "context": dict(self.context),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> RewardTrace:
+        """Deserialize a :class:`RewardTrace` from *data*.
+
+        Raises
+        ------
+        ValueError
+            If any required field is missing.
+        """
+        missing = _REQUIRED_TRACE_FIELDS - data.keys()
+        if missing:
+            raise ValueError(f"Missing required fields: {sorted(missing)}")
+        return cls(
+            node_id=data["node_id"],
+            task_id=data["task_id"],
+            outcome=TraceOutcome(data["outcome"]),
+            duration_ms=int(data["duration_ms"]),
+            retry_count=int(data["retry_count"]),
+            context=dict(data.get("context") or {}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# RewardResult
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_RESULT_FIELDS = frozenset({"trace_node_id", "score", "template_id"})
+
+
+@dataclasses.dataclass(frozen=True)
+class RewardResult:
+    """Scalar reward output produced by the evaluator for a single trace.
+
+    Parameters
+    ----------
+    trace_node_id:
+        The node ID from the originating :class:`RewardTrace`.
+    score:
+        Reward score in the range ``[-1.0, 1.0]``.  Positive values signal a
+        good outcome; negative values signal a bad outcome.
+    template_id:
+        Identifier of the template that produced this result.
+    rationale:
+        Optional human-readable explanation of the score.
+    metadata:
+        Optional structured metadata.
+    """
+
+    trace_node_id: str
+    score: float
+    template_id: str
+    rationale: str = ""
+    metadata: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not (-1.0 <= self.score <= 1.0):
+            raise ValueError(f"score must be in [-1.0, 1.0], got {self.score}")
+
+    def to_dict(self) -> dict:
+        return {
+            "trace_node_id": self.trace_node_id,
+            "score": self.score,
+            "template_id": self.template_id,
+            "rationale": self.rationale,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> RewardResult:
+        """Deserialize a :class:`RewardResult` from *data*.
+
+        Raises
+        ------
+        ValueError
+            If any required field is missing or *score* is out of range.
+        """
+        missing = _REQUIRED_RESULT_FIELDS - data.keys()
+        if missing:
+            raise ValueError(f"Missing required fields: {sorted(missing)}")
+        return cls(
+            trace_node_id=data["trace_node_id"],
+            score=float(data["score"]),
+            template_id=data["template_id"],
+            rationale=data.get("rationale", ""),
+            metadata=dict(data.get("metadata") or {}),
+        )

--- a/tests/test_reward_models.py
+++ b/tests/test_reward_models.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import pytest
+
+from openbad.tasks.reward_models import (
+    RewardResult,
+    RewardTrace,
+    TraceOutcome,
+)
+
+# ---------------------------------------------------------------------------
+# RewardTrace — validation
+# ---------------------------------------------------------------------------
+
+
+def test_trace_created_with_required_fields() -> None:
+    trace = RewardTrace(
+        node_id="n1",
+        task_id="t1",
+        outcome=TraceOutcome.SUCCESS,
+        duration_ms=200,
+        retry_count=0,
+    )
+    assert trace.node_id == "n1"
+    assert trace.outcome == TraceOutcome.SUCCESS
+
+
+def test_trace_negative_duration_raises() -> None:
+    with pytest.raises(ValueError, match="duration_ms"):
+        RewardTrace(
+            node_id="n1",
+            task_id="t1",
+            outcome=TraceOutcome.SUCCESS,
+            duration_ms=-1,
+            retry_count=0,
+        )
+
+
+def test_trace_negative_retry_count_raises() -> None:
+    with pytest.raises(ValueError, match="retry_count"):
+        RewardTrace(
+            node_id="n1",
+            task_id="t1",
+            outcome=TraceOutcome.FAILURE,
+            duration_ms=0,
+            retry_count=-1,
+        )
+
+
+def test_trace_from_dict_missing_field_raises() -> None:
+    with pytest.raises(ValueError, match="Missing required fields"):
+        RewardTrace.from_dict({"node_id": "n1", "task_id": "t1"})
+
+
+def test_trace_from_dict_invalid_outcome_raises() -> None:
+    with pytest.raises(ValueError):
+        RewardTrace.from_dict(
+            {
+                "node_id": "n1",
+                "task_id": "t1",
+                "outcome": "NOT_VALID",
+                "duration_ms": 100,
+                "retry_count": 0,
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# RewardTrace — serialization round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_trace_round_trip() -> None:
+    trace = RewardTrace(
+        node_id="n1",
+        task_id="t1",
+        outcome=TraceOutcome.SUCCESS,
+        duration_ms=500,
+        retry_count=2,
+        context={"model": "gpt-4"},
+    )
+    loaded = RewardTrace.from_dict(trace.to_dict())
+
+    assert loaded.node_id == trace.node_id
+    assert loaded.outcome == trace.outcome
+    assert loaded.duration_ms == trace.duration_ms
+    assert loaded.retry_count == trace.retry_count
+    assert loaded.context == trace.context
+
+
+def test_trace_to_dict_contains_required_keys() -> None:
+    trace = RewardTrace(
+        node_id="n1",
+        task_id="t1",
+        outcome=TraceOutcome.TIMEOUT,
+        duration_ms=0,
+        retry_count=1,
+    )
+    d = trace.to_dict()
+    for key in ("node_id", "task_id", "outcome", "duration_ms", "retry_count"):
+        assert key in d
+
+
+# ---------------------------------------------------------------------------
+# RewardResult — validation
+# ---------------------------------------------------------------------------
+
+
+def test_result_score_out_of_range_high_raises() -> None:
+    with pytest.raises(ValueError, match="score"):
+        RewardResult(trace_node_id="n1", score=1.5, template_id="tmpl")
+
+
+def test_result_score_out_of_range_low_raises() -> None:
+    with pytest.raises(ValueError, match="score"):
+        RewardResult(trace_node_id="n1", score=-2.0, template_id="tmpl")
+
+
+def test_result_score_boundary_valid() -> None:
+    hi = RewardResult(trace_node_id="n1", score=1.0, template_id="tmpl")
+    lo = RewardResult(trace_node_id="n1", score=-1.0, template_id="tmpl")
+    assert hi.score == 1.0
+    assert lo.score == -1.0
+
+
+def test_result_from_dict_missing_field_raises() -> None:
+    with pytest.raises(ValueError, match="Missing required fields"):
+        RewardResult.from_dict({"trace_node_id": "n1"})
+
+
+# ---------------------------------------------------------------------------
+# RewardResult — serialization round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_result_round_trip() -> None:
+    result = RewardResult(
+        trace_node_id="n1",
+        score=0.75,
+        template_id="success_template",
+        rationale="All steps completed",
+        metadata={"version": "1.0"},
+    )
+    loaded = RewardResult.from_dict(result.to_dict())
+
+    assert loaded.trace_node_id == result.trace_node_id
+    assert loaded.score == result.score
+    assert loaded.template_id == result.template_id
+    assert loaded.rationale == result.rationale
+    assert loaded.metadata == result.metadata
+
+
+def test_result_to_dict_contains_required_keys() -> None:
+    result = RewardResult(trace_node_id="n1", score=0.0, template_id="t")
+    d = result.to_dict()
+    for key in ("trace_node_id", "score", "template_id", "rationale", "metadata"):
+        assert key in d


### PR DESCRIPTION
Closes #359

## Summary
- Created `src/openbad/tasks/reward_models.py`:
  - `TraceOutcome`: SUCCESS / FAILURE / TIMEOUT / CANCELLED StrEnum
  - `RewardTrace`: frozen dataclass (node_id, task_id, outcome, duration_ms, retry_count, context); validates non-negative fields; `to_dict`/`from_dict`
  - `RewardResult`: frozen dataclass (trace_node_id, score ∈ [-1,1], template_id, rationale, metadata); validates score range; `to_dict`/`from_dict`

## How to test
```
pytest tests/test_reward_models.py -q  # 13 passed
```