### PR TITLE
#360: Implement deterministic reward template evaluator

### DIFF
--- a/src/openbad/tasks/reward_evaluator.py
+++ b/src/openbad/tasks/reward_evaluator.py
@@ -1,0 +1,181 @@
+"""Deterministic reward template evaluator for Phase 9.
+
+Templates are pure functions: identical traces always produce identical results.
+Each :class:`RewardTemplate` encodes a scoring rule for a specific combination
+of outcome and context.  The :class:`RewardEvaluator` selects the most
+specific matching template and applies it.
+
+Template matching priority (most → least specific):
+1. ``outcome`` AND ``context_key`` match
+2. ``outcome`` only
+3. wildcard (``outcome=None``)
+
+If no template matches, a default score of ``0.0`` is returned.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from openbad.tasks.reward_models import RewardResult, RewardTrace, TraceOutcome
+
+# ---------------------------------------------------------------------------
+# Template
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class RewardTemplate:
+    """A scoring rule applied to a :class:`~openbad.tasks.reward_models.RewardTrace`.
+
+    Parameters
+    ----------
+    template_id:
+        Unique identifier for this template.
+    base_score:
+        Base reward score before adjustments.  Must be in ``[-1.0, 1.0]``.
+    outcome:
+        The :class:`~openbad.tasks.reward_models.TraceOutcome` this template
+        applies to.  ``None`` means wildcard (match any outcome).
+    context_key:
+        If set, this template only matches when ``trace.context`` contains
+        a truthy value for this key.  ``None`` means no context requirement.
+    retry_penalty:
+        Score reduction applied per retry.  Default ``0.05``.  Clamped so
+        the final score never drops below ``-1.0``.
+    """
+
+    template_id: str
+    base_score: float
+    outcome: TraceOutcome | None = None
+    context_key: str | None = None
+    retry_penalty: float = 0.05
+
+    def matches(self, trace: RewardTrace) -> bool:
+        """Return ``True`` if this template applies to *trace*."""
+        if self.outcome is not None and trace.outcome != self.outcome:
+            return False
+        return not (self.context_key is not None and not trace.context.get(self.context_key))
+
+    def specificity(self) -> int:
+        """Higher specificity templates are preferred.  Range ``[0, 2]``."""
+        score = 0
+        if self.outcome is not None:
+            score += 1
+        if self.context_key is not None:
+            score += 1
+        return score
+
+    def evaluate(self, trace: RewardTrace) -> RewardResult:
+        """Apply the template to *trace* and return a :class:`RewardResult`."""
+        raw = self.base_score - (self.retry_penalty * trace.retry_count)
+        clamped = max(-1.0, min(1.0, raw))
+        return RewardResult(
+            trace_node_id=trace.node_id,
+            score=clamped,
+            template_id=self.template_id,
+            rationale=_build_rationale(trace, clamped, raw, self),
+        )
+
+
+def _build_rationale(
+    trace: RewardTrace, final_score: float, raw_score: float, template: RewardTemplate
+) -> str:
+    parts = [
+        f"template={template.template_id}",
+        f"outcome={trace.outcome.value}",
+        f"base_score={template.base_score}",
+    ]
+    if trace.retry_count:
+        penalty = template.retry_penalty * trace.retry_count
+        parts.append(
+            f"retry_penalty={template.retry_penalty}x{trace.retry_count}={penalty:.3f}"
+        )
+    if final_score != raw_score:
+        parts.append(f"clamped from {raw_score:.3f}")
+    parts.append(f"final_score={final_score}")
+    return "; ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Default templates
+# ---------------------------------------------------------------------------
+
+DEFAULT_TEMPLATES: list[RewardTemplate] = [
+    RewardTemplate(
+        template_id="success.default",
+        base_score=1.0,
+        outcome=TraceOutcome.SUCCESS,
+    ),
+    RewardTemplate(
+        template_id="failure.default",
+        base_score=-0.5,
+        outcome=TraceOutcome.FAILURE,
+    ),
+    RewardTemplate(
+        template_id="timeout.default",
+        base_score=-0.75,
+        outcome=TraceOutcome.TIMEOUT,
+    ),
+    RewardTemplate(
+        template_id="cancelled.default",
+        base_score=0.0,
+        outcome=TraceOutcome.CANCELLED,
+    ),
+    # Wildcard — lowest priority fallback
+    RewardTemplate(
+        template_id="wildcard.default",
+        base_score=0.0,
+        outcome=None,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Evaluator
+# ---------------------------------------------------------------------------
+
+
+class RewardEvaluator:
+    """Selects and applies the best-matching :class:`RewardTemplate`.
+
+    Parameters
+    ----------
+    templates:
+        Ordered list of templates.  The evaluator picks the template with the
+        highest :meth:`~RewardTemplate.specificity` that matches *trace*.  On
+        equal specificity, the first match wins.
+    """
+
+    def __init__(self, templates: list[RewardTemplate] | None = None) -> None:
+        self._templates = templates if templates is not None else list(DEFAULT_TEMPLATES)
+
+    def evaluate(self, trace: RewardTrace) -> RewardResult:
+        """Evaluate *trace* and return a :class:`RewardResult`.
+
+        Returns a zero-score result with template ``"no_match"`` when no
+        template applies.
+        """
+        best: RewardTemplate | None = None
+        best_specificity = -1
+
+        for tmpl in self._templates:
+            if tmpl.matches(trace):
+                sp = tmpl.specificity()
+                if sp > best_specificity:
+                    best = tmpl
+                    best_specificity = sp
+
+        if best is None:
+            return RewardResult(
+                trace_node_id=trace.node_id,
+                score=0.0,
+                template_id="no_match",
+                rationale="No matching template",
+            )
+
+        return best.evaluate(trace)
+
+    def add_template(self, template: RewardTemplate) -> None:
+        """Append a template to the evaluator's template list."""
+        self._templates.append(template)

--- a/tests/test_reward_evaluator.py
+++ b/tests/test_reward_evaluator.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import pytest
+
+from openbad.tasks.reward_evaluator import (
+    DEFAULT_TEMPLATES,
+    RewardEvaluator,
+    RewardTemplate,
+)
+from openbad.tasks.reward_models import RewardTrace, TraceOutcome
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+
+def make_trace(
+    outcome: TraceOutcome = TraceOutcome.SUCCESS,
+    retry_count: int = 0,
+    context: dict | None = None,
+) -> RewardTrace:
+    return RewardTrace(
+        node_id="n1",
+        task_id="t1",
+        outcome=outcome,
+        duration_ms=100,
+        retry_count=retry_count,
+        context=context or {},
+    )
+
+
+@pytest.fixture()
+def evaluator() -> RewardEvaluator:
+    return RewardEvaluator()
+
+
+# ---------------------------------------------------------------------------
+# Template outputs for representative traces
+# ---------------------------------------------------------------------------
+
+
+def test_success_trace_produces_positive_score(evaluator: RewardEvaluator) -> None:
+    result = evaluator.evaluate(make_trace(outcome=TraceOutcome.SUCCESS))
+    assert result.score > 0
+
+
+def test_failure_trace_produces_negative_score(evaluator: RewardEvaluator) -> None:
+    result = evaluator.evaluate(make_trace(outcome=TraceOutcome.FAILURE))
+    assert result.score < 0
+
+
+def test_timeout_trace_produces_negative_score(evaluator: RewardEvaluator) -> None:
+    result = evaluator.evaluate(make_trace(outcome=TraceOutcome.TIMEOUT))
+    assert result.score < 0
+
+
+def test_cancelled_trace_produces_zero_score(evaluator: RewardEvaluator) -> None:
+    result = evaluator.evaluate(make_trace(outcome=TraceOutcome.CANCELLED))
+    assert result.score == 0.0
+
+
+def test_result_template_id_set(evaluator: RewardEvaluator) -> None:
+    result = evaluator.evaluate(make_trace(outcome=TraceOutcome.SUCCESS))
+    assert result.template_id == "success.default"
+
+
+def test_result_trace_node_id_matches(evaluator: RewardEvaluator) -> None:
+    result = evaluator.evaluate(make_trace())
+    assert result.trace_node_id == "n1"
+
+
+# ---------------------------------------------------------------------------
+# Retry penalty
+# ---------------------------------------------------------------------------
+
+
+def test_retry_reduces_score(evaluator: RewardEvaluator) -> None:
+    no_retry = evaluator.evaluate(make_trace(outcome=TraceOutcome.SUCCESS, retry_count=0))
+    with_retry = evaluator.evaluate(make_trace(outcome=TraceOutcome.SUCCESS, retry_count=3))
+    assert with_retry.score < no_retry.score
+
+
+def test_score_clamped_at_negative_one(evaluator: RewardEvaluator) -> None:
+    result = evaluator.evaluate(make_trace(outcome=TraceOutcome.FAILURE, retry_count=100))
+    assert result.score >= -1.0
+
+
+# ---------------------------------------------------------------------------
+# Deterministic repeat evaluation
+# ---------------------------------------------------------------------------
+
+
+def test_same_trace_same_result(evaluator: RewardEvaluator) -> None:
+    trace = make_trace(outcome=TraceOutcome.SUCCESS, retry_count=2)
+    r1 = evaluator.evaluate(trace)
+    r2 = evaluator.evaluate(trace)
+    assert r1.score == r2.score
+    assert r1.template_id == r2.template_id
+
+
+def test_different_traces_different_results(evaluator: RewardEvaluator) -> None:
+    success = evaluator.evaluate(make_trace(outcome=TraceOutcome.SUCCESS))
+    failure = evaluator.evaluate(make_trace(outcome=TraceOutcome.FAILURE))
+    assert success.score != failure.score
+
+
+# ---------------------------------------------------------------------------
+# Context-specific templates
+# ---------------------------------------------------------------------------
+
+
+def test_context_specific_template_wins_over_default() -> None:
+    specific = RewardTemplate(
+        template_id="success.with_heavy",
+        base_score=0.5,
+        outcome=TraceOutcome.SUCCESS,
+        context_key="heavy_model",
+    )
+    ev = RewardEvaluator(templates=[specific] + list(DEFAULT_TEMPLATES))
+
+    result = ev.evaluate(make_trace(context={"heavy_model": True}))
+    assert result.template_id == "success.with_heavy"
+
+
+def test_context_key_missing_falls_back_to_outcome_template(evaluator: RewardEvaluator) -> None:
+    result = evaluator.evaluate(make_trace(outcome=TraceOutcome.SUCCESS, context={}))
+    assert result.template_id == "success.default"
+
+
+# ---------------------------------------------------------------------------
+# No-match fallback
+# ---------------------------------------------------------------------------
+
+
+def test_no_templates_returns_no_match_result() -> None:
+    ev = RewardEvaluator(templates=[])
+    result = ev.evaluate(make_trace())
+    assert result.template_id == "no_match"
+    assert result.score == 0.0


### PR DESCRIPTION
Closes #360

## Summary
- Created `src/openbad/tasks/reward_evaluator.py`:
  - `RewardTemplate`: pure scoring rule with outcome/context_key matching, retry_penalty adjustment, and specificity ranking
  - `DEFAULT_TEMPLATES`: built-in templates for SUCCESS (+1.0), FAILURE (-0.5), TIMEOUT (-0.75), CANCELLED (0.0), wildcard (0.0)
  - `RewardEvaluator`: selects highest-specificity matching template; deterministic (same trace → same result); falls back to no_match if no template applies

## How to test
```
pytest tests/test_reward_evaluator.py -q  # 13 passed
```