### PR TITLE
#361: Map reward outcomes to endocrine updates and persistence

### DIFF
--- a/src/openbad/tasks/reward_endocrine.py
+++ b/src/openbad/tasks/reward_endocrine.py
@@ -1,0 +1,241 @@
+"""Reward-to-endocrine mapping and persistence layer for Phase 9.
+
+Translates :class:`~openbad.tasks.reward_models.RewardResult` objects into
+hormone adjustments via :class:`~openbad.endocrine.controller.EndocrineController`
+and persists reward evaluation records in the ``reward_records`` SQLite table.
+
+Hormone mapping is configurable via :class:`RewardEndocrineConfig`.  The
+default mapping follows intuitive conventions:
+- High positive reward → dopamine boost, cortisol reduction
+- Negative reward → cortisol boost
+- Timeout → adrenaline / cortisol surge
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+
+from openbad.endocrine.controller import EndocrineController
+from openbad.tasks.reward_models import RewardResult, RewardTrace, TraceOutcome
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS reward_records (
+    record_id    TEXT PRIMARY KEY,
+    task_id      TEXT NOT NULL,
+    node_id      TEXT NOT NULL,
+    template_id  TEXT NOT NULL,
+    score        REAL NOT NULL,
+    rationale    TEXT,
+    created_at   TEXT NOT NULL
+)
+"""
+
+_INSERT = """
+INSERT INTO reward_records
+    (record_id, task_id, node_id, template_id, score, rationale, created_at)
+VALUES
+    (:record_id, :task_id, :node_id, :template_id, :score, :rationale, :created_at)
+"""
+
+_SELECT_BY_TASK = "SELECT * FROM reward_records WHERE task_id = ? ORDER BY created_at"
+_SELECT_BY_NODE = "SELECT * FROM reward_records WHERE node_id = ? ORDER BY created_at"
+
+
+def initialize_reward_db(conn: sqlite3.Connection) -> None:
+    """Create the ``reward_records`` table if it does not exist."""
+    conn.execute(_CREATE_TABLE)
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Hormone mapping config
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class HormoneMapping:
+    """A single hormone adjustment rule.
+
+    Parameters
+    ----------
+    hormone:
+        Name of the hormone to adjust (e.g. ``"dopamine"``).
+    amount:
+        Signed float.  Positive = boost, negative = reduction.
+    """
+
+    hormone: str
+    amount: float
+
+
+@dataclasses.dataclass
+class RewardEndocrineConfig:
+    """Configures how reward scores map to hormone adjustments.
+
+    Each outcome has a list of :class:`HormoneMapping` rules applied whenever
+    a :class:`~openbad.tasks.reward_models.RewardResult` with that outcome is
+    processed.  Rules are cumulative within a single evaluation.
+    """
+
+    mappings: dict[TraceOutcome, list[HormoneMapping]] = dataclasses.field(
+        default_factory=dict
+    )
+
+    @classmethod
+    def default(cls) -> RewardEndocrineConfig:
+        """Return sensible defaults matching the project endocrine conventions."""
+        return cls(
+            mappings={
+                TraceOutcome.SUCCESS: [
+                    HormoneMapping("dopamine", 0.3),
+                    HormoneMapping("cortisol", -0.1),
+                ],
+                TraceOutcome.FAILURE: [
+                    HormoneMapping("cortisol", 0.2),
+                ],
+                TraceOutcome.TIMEOUT: [
+                    HormoneMapping("adrenaline", 0.4),
+                    HormoneMapping("cortisol", 0.2),
+                ],
+                TraceOutcome.CANCELLED: [],
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Record model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class RewardRecord:
+    """A persisted snapshot of a reward evaluation."""
+
+    record_id: str
+    task_id: str
+    node_id: str
+    template_id: str
+    score: float
+    created_at: datetime
+    rationale: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "record_id": self.record_id,
+            "task_id": self.task_id,
+            "node_id": self.node_id,
+            "template_id": self.template_id,
+            "score": self.score,
+            "rationale": self.rationale,
+            "created_at": self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def _from_row(cls, row: sqlite3.Row) -> RewardRecord:
+        return cls(
+            record_id=row["record_id"],
+            task_id=row["task_id"],
+            node_id=row["node_id"],
+            template_id=row["template_id"],
+            score=row["score"],
+            rationale=row["rationale"] or "",
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reward→Endocrine bridge
+# ---------------------------------------------------------------------------
+
+
+class RewardEndocrineBridge:
+    """Applies reward results to the endocrine system and persists records.
+
+    Parameters
+    ----------
+    conn:
+        Open ``sqlite3.Connection`` with the ``reward_records`` table.
+    controller:
+        The :class:`~openbad.endocrine.controller.EndocrineController` to
+        receive hormone adjustments.
+    config:
+        Hormone mapping configuration.  Defaults to :meth:`RewardEndocrineConfig.default`.
+    """
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        controller: EndocrineController,
+        config: RewardEndocrineConfig | None = None,
+    ) -> None:
+        conn.row_factory = sqlite3.Row
+        self._conn = conn
+        self._controller = controller
+        self._config = config or RewardEndocrineConfig.default()
+
+    def apply(self, trace: RewardTrace, result: RewardResult) -> RewardRecord:
+        """Persist reward record and apply configured hormone adjustments.
+
+        Parameters
+        ----------
+        trace:
+            The execution trace that was evaluated.
+        result:
+            The reward result from the evaluator.
+
+        Returns
+        -------
+        RewardRecord
+            The persisted record.
+        """
+        # Persist
+        record_id = str(uuid.uuid4())
+        now = datetime.now(tz=UTC)
+        self._conn.execute(
+            _INSERT,
+            {
+                "record_id": record_id,
+                "task_id": trace.task_id,
+                "node_id": trace.node_id,
+                "template_id": result.template_id,
+                "score": result.score,
+                "rationale": result.rationale,
+                "created_at": now.isoformat(),
+            },
+        )
+        self._conn.commit()
+
+        # Hormone adjustments — may raise on unrecognized hormone; callers
+        # should handle gracefully (non-fatal mandate from issue AC).
+        mappings = self._config.mappings.get(trace.outcome, [])
+        for mapping in mappings:
+            with contextlib.suppress(Exception):
+                self._controller.trigger(mapping.hormone, mapping.amount)
+
+        return RewardRecord(
+            record_id=record_id,
+            task_id=trace.task_id,
+            node_id=trace.node_id,
+            template_id=result.template_id,
+            score=result.score,
+            rationale=result.rationale,
+            created_at=now,
+        )
+
+    def query_by_task(self, task_id: str) -> list[RewardRecord]:
+        """Return all reward records for *task_id*, oldest first."""
+        rows = self._conn.execute(_SELECT_BY_TASK, (task_id,)).fetchall()
+        return [RewardRecord._from_row(r) for r in rows]
+
+    def query_by_node(self, node_id: str) -> list[RewardRecord]:
+        """Return all reward records for *node_id*, oldest first."""
+        rows = self._conn.execute(_SELECT_BY_NODE, (node_id,)).fetchall()
+        return [RewardRecord._from_row(r) for r in rows]

--- a/tests/test_reward_endocrine.py
+++ b/tests/test_reward_endocrine.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from openbad.endocrine.controller import EndocrineController
+from openbad.tasks.reward_endocrine import (
+    RewardEndocrineBridge,
+    RewardRecord,
+    initialize_reward_db,
+)
+from openbad.tasks.reward_models import RewardResult, RewardTrace, TraceOutcome
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_trace(outcome: TraceOutcome = TraceOutcome.SUCCESS) -> RewardTrace:
+    return RewardTrace(
+        node_id="n1",
+        task_id="t1",
+        outcome=outcome,
+        duration_ms=100,
+        retry_count=0,
+    )
+
+
+def make_result(score: float = 0.8, template_id: str = "success.default") -> RewardResult:
+    return RewardResult(
+        trace_node_id="n1",
+        score=score,
+        template_id=template_id,
+        rationale="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "reward.db")
+    initialize_reward_db(conn)
+    return conn
+
+
+@pytest.fixture()
+def controller() -> EndocrineController:
+    return EndocrineController()
+
+
+@pytest.fixture()
+def bridge(
+    db: sqlite3.Connection, controller: EndocrineController
+) -> RewardEndocrineBridge:
+    return RewardEndocrineBridge(db, controller)
+
+
+# ---------------------------------------------------------------------------
+# Hormone mapping
+# ---------------------------------------------------------------------------
+
+
+def test_success_triggers_dopamine(
+    bridge: RewardEndocrineBridge, controller: EndocrineController
+) -> None:
+    before = controller.level("dopamine")
+    bridge.apply(make_trace(TraceOutcome.SUCCESS), make_result())
+    assert controller.level("dopamine") > before
+
+
+def test_failure_triggers_cortisol(
+    bridge: RewardEndocrineBridge, controller: EndocrineController
+) -> None:
+    before = controller.level("cortisol")
+    bridge.apply(make_trace(TraceOutcome.FAILURE), make_result(score=-0.5))
+    assert controller.level("cortisol") > before
+
+
+def test_timeout_triggers_adrenaline(
+    bridge: RewardEndocrineBridge, controller: EndocrineController
+) -> None:
+    before = controller.level("adrenaline")
+    bridge.apply(make_trace(TraceOutcome.TIMEOUT), make_result(score=-0.75))
+    assert controller.level("adrenaline") > before
+
+
+def test_cancelled_applies_no_hormone_changes(
+    bridge: RewardEndocrineBridge, controller: EndocrineController
+) -> None:
+    state_before = controller.get_state().to_dict()
+    bridge.apply(make_trace(TraceOutcome.CANCELLED), make_result(score=0.0))
+    # Cancelled → empty mappings; state unchanged
+    state_after = controller.get_state().to_dict()
+    assert state_before == state_after
+
+
+def test_endocrine_hook_error_does_not_propagate(db: sqlite3.Connection) -> None:
+    """Endocrine triggers must not crash execution."""
+    bad_controller = MagicMock(spec=EndocrineController)
+    bad_controller.trigger.side_effect = RuntimeError("boom")
+
+    bridge = RewardEndocrineBridge(db, bad_controller)
+    # Should not raise
+    bridge.apply(make_trace(TraceOutcome.SUCCESS), make_result())
+
+
+# ---------------------------------------------------------------------------
+# Reward record persistence
+# ---------------------------------------------------------------------------
+
+
+def test_apply_persists_record(bridge: RewardEndocrineBridge) -> None:
+    record = bridge.apply(make_trace(), make_result())
+
+    assert isinstance(record, RewardRecord)
+    assert record.task_id == "t1"
+    assert record.node_id == "n1"
+    assert record.score == 0.8
+
+
+def test_query_by_task_returns_records(bridge: RewardEndocrineBridge) -> None:
+    bridge.apply(make_trace(), make_result(score=0.5))
+    bridge.apply(make_trace(), make_result(score=0.9))
+
+    records = bridge.query_by_task("t1")
+    assert len(records) == 2
+
+
+def test_query_by_node_returns_records(bridge: RewardEndocrineBridge) -> None:
+    bridge.apply(make_trace(), make_result())
+    records = bridge.query_by_node("n1")
+    assert len(records) == 1
+    assert records[0].node_id == "n1"
+
+
+def test_query_by_task_excludes_other_tasks(
+    db: sqlite3.Connection, controller: EndocrineController
+) -> None:
+    bridge = RewardEndocrineBridge(db, controller)
+    other_trace = RewardTrace(
+        node_id="n2",
+        task_id="other-task",
+        outcome=TraceOutcome.SUCCESS,
+        duration_ms=50,
+        retry_count=0,
+    )
+    bridge.apply(make_trace(), make_result())
+    bridge.apply(other_trace, make_result())
+
+    records = bridge.query_by_task("t1")
+    assert all(r.task_id == "t1" for r in records)
+
+
+def test_query_empty_task_returns_empty(bridge: RewardEndocrineBridge) -> None:
+    assert bridge.query_by_task("no-such-task") == []


### PR DESCRIPTION
Closes #361

## Summary
- `RewardEndocrineBridge`: persists reward records and applies hormone adjustments via `EndocrineController`
- `RewardEndocrineConfig` / `HormoneMapping`: configurable outcome→hormone mapping (default: SUCCESS→dopamine, FAILURE/TIMEOUT→cortisol, TIMEOUT also adrenaline, CANCELLED→no-op)
- `RewardRecord`: frozen dataclass with `to_dict()`; queryable by task_id or node_id
- Endocrine hooks suppressed with `contextlib.suppress` — never crash execution

## How to test
```
pytest tests/test_reward_endocrine.py -q  # 10 passed
```