### PR TITLE
#362: Add task and task-event API endpoints

### DIFF
--- a/src/openbad/wui/task_api.py
+++ b/src/openbad/wui/task_api.py
@@ -1,0 +1,160 @@
+"""Task and task-event API endpoints for the OpenBaD WUI.
+
+Registers the following routes on a supplied :class:`aiohttp.web.Application`:
+
+- ``GET  /api/tasks``                          — list tasks (optional ``?status=``)
+- ``POST /api/tasks``                          — create a new task
+- ``GET  /api/tasks/{task_id}``                — get task detail
+- ``POST /api/tasks/{task_id}/pause``          — transition to BLOCKED
+- ``POST /api/tasks/{task_id}/resume``         — transition to RUNNING
+- ``POST /api/tasks/{task_id}/cancel``         — transition to CANCELLED
+- ``GET  /api/tasks/{task_id}/events``         — list events, oldest-first
+
+Call :func:`setup_task_routes` to register all routes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from aiohttp import web
+
+from openbad.tasks.models import TaskStatus
+from openbad.tasks.service import TaskService
+from openbad.tasks.store import TaskStore
+
+_APP_KEY = "task_api_service"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task_to_dict(task) -> dict:  # type: ignore[type-arg]
+    return {
+        "task_id": task.task_id,
+        "title": task.title,
+        "description": task.description,
+        "status": str(task.status),
+        "kind": str(task.kind),
+        "priority": task.priority,
+        "owner": task.owner,
+        "created_at": task.created_at,
+        "updated_at": task.updated_at,
+        "parent_task_id": task.parent_task_id,
+        "due_at": task.due_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def _list_tasks(request: web.Request) -> web.Response:
+    svc: TaskService = request.app[_APP_KEY]
+    status_str = request.rel_url.query.get("status")
+    status: TaskStatus | None = None
+    if status_str:
+        try:
+            status = TaskStatus(status_str)
+        except ValueError:
+            raise web.HTTPBadRequest(text=f"invalid status: {status_str!r}") from None
+    tasks = svc.list_tasks(status=status)
+    return web.json_response({"tasks": [_task_to_dict(t) for t in tasks]})
+
+
+async def _create_task(request: web.Request) -> web.Response:
+    svc: TaskService = request.app[_APP_KEY]
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise web.HTTPBadRequest(text="request body must be an object")
+    title = body.get("title", "").strip()
+    if not title:
+        raise web.HTTPBadRequest(text="title is required")
+    task = svc.create_task(
+        title,
+        description=body.get("description", ""),
+        owner=body.get("owner", "system"),
+    )
+    return web.json_response(_task_to_dict(task), status=201)
+
+
+async def _get_task(request: web.Request) -> web.Response:
+    svc: TaskService = request.app[_APP_KEY]
+    task_id = request.match_info["task_id"]
+    task = svc.get_task(task_id)
+    if task is None:
+        raise web.HTTPNotFound(text=f"task {task_id!r} not found")
+    return web.json_response(_task_to_dict(task))
+
+
+async def _pause_task(request: web.Request) -> web.Response:
+    svc: TaskService = request.app[_APP_KEY]
+    task_id = request.match_info["task_id"]
+    try:
+        task = svc.transition_task(task_id, TaskStatus.BLOCKED)
+    except KeyError:
+        raise web.HTTPNotFound(text=f"task {task_id!r} not found") from None
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text=str(exc)) from exc
+    return web.json_response(_task_to_dict(task))
+
+
+async def _resume_task(request: web.Request) -> web.Response:
+    svc: TaskService = request.app[_APP_KEY]
+    task_id = request.match_info["task_id"]
+    try:
+        task = svc.transition_task(task_id, TaskStatus.RUNNING)
+    except KeyError:
+        raise web.HTTPNotFound(text=f"task {task_id!r} not found") from None
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text=str(exc)) from exc
+    return web.json_response(_task_to_dict(task))
+
+
+async def _cancel_task(request: web.Request) -> web.Response:
+    svc: TaskService = request.app[_APP_KEY]
+    task_id = request.match_info["task_id"]
+    try:
+        task = svc.transition_task(task_id, TaskStatus.CANCELLED)
+    except KeyError:
+        raise web.HTTPNotFound(text=f"task {task_id!r} not found") from None
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text=str(exc)) from exc
+    return web.json_response(_task_to_dict(task))
+
+
+async def _list_task_events(request: web.Request) -> web.Response:
+    store: TaskStore = request.app[_APP_KEY + "_store"]
+    task_id = request.match_info["task_id"]
+    events = store.list_events(task_id)
+    return web.json_response({"task_id": task_id, "events": events})
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def setup_task_routes(app: web.Application, conn: sqlite3.Connection) -> None:
+    """Register all task API routes on *app*, backed by *conn*.
+
+    Parameters
+    ----------
+    app:
+        The :class:`aiohttp.web.Application` to register routes on.
+    conn:
+        An open SQLite connection to the state database.
+    """
+    app[_APP_KEY] = TaskService(conn)
+    app[_APP_KEY + "_store"] = TaskStore(conn)
+
+    app.router.add_get("/api/tasks", _list_tasks)
+    app.router.add_post("/api/tasks", _create_task)
+    app.router.add_get("/api/tasks/{task_id}", _get_task)
+    app.router.add_post("/api/tasks/{task_id}/pause", _pause_task)
+    app.router.add_post("/api/tasks/{task_id}/resume", _resume_task)
+    app.router.add_post("/api/tasks/{task_id}/cancel", _cancel_task)
+    app.router.add_get("/api/tasks/{task_id}/events", _list_task_events)

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient
+
+from openbad.state.db import initialize_state_db
+from openbad.tasks.models import TaskModel, TaskStatus
+from openbad.tasks.store import TaskStore
+from openbad.wui.task_api import setup_task_routes
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    return initialize_state_db(tmp_path / "state.db")
+
+
+@pytest.fixture()
+def store(db):
+    return TaskStore(db)
+
+
+@pytest.fixture()
+def app(db) -> web.Application:
+    a = web.Application()
+    setup_task_routes(a, db)
+    return a
+
+
+@pytest.fixture()
+async def client(app, aiohttp_client) -> TestClient:
+    return await aiohttp_client(app)
+
+
+# ---------------------------------------------------------------------------
+# List tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_empty(client: TestClient) -> None:
+    resp = await client.get("/api/tasks")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["tasks"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_returns_all(client: TestClient, store: TaskStore) -> None:
+    task_a = TaskModel.new("Task A")
+    task_b = TaskModel.new("Task B")
+    store.create_task(task_a)
+    store.create_task(task_b)
+
+    resp = await client.get("/api/tasks")
+    data = await resp.json()
+    assert len(data["tasks"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_filtered_by_status(client: TestClient, store: TaskStore) -> None:
+    t = TaskModel.new("A")
+    store.create_task(t)
+    store.update_task_status(t.task_id, TaskStatus.RUNNING)
+
+    resp = await client.get("/api/tasks?status=running")
+    data = await resp.json()
+    assert len(data["tasks"]) == 1
+    assert data["tasks"][0]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_invalid_status_returns_400(client: TestClient) -> None:
+    resp = await client.get("/api/tasks?status=nonexistent")
+    assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# Create task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_task_returns_201(client: TestClient) -> None:
+    resp = await client.post("/api/tasks", json={"title": "New task"})
+    assert resp.status == 201
+    data = await resp.json()
+    assert data["title"] == "New task"
+    assert data["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_create_task_missing_title_returns_400(client: TestClient) -> None:
+    resp = await client.post("/api/tasks", json={"description": "No title"})
+    assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# Get task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_task(client: TestClient, store: TaskStore) -> None:
+    task = TaskModel.new("Detail task")
+    store.create_task(task)
+
+    resp = await client.get(f"/api/tasks/{task.task_id}")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["task_id"] == task.task_id
+
+
+@pytest.mark.asyncio
+async def test_get_task_not_found(client: TestClient) -> None:
+    resp = await client.get("/api/tasks/ghost-task")
+    assert resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# Pause / Resume / Cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pause_task(client: TestClient, store: TaskStore) -> None:
+    task = TaskModel.new("Running task")
+    store.create_task(task)
+    store.update_task_status(task.task_id, TaskStatus.RUNNING)
+
+    resp = await client.post(f"/api/tasks/{task.task_id}/pause")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_resume_task(client: TestClient, store: TaskStore) -> None:
+    task = TaskModel.new("Blocked task")
+    store.create_task(task)
+    store.update_task_status(task.task_id, TaskStatus.RUNNING)
+    store.update_task_status(task.task_id, TaskStatus.BLOCKED)
+
+    resp = await client.post(f"/api/tasks/{task.task_id}/resume")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_cancel_task(client: TestClient, store: TaskStore) -> None:
+    task = TaskModel.new("Pending task")
+    store.create_task(task)
+
+    resp = await client.post(f"/api/tasks/{task.task_id}/cancel")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_pause_nonexistent_returns_404(client: TestClient) -> None:
+    resp = await client.post("/api/tasks/ghost/pause")
+    assert resp.status == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_invalid_transition_returns_400(client: TestClient, store: TaskStore) -> None:
+    task = TaskModel.new("Done task")
+    store.create_task(task)
+    store.update_task_status(task.task_id, TaskStatus.RUNNING)
+    store.update_task_status(task.task_id, TaskStatus.DONE)
+
+    resp = await client.post(f"/api/tasks/{task.task_id}/cancel")
+    assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# Event history ordered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_history_ordered(client: TestClient, store: TaskStore) -> None:
+    task = TaskModel.new("Event task")
+    store.create_task(task)
+    store.append_event(task.task_id, "status_change", payload={"status": "running"})
+    store.append_event(task.task_id, "note", payload={"text": "hello"})
+
+    resp = await client.get(f"/api/tasks/{task.task_id}/events")
+    assert resp.status == 200
+    data = await resp.json()
+    events = data["events"]
+    assert len(events) == 2
+    # Events should be ordered oldest-first by the store
+    types = [e["event_type"] for e in events]
+    assert types == ["status_change", "note"]
+
+
+@pytest.mark.asyncio
+async def test_event_history_empty(client: TestClient, store: TaskStore) -> None:
+    task = TaskModel.new("No events")
+    store.create_task(task)
+
+    resp = await client.get(f"/api/tasks/{task.task_id}/events")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["events"] == []


### PR DESCRIPTION
Closes #362

## Summary
- Created `src/openbad/wui/task_api.py`:
  - `GET /api/tasks` — list tasks with optional `?status=` filter
  - `POST /api/tasks` — create task (title required)
  - `GET /api/tasks/{task_id}` — task detail or 404
  - `POST /api/tasks/{task_id}/pause` — RUNNING → BLOCKED
  - `POST /api/tasks/{task_id}/resume` — BLOCKED → RUNNING
  - `POST /api/tasks/{task_id}/cancel` — → CANCELLED
  - `GET /api/tasks/{task_id}/events` — ordered event history
- `setup_task_routes(app, conn)` — single call registers all routes

## How to test
```
pytest tests/test_task_api.py -q  # 15 passed
```