### PR TITLE
#363: Add research capability audit and scheduler state endpoints

### DIFF
--- a/src/openbad/wui/research_api.py
+++ b/src/openbad/wui/research_api.py
@@ -1,0 +1,136 @@
+"""Research, capability, MCP audit, and scheduler state API endpoints.
+
+Registers the following routes on a supplied :class:`aiohttp.web.Application`:
+
+- ``GET /api/research``                        — list pending research nodes
+- ``GET /api/research/{research_id}``          — get research node by id
+- ``GET /api/capabilities``                    — list registered capabilities
+- ``GET /api/mcp/audit``                       — recent MCP audit records
+- ``GET /api/scheduler/state``                 — scheduler config / quiet-hour status
+
+Call :func:`setup_research_routes` to register all routes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from aiohttp import web
+
+from openbad.plugins.mcp_audit import MCPAuditStore
+from openbad.plugins.registry import CapabilityRegistry, PermissionPolicy
+from openbad.tasks.research_queue import ResearchQueue
+from openbad.tasks.scheduler import SchedulerConfig
+
+_KEY_RESEARCH = "research_api_queue"
+_KEY_CAPABILITIES = "research_api_registry"
+_KEY_AUDIT = "research_api_audit"
+_KEY_SCHEDULER = "research_api_scheduler_cfg"
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def _list_research(request: web.Request) -> web.Response:
+    queue: ResearchQueue = request.app[_KEY_RESEARCH]
+    nodes = queue.list_pending()
+    return web.json_response({"nodes": [n.to_dict() for n in nodes]})
+
+
+async def _get_research(request: web.Request) -> web.Response:
+    queue: ResearchQueue = request.app[_KEY_RESEARCH]
+    research_id = request.match_info["research_id"]
+    node = queue.get(research_id)
+    if node is None:
+        raise web.HTTPNotFound(text=f"research node {research_id!r} not found")
+    return web.json_response(node.to_dict())
+
+
+async def _list_capabilities(request: web.Request) -> web.Response:
+    registry: CapabilityRegistry = request.app[_KEY_CAPABILITIES]
+    entries = registry.list_all()
+    return web.json_response(
+        {
+            "capabilities": [
+                {
+                    "capability_id": e.capability_id,
+                    "manifest_name": e.plugin_name,
+                    "permissions": e.permissions,
+                    "system1": e.system1,
+                    "description": e.description,
+                }
+                for e in entries
+            ]
+        }
+    )
+
+
+async def _list_audit(request: web.Request) -> web.Response:
+    audit: MCPAuditStore = request.app[_KEY_AUDIT]
+    task_id = request.rel_url.query.get("task_id")
+    run_id = request.rel_url.query.get("run_id")
+    if task_id:
+        records = audit.query_by_task(task_id)
+    elif run_id:
+        records = audit.query_by_run(run_id)
+    else:
+        records = []
+    return web.json_response({"records": [r.to_dict() for r in records]})
+
+
+async def _get_scheduler_state(request: web.Request) -> web.Response:
+    cfg: SchedulerConfig = request.app[_KEY_SCHEDULER]
+    return web.json_response(
+        {
+            "quiet_hour_active": cfg.is_quiet_hour(),
+            "poll_limit": cfg.poll_limit,
+            "lease_ttl_seconds": cfg.lease_ttl_seconds,
+            "quiet_hours": [
+                {"start_hour": w.start_hour, "end_hour": w.end_hour}
+                for w in cfg.quiet_hours
+            ],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def setup_research_routes(
+    app: web.Application,
+    conn: sqlite3.Connection,
+    *,
+    registry: CapabilityRegistry | None = None,
+    scheduler_config: SchedulerConfig | None = None,
+) -> None:
+    """Register research, capability, audit, and scheduler routes on *app*.
+
+    Parameters
+    ----------
+    app:
+        The :class:`aiohttp.web.Application` to register routes on.
+    conn:
+        An open SQLite connection to the state database (must have
+        ``research_queue`` and ``mcp_audit`` tables).
+    registry:
+        Optional pre-populated :class:`~openbad.plugins.registry.CapabilityRegistry`.
+        A registry with an open :class:`~openbad.plugins.registry.PermissionPolicy`
+        is created if omitted.
+    scheduler_config:
+        Optional :class:`~openbad.tasks.scheduler.SchedulerConfig`.
+        Defaults to an empty config if omitted.
+    """
+    app[_KEY_RESEARCH] = ResearchQueue(conn)
+    app[_KEY_CAPABILITIES] = registry or CapabilityRegistry(PermissionPolicy(None))
+    app[_KEY_AUDIT] = MCPAuditStore(conn)
+    app[_KEY_SCHEDULER] = scheduler_config or SchedulerConfig()
+
+    app.router.add_get("/api/research", _list_research)
+    app.router.add_get("/api/research/{research_id}", _get_research)
+    app.router.add_get("/api/capabilities", _list_capabilities)
+    app.router.add_get("/api/mcp/audit", _list_audit)
+    app.router.add_get("/api/scheduler/state", _get_scheduler_state)

--- a/tests/test_research_api.py
+++ b/tests/test_research_api.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient
+
+from openbad.plugins.mcp_audit import MCPAuditStore, initialize_audit_db
+from openbad.plugins.registry import CapabilityRegistry, PermissionPolicy
+from openbad.tasks.research_queue import ResearchQueue, initialize_research_db
+from openbad.tasks.scheduler import QuietHoursWindow, SchedulerConfig
+from openbad.wui.research_api import setup_research_routes
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    conn = sqlite3.connect(str(tmp_path / "research.db"))
+    conn.row_factory = sqlite3.Row
+    initialize_research_db(conn)
+    initialize_audit_db(conn)
+    return conn
+
+
+@pytest.fixture()
+def app(db) -> web.Application:
+    a = web.Application()
+    setup_research_routes(a, db)
+    return a
+
+
+@pytest.fixture()
+async def client(app, aiohttp_client) -> TestClient:
+    return await aiohttp_client(app)
+
+
+# ---------------------------------------------------------------------------
+# Research endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_research_empty(client: TestClient) -> None:
+    resp = await client.get("/api/research")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["nodes"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_research_returns_pending(client: TestClient, db) -> None:
+    queue = ResearchQueue(db)
+    queue.enqueue("Find X", priority=5)
+    queue.enqueue("Find Y", priority=3)
+
+    resp = await client.get("/api/research")
+    data = await resp.json()
+    assert len(data["nodes"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_research_by_id(client: TestClient, db) -> None:
+    queue = ResearchQueue(db)
+    node = queue.enqueue("Find Z", priority=1)
+
+    resp = await client.get(f"/api/research/{node.node_id}")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["node_id"] == node.node_id
+    assert data["title"] == "Find Z"
+
+
+@pytest.mark.asyncio
+async def test_get_research_not_found(client: TestClient) -> None:
+    resp = await client.get("/api/research/ghost-node")
+    assert resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# Capability endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capabilities_empty(client: TestClient) -> None:
+    resp = await client.get("/api/capabilities")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["capabilities"] == []
+
+
+@pytest.mark.asyncio
+async def test_capabilities_with_registry(db, aiohttp_client) -> None:
+    from openbad.plugins.manifest import CapabilityEntry, CapabilityManifest
+
+    policy = PermissionPolicy({"file.read"})
+    registry = CapabilityRegistry(policy)
+    manifest = CapabilityManifest(
+        name="test_pack",
+        version="1.0",
+        module="test.pack",
+        capabilities=[
+            CapabilityEntry(
+                id="test_pack.do_thing",
+                permissions=["file.read"],
+                description="Does a thing",
+            )
+        ],
+    )
+    registry.register(manifest)
+
+    a = web.Application()
+    setup_research_routes(a, db, registry=registry)
+    cli = await aiohttp_client(a)
+
+    resp = await cli.get("/api/capabilities")
+    data = await resp.json()
+    assert len(data["capabilities"]) == 1
+    assert data["capabilities"][0]["capability_id"] == "test_pack.do_thing"
+
+
+# ---------------------------------------------------------------------------
+# Audit endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_empty_no_filter(client: TestClient) -> None:
+    resp = await client.get("/api/mcp/audit")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["records"] == []
+
+
+@pytest.mark.asyncio
+async def test_audit_by_task_id(client: TestClient, db) -> None:
+    audit = MCPAuditStore(db)
+    audit.record(
+        "session-1",
+        "read_file",
+        success=True,
+        task_id="task-99",
+        run_id="run-1",
+    )
+
+    resp = await client.get("/api/mcp/audit?task_id=task-99")
+    data = await resp.json()
+    assert len(data["records"]) == 1
+    assert data["records"][0]["task_id"] == "task-99"
+
+
+@pytest.mark.asyncio
+async def test_audit_by_run_id(client: TestClient, db) -> None:
+    audit = MCPAuditStore(db)
+    audit.record(
+        "session-2",
+        "write_file",
+        success=False,
+        task_id="task-100",
+        run_id="run-special",
+    )
+
+    resp = await client.get("/api/mcp/audit?run_id=run-special")
+    data = await resp.json()
+    assert len(data["records"]) == 1
+    assert data["records"][0]["run_id"] == "run-special"
+
+
+# ---------------------------------------------------------------------------
+# Scheduler state endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduler_state_default(client: TestClient) -> None:
+    resp = await client.get("/api/scheduler/state")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["quiet_hour_active"] is False
+    assert data["poll_limit"] == 10
+    assert data["quiet_hours"] == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_state_with_config(db, aiohttp_client) -> None:
+    cfg = SchedulerConfig(
+        lease_ttl_seconds=120.0,
+        poll_limit=5,
+        quiet_hours=[QuietHoursWindow(0, 23)],  # always active
+    )
+    a = web.Application()
+    setup_research_routes(a, db, scheduler_config=cfg)
+    cli = await aiohttp_client(a)
+
+    resp = await cli.get("/api/scheduler/state")
+    data = await resp.json()
+    assert data["quiet_hour_active"] is True
+    assert data["poll_limit"] == 5
+    assert len(data["quiet_hours"]) == 1


### PR DESCRIPTION
Closes #363

## Summary
- Created `src/openbad/wui/research_api.py`:
  - `GET /api/research` — list pending research nodes (empty-state: `[]`)
  - `GET /api/research/{research_id}` — node detail or 404
  - `GET /api/capabilities` — list all registered capabilities
  - `GET /api/mcp/audit?task_id=&run_id=` — MCP audit records filtered by task or run
  - `GET /api/scheduler/state` — quiet-hour status + scheduler config
- `setup_research_routes(app, conn, *, registry, scheduler_config)` single entry point

## How to test
```
pytest tests/test_research_api.py -q  # 11 passed
```