### PR TITLE
#364: Add minimal WUI task research and audit views

### DIFF
--- a/src/openbad/wui/build/research.html
+++ b/src/openbad/wui/build/research.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenBaD — Research &amp; Audit</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: system-ui, sans-serif; background: #0f1117; color: #e2e8f0; min-height: 100vh; }
+      header { padding: 1rem 2rem; border-bottom: 1px solid #1e2433; display: flex; align-items: center; gap: 1rem; }
+      header h1 { font-size: 1.25rem; font-weight: 600; }
+      header a { color: #94a3b8; font-size: 0.875rem; text-decoration: none; }
+      header a:hover { color: #e2e8f0; }
+      main { padding: 2rem; max-width: 1100px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+      @media (max-width: 800px) { main { grid-template-columns: 1fr; } }
+      .panel { background: #1a1f2e; border: 1px solid #1e2433; border-radius: 0.5rem; padding: 1.5rem; }
+      .panel h2 { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em; }
+      table { width: 100%; border-collapse: collapse; font-size: 0.8125rem; }
+      th { text-align: left; padding: 0.4rem 0.5rem; color: #64748b; border-bottom: 1px solid #1e2433; }
+      td { padding: 0.4rem 0.5rem; border-bottom: 1px solid #1a2035; word-break: break-all; }
+      tr:hover td { background: #1e2433; }
+      .empty { color: #475569; font-style: italic; }
+      .badge { display: inline-block; padding: 0.1rem 0.4rem; border-radius: 9999px; font-size: 0.75rem; }
+      .badge-pending { background: #334155; color: #94a3b8; }
+      .badge-dequeued { background: #14532d; color: #4ade80; }
+      .ok { color: #4ade80; }
+      .err { color: #f87171; }
+      input[type=text] { background: #1a1f2e; border: 1px solid #334155; color: #e2e8f0; padding: 0.25rem 0.5rem; border-radius: 0.25rem; width: 100%; margin-bottom: 0.5rem; font-size: 0.8125rem; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>OpenBaD</h1>
+      <a href="/">Dashboard</a>
+      <a href="/tasks.html">Tasks</a>
+      <a href="/research.html" style="color:#e2e8f0">Research &amp; Audit</a>
+    </header>
+    <main>
+
+      <!-- Research Queue Panel -->
+      <div class="panel" id="research-panel">
+        <h2>Research Queue</h2>
+        <div id="research-content"><p class="empty">Loading…</p></div>
+      </div>
+
+      <!-- MCP Audit Panel -->
+      <div class="panel" id="audit-panel">
+        <h2>MCP Audit
+        </h2>
+        <input type="text" id="audit-task-filter" placeholder="Filter by task_id…" oninput="loadAudit()" />
+        <div id="audit-content"><p class="empty">Loading…</p></div>
+      </div>
+
+      <!-- Capabilities Panel -->
+      <div class="panel" id="capabilities-panel">
+        <h2>Capabilities</h2>
+        <div id="capabilities-content"><p class="empty">Loading…</p></div>
+      </div>
+
+      <!-- Scheduler Panel -->
+      <div class="panel" id="scheduler-panel">
+        <h2>Scheduler State</h2>
+        <div id="scheduler-content"><p class="empty">Loading…</p></div>
+      </div>
+    </main>
+    <script>
+      const BASE = '';
+
+      function escHtml(s) {
+        return String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      }
+
+      async function loadResearch() {
+        const el = document.getElementById('research-content');
+        try {
+          const res = await fetch(`${BASE}/api/research`);
+          if (!res.ok) { el.innerHTML = `<p class="empty">Error ${res.status}</p>`; return; }
+          const { nodes } = await res.json();
+          if (!nodes.length) {
+            el.innerHTML = '<p class="empty">Queue is empty.</p>';
+            return;
+          }
+          el.innerHTML = `<table>
+            <thead><tr><th>Title</th><th>Priority</th><th>Status</th></tr></thead>
+            <tbody>${nodes.map(n => `
+              <tr>
+                <td>${escHtml(n.title)}</td>
+                <td>${n.priority}</td>
+                <td><span class="badge badge-${n.status}">${n.status}</span></td>
+              </tr>`).join('')}
+            </tbody></table>`;
+        } catch { el.innerHTML = '<p class="empty">Failed to load.</p>'; }
+      }
+
+      async function loadAudit() {
+        const el = document.getElementById('audit-content');
+        const taskId = document.getElementById('audit-task-filter').value.trim();
+        const url = taskId ? `${BASE}/api/mcp/audit?task_id=${encodeURIComponent(taskId)}` : `${BASE}/api/mcp/audit`;
+        try {
+          const res = await fetch(url);
+          if (!res.ok) { el.innerHTML = `<p class="empty">Error ${res.status}</p>`; return; }
+          const { records } = await res.json();
+          if (!records.length) {
+            el.innerHTML = '<p class="empty">No audit records.</p>';
+            return;
+          }
+          el.innerHTML = `<table>
+            <thead><tr><th>Tool</th><th>Session</th><th>OK</th></tr></thead>
+            <tbody>${records.map(r => `
+              <tr>
+                <td>${escHtml(r.tool_name)}</td>
+                <td>${escHtml(r.session_id)}</td>
+                <td class="${r.success ? 'ok' : 'err'}">${r.success ? '✓' : '✗'}</td>
+              </tr>`).join('')}
+            </tbody></table>`;
+        } catch { el.innerHTML = '<p class="empty">Failed to load.</p>'; }
+      }
+
+      async function loadCapabilities() {
+        const el = document.getElementById('capabilities-content');
+        try {
+          const res = await fetch(`${BASE}/api/capabilities`);
+          if (!res.ok) { el.innerHTML = `<p class="empty">Error ${res.status}</p>`; return; }
+          const { capabilities } = await res.json();
+          if (!capabilities.length) {
+            el.innerHTML = '<p class="empty">No capabilities registered.</p>';
+            return;
+          }
+          el.innerHTML = `<table>
+            <thead><tr><th>ID</th><th>S1</th><th>Permissions</th></tr></thead>
+            <tbody>${capabilities.map(c => `
+              <tr>
+                <td>${escHtml(c.capability_id)}</td>
+                <td>${c.system1 ? '✓' : ''}</td>
+                <td>${c.permissions.join(', ')}</td>
+              </tr>`).join('')}
+            </tbody></table>`;
+        } catch { el.innerHTML = '<p class="empty">Failed to load.</p>'; }
+      }
+
+      async function loadScheduler() {
+        const el = document.getElementById('scheduler-content');
+        try {
+          const res = await fetch(`${BASE}/api/scheduler/state`);
+          if (!res.ok) { el.innerHTML = `<p class="empty">Error ${res.status}</p>`; return; }
+          const s = await res.json();
+          el.innerHTML = `<table>
+            <tbody>
+              <tr><th>Quiet Hour Active</th><td>${s.quiet_hour_active ? '<span class="err">Yes</span>' : '<span class="ok">No</span>'}</td></tr>
+              <tr><th>Poll Limit</th><td>${s.poll_limit}</td></tr>
+              <tr><th>Lease TTL (s)</th><td>${s.lease_ttl_seconds}</td></tr>
+              <tr><th>Quiet Windows</th><td>${s.quiet_hours.length ? s.quiet_hours.map(w=>`${w.start_hour}–${w.end_hour}`).join(', ') : 'None'}</td></tr>
+            </tbody></table>`;
+        } catch { el.innerHTML = '<p class="empty">Failed to load.</p>'; }
+      }
+
+      loadResearch();
+      loadAudit();
+      loadCapabilities();
+      loadScheduler();
+    </script>
+  </body>
+</html>

--- a/src/openbad/wui/build/tasks.html
+++ b/src/openbad/wui/build/tasks.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenBaD — Tasks</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: system-ui, sans-serif; background: #0f1117; color: #e2e8f0; min-height: 100vh; }
+      header { padding: 1rem 2rem; border-bottom: 1px solid #1e2433; display: flex; align-items: center; gap: 1rem; }
+      header h1 { font-size: 1.25rem; font-weight: 600; }
+      header a { color: #94a3b8; font-size: 0.875rem; text-decoration: none; }
+      header a:hover { color: #e2e8f0; }
+      main { padding: 2rem; max-width: 1100px; margin: 0 auto; }
+      .panel { background: #1a1f2e; border: 1px solid #1e2433; border-radius: 0.5rem; padding: 1.5rem; margin-bottom: 1.5rem; }
+      .panel h2 { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em; }
+      table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+      th { text-align: left; padding: 0.5rem 0.75rem; color: #64748b; border-bottom: 1px solid #1e2433; }
+      td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #1a2035; }
+      tr:hover td { background: #1e2433; }
+      .badge { display: inline-block; padding: 0.1rem 0.5rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; }
+      .badge-pending { background: #334155; color: #94a3b8; }
+      .badge-running { background: #1e3a5f; color: #60a5fa; }
+      .badge-blocked { background: #3b2f10; color: #fbbf24; }
+      .badge-done { background: #14532d; color: #4ade80; }
+      .badge-failed { background: #450a0a; color: #f87171; }
+      .badge-cancelled { background: #1c1c1c; color: #6b7280; }
+      .empty { color: #475569; font-style: italic; padding: 1rem 0; }
+      .detail-section { display: none; }
+      .detail-section.active { display: block; }
+      #events-list { font-size: 0.8125rem; }
+      #events-list li { padding: 0.25rem 0; border-bottom: 1px solid #1a2035; list-style: none; }
+      button.action { background: #1e2433; border: 1px solid #334155; color: #94a3b8; padding: 0.25rem 0.75rem; border-radius: 0.25rem; cursor: pointer; font-size: 0.8125rem; margin-right: 0.25rem; }
+      button.action:hover { background: #2d3748; color: #e2e8f0; }
+      #status-filter { background: #1a1f2e; border: 1px solid #334155; color: #e2e8f0; padding: 0.25rem 0.5rem; border-radius: 0.25rem; margin-left: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>OpenBaD</h1>
+      <a href="/">Dashboard</a>
+      <a href="/tasks.html" style="color:#e2e8f0">Tasks</a>
+      <a href="/research.html">Research &amp; Audit</a>
+    </header>
+    <main>
+      <div class="panel">
+        <h2>Task List
+          <label for="status-filter" style="font-weight:400;text-transform:none;letter-spacing:0">Filter:
+            <select id="status-filter" onchange="loadTasks()">
+              <option value="">All</option>
+              <option value="pending">Pending</option>
+              <option value="running">Running</option>
+              <option value="blocked">Blocked</option>
+              <option value="done">Done</option>
+              <option value="failed">Failed</option>
+              <option value="cancelled">Cancelled</option>
+            </select>
+          </label>
+        </h2>
+        <div id="task-list-container">
+          <p class="empty" id="task-list-empty">Loading…</p>
+          <table id="task-table" style="display:none">
+            <thead><tr><th>Title</th><th>Status</th><th>Priority</th><th>Owner</th><th>Actions</th></tr></thead>
+            <tbody id="task-tbody"></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="panel detail-section" id="detail-panel">
+        <h2>Task Detail — <span id="detail-title"></span></h2>
+        <table id="detail-table" style="margin-bottom:1rem">
+          <tbody id="detail-tbody"></tbody>
+        </table>
+        <h2 style="margin-bottom:0.5rem">Events</h2>
+        <ul id="events-list"><li class="empty">No events.</li></ul>
+      </div>
+    </main>
+    <script>
+      const BASE = '';
+
+      async function loadTasks() {
+        const status = document.getElementById('status-filter').value;
+        const url = status ? `${BASE}/api/tasks?status=${status}` : `${BASE}/api/tasks`;
+        const tbody = document.getElementById('task-tbody');
+        const table = document.getElementById('task-table');
+        const empty = document.getElementById('task-list-empty');
+        try {
+          const res = await fetch(url);
+          if (!res.ok) { empty.textContent = `Error ${res.status}`; empty.style.display=''; table.style.display='none'; return; }
+          const { tasks } = await res.json();
+          if (tasks.length === 0) {
+            empty.textContent = 'No tasks found.';
+            empty.style.display = '';
+            table.style.display = 'none';
+          } else {
+            empty.style.display = 'none';
+            table.style.display = '';
+            tbody.innerHTML = tasks.map(t => `
+              <tr>
+                <td><a href="#" onclick="loadDetail('${t.task_id}');return false;">${escHtml(t.title)}</a></td>
+                <td><span class="badge badge-${t.status}">${t.status}</span></td>
+                <td>${t.priority}</td>
+                <td>${escHtml(t.owner)}</td>
+                <td>
+                  <button class="action" onclick="pause('${t.task_id}')">Pause</button>
+                  <button class="action" onclick="resume('${t.task_id}')">Resume</button>
+                  <button class="action" onclick="cancel('${t.task_id}')">Cancel</button>
+                </td>
+              </tr>`).join('');
+          }
+        } catch (err) {
+          empty.textContent = 'Failed to load tasks.';
+        }
+      }
+
+      async function loadDetail(taskId) {
+        const panel = document.getElementById('detail-panel');
+        panel.classList.add('active');
+        const [taskRes, eventsRes] = await Promise.all([
+          fetch(`${BASE}/api/tasks/${taskId}`),
+          fetch(`${BASE}/api/tasks/${taskId}/events`),
+        ]);
+        if (!taskRes.ok) { document.getElementById('detail-title').textContent = 'Not found'; return; }
+        const task = await taskRes.json();
+        document.getElementById('detail-title').textContent = task.title;
+        const fields = ['task_id','status','kind','priority','owner','created_at','updated_at','parent_task_id','due_at'];
+        document.getElementById('detail-tbody').innerHTML = fields.map(f =>
+          `<tr><th style="width:9rem">${f}</th><td>${task[f] ?? '—'}</td></tr>`).join('');
+        if (eventsRes.ok) {
+          const { events } = await eventsRes.json();
+          document.getElementById('events-list').innerHTML = events.length
+            ? events.map(e => `<li>${escHtml(e.event_type)} — ${e.created_at ?? ''}</li>`).join('')
+            : '<li class="empty">No events.</li>';
+        }
+      }
+
+      async function doAction(taskId, action) {
+        const res = await fetch(`${BASE}/api/tasks/${taskId}/${action}`, { method: 'POST' });
+        if (!res.ok) { alert(`Action failed: ${res.status} ${await res.text()}`); return; }
+        await loadTasks();
+        await loadDetail(taskId);
+      }
+      const pause = id => doAction(id, 'pause');
+      const resume = id => doAction(id, 'resume');
+      const cancel = id => doAction(id, 'cancel');
+
+      function escHtml(s) {
+        return String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      }
+
+      loadTasks();
+    </script>
+  </body>
+</html>

--- a/tests/test_wui_views.py
+++ b/tests/test_wui_views.py
@@ -1,0 +1,220 @@
+"""Integration tests: WUI task/research/audit views render without errors.
+
+These tests wire up both :func:`setup_task_routes` and
+:func:`setup_research_routes` on a single aiohttp app, then exercise the
+complete request/response cycle as the HTML views would.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient
+
+from openbad.plugins.mcp_audit import MCPAuditStore, initialize_audit_db
+from openbad.state.db import initialize_state_db
+from openbad.tasks.models import TaskModel, TaskStatus
+from openbad.tasks.research_queue import ResearchQueue, initialize_research_db
+from openbad.tasks.store import TaskStore
+from openbad.wui.research_api import setup_research_routes
+from openbad.wui.task_api import setup_task_routes
+
+BUILD_DIR = Path(__file__).resolve().parent.parent / "src" / "openbad" / "wui" / "build"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def task_db(tmp_path: Path):
+    return initialize_state_db(tmp_path / "state.db")
+
+
+@pytest.fixture()
+def research_db(tmp_path: Path):
+    conn = sqlite3.connect(str(tmp_path / "research.db"))
+    conn.row_factory = sqlite3.Row
+    initialize_research_db(conn)
+    initialize_audit_db(conn)
+    return conn
+
+
+@pytest.fixture()
+def app(task_db, research_db) -> web.Application:
+    a = web.Application()
+    setup_task_routes(a, task_db)
+    setup_research_routes(a, research_db)
+
+    # Serve the static HTML views
+    if BUILD_DIR.is_dir():
+
+        async def _tasks_view(_req: web.Request) -> web.FileResponse:
+            return web.FileResponse(BUILD_DIR / "tasks.html")
+
+        async def _research_view(_req: web.Request) -> web.FileResponse:
+            return web.FileResponse(BUILD_DIR / "research.html")
+
+        a.router.add_get("/tasks.html", _tasks_view)
+        a.router.add_get("/research.html", _research_view)
+
+    return a
+
+
+@pytest.fixture()
+async def client(app, aiohttp_client) -> TestClient:
+    return await aiohttp_client(app)
+
+
+# ---------------------------------------------------------------------------
+# Task list / detail rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_list_empty_state(client: TestClient) -> None:
+    """API returns empty list — view renders empty-state."""
+    resp = await client.get("/api/tasks")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["tasks"] == []
+
+
+@pytest.mark.asyncio
+async def test_task_list_populated_state(client: TestClient, task_db) -> None:
+    """Multiple tasks — list endpoint returns all."""
+    store = TaskStore(task_db)
+    store.create_task(TaskModel.new("Alpha"))
+    store.create_task(TaskModel.new("Beta"))
+
+    resp = await client.get("/api/tasks")
+    data = await resp.json()
+    assert len(data["tasks"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_task_detail_rendering(client: TestClient, task_db) -> None:
+    """Detail endpoint returns task + event history."""
+    store = TaskStore(task_db)
+    task = TaskModel.new("Detail task")
+    store.create_task(task)
+    store.append_event(task.task_id, "status_change", payload={"status": "running"})
+
+    detail_resp = await client.get(f"/api/tasks/{task.task_id}")
+    events_resp = await client.get(f"/api/tasks/{task.task_id}/events")
+
+    assert detail_resp.status == 200
+    assert events_resp.status == 200
+
+    detail = await detail_resp.json()
+    events = await events_resp.json()
+
+    assert detail["title"] == "Detail task"
+    assert len(events["events"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_task_blocked_state(client: TestClient, task_db) -> None:
+    """Blocked task detail shows `blocked` status."""
+    store = TaskStore(task_db)
+    task = TaskModel.new("Blocked task")
+    store.create_task(task)
+    store.update_task_status(task.task_id, TaskStatus.RUNNING)
+    store.update_task_status(task.task_id, TaskStatus.BLOCKED)
+
+    resp = await client.get(f"/api/tasks/{task.task_id}")
+    data = await resp.json()
+    assert data["status"] == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_task_view_html_served(client: TestClient) -> None:
+    """tasks.html static file is served if the build directory exists."""
+    resp = await client.get("/tasks.html")
+    if BUILD_DIR.is_dir() and (BUILD_DIR / "tasks.html").exists():
+        assert resp.status == 200
+        text = await resp.text()
+        assert "tasks" in text.lower()
+    else:
+        # Build dir absent in CI — skip gracefully
+        assert resp.status in (200, 404)
+
+
+# ---------------------------------------------------------------------------
+# Research queue and audit panel rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_research_panel_empty_state(client: TestClient) -> None:
+    resp = await client.get("/api/research")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["nodes"] == []
+
+
+@pytest.mark.asyncio
+async def test_research_panel_populated(client: TestClient, research_db) -> None:
+    queue = ResearchQueue(research_db)
+    queue.enqueue("Investigate X", priority=2)
+    queue.enqueue("Investigate Y", priority=5)
+
+    resp = await client.get("/api/research")
+    data = await resp.json()
+    assert len(data["nodes"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_audit_panel_empty_state(client: TestClient) -> None:
+    resp = await client.get("/api/mcp/audit")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["records"] == []
+
+
+@pytest.mark.asyncio
+async def test_audit_panel_with_records(client: TestClient, research_db) -> None:
+    audit = MCPAuditStore(research_db)
+    audit.record("s1", "read_file", success=True, task_id="t1", run_id="r1")
+
+    resp = await client.get("/api/mcp/audit?task_id=t1")
+    data = await resp.json()
+    assert len(data["records"]) == 1
+    assert data["records"][0]["tool_name"] == "read_file"
+
+
+@pytest.mark.asyncio
+async def test_research_view_html_served(client: TestClient) -> None:
+    resp = await client.get("/research.html")
+    if BUILD_DIR.is_dir() and (BUILD_DIR / "research.html").exists():
+        assert resp.status == 200
+        text = await resp.text()
+        assert "research" in text.lower()
+    else:
+        assert resp.status in (200, 404)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler and capabilities sections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduler_state_section(client: TestClient) -> None:
+    resp = await client.get("/api/scheduler/state")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "quiet_hour_active" in data
+    assert "poll_limit" in data
+
+
+@pytest.mark.asyncio
+async def test_capabilities_section_empty(client: TestClient) -> None:
+    resp = await client.get("/api/capabilities")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "capabilities" in data


### PR DESCRIPTION
Closes #364

## Summary
- Added `src/openbad/wui/build/tasks.html`: task list (filterable by status), task detail with event history, pause/resume/cancel action buttons
- Added `src/openbad/wui/build/research.html`: research queue panel, MCP audit panel (filterable by task_id), capabilities panel, scheduler state panel
- Both views handle empty-state and blocked-state gracefully in vanilla JS
- `tests/test_wui_views.py`: integration tests wiring both task_api and research_api routes, verifying all panels render from API state (empty-state and populated-state covered)

## How to test
```
pytest tests/test_wui_views.py -q  # 12 passed
```