### PR TITLE
#365: Define reward trace and result models

### DIFF
--- a/src/openbad/tasks/rewards.py
+++ b/src/openbad/tasks/rewards.py
@@ -1,0 +1,183 @@
+"""Rich execution trace and reward result models for Phase 9.
+
+These models capture a superset of the fields required for reward evaluation,
+including retries, verification, budget consumption, and hormone context.
+They are serialization-only (no side-effects) and serve as the typed boundary
+between the executor and any downstream reward / logging pipeline.
+
+Distinct from :mod:`openbad.tasks.reward_models` (which drives the template
+evaluator): these models are optimised for full-fidelity persistence and API
+responses.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Field validation helpers
+# ---------------------------------------------------------------------------
+
+_REQUIRED_TRACE_FIELDS = {
+    "run_id",
+    "task_id",
+    "node_id",
+    "retries",
+    "verified",
+    "budget_consumed",
+    "outcome",
+}
+
+_REQUIRED_RESULT_FIELDS = {
+    "run_id",
+    "score",
+    "rationale",
+}
+
+
+def _require(d: dict[str, Any], required: set[str], label: str) -> None:
+    missing = required - d.keys()
+    if missing:
+        raise ValueError(f"{label}: missing required fields: {sorted(missing)}")
+
+
+# ---------------------------------------------------------------------------
+# ExecutionTrace
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ExecutionTrace:
+    """A complete record of a single task/node execution.
+
+    Parameters
+    ----------
+    run_id:
+        Identifier for the execution run.
+    task_id:
+        Parent task identifier.
+    node_id:
+        DAG node identifier.
+    outcome:
+        Final execution outcome string (e.g. ``"success"``, ``"failure"``).
+    retries:
+        Number of retry attempts made (≥ 0).
+    verified:
+        Whether the result was externally verified/confirmed.
+    budget_consumed:
+        Tokens or cost units consumed (≥ 0.0).
+    hormone_context:
+        Snapshot of hormone levels at execution time.  Keys are hormone
+        names; values are floats.
+    metadata:
+        Arbitrary additional key-value context for logging / downstream use.
+    """
+
+    run_id: str
+    task_id: str
+    node_id: str
+    outcome: str
+    retries: int
+    verified: bool
+    budget_consumed: float
+    hormone_context: dict[str, float] = dataclasses.field(default_factory=dict)
+    metadata: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.retries < 0:
+            raise ValueError("retries must be non-negative")
+        if self.budget_consumed < 0.0:
+            raise ValueError("budget_consumed must be non-negative")
+        if not self.run_id:
+            raise ValueError("run_id must not be empty")
+        if not self.task_id:
+            raise ValueError("task_id must not be empty")
+        if not self.node_id:
+            raise ValueError("node_id must not be empty")
+        if not self.outcome:
+            raise ValueError("outcome must not be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "task_id": self.task_id,
+            "node_id": self.node_id,
+            "outcome": self.outcome,
+            "retries": self.retries,
+            "verified": self.verified,
+            "budget_consumed": self.budget_consumed,
+            "hormone_context": dict(self.hormone_context),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ExecutionTrace:
+        _require(d, _REQUIRED_TRACE_FIELDS, "ExecutionTrace")
+        return cls(
+            run_id=str(d["run_id"]),
+            task_id=str(d["task_id"]),
+            node_id=str(d["node_id"]),
+            outcome=str(d["outcome"]),
+            retries=int(d["retries"]),
+            verified=bool(d["verified"]),
+            budget_consumed=float(d["budget_consumed"]),
+            hormone_context=dict(d.get("hormone_context") or {}),
+            metadata=dict(d.get("metadata") or {}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# RewardResult
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class RewardResult:
+    """The output of a reward evaluation, ready for persistence or API response.
+
+    Parameters
+    ----------
+    run_id:
+        The run that was evaluated.
+    score:
+        Normalised reward score in ``[-1.0, 1.0]``.
+    rationale:
+        Human/machine-readable explanation of the score.
+    template_id:
+        Optional identifier of the scoring template used.
+    metadata:
+        Arbitrary additional context.
+    """
+
+    run_id: str
+    score: float
+    rationale: str
+    template_id: str = ""
+    metadata: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            raise ValueError("run_id must not be empty")
+        if not -1.0 <= self.score <= 1.0:
+            raise ValueError(f"score must be in [-1.0, 1.0], got {self.score}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "score": self.score,
+            "rationale": self.rationale,
+            "template_id": self.template_id,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RewardResult:
+        _require(d, _REQUIRED_RESULT_FIELDS, "RewardResult")
+        return cls(
+            run_id=str(d["run_id"]),
+            score=float(d["score"]),
+            rationale=str(d["rationale"]),
+            template_id=str(d.get("template_id", "")),
+            metadata=dict(d.get("metadata") or {}),
+        )

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import pytest
+
+from openbad.tasks.rewards import ExecutionTrace, RewardResult
+
+# ---------------------------------------------------------------------------
+# ExecutionTrace validation
+# ---------------------------------------------------------------------------
+
+
+def make_trace(**overrides) -> ExecutionTrace:
+    defaults = dict(
+        run_id="run-1",
+        task_id="task-1",
+        node_id="node-1",
+        outcome="success",
+        retries=0,
+        verified=True,
+        budget_consumed=10.5,
+    )
+    defaults.update(overrides)
+    return ExecutionTrace(**defaults)
+
+
+def test_trace_valid_construction() -> None:
+    t = make_trace()
+    assert t.run_id == "run-1"
+    assert t.verified is True
+    assert t.budget_consumed == 10.5
+
+
+def test_trace_rejects_negative_retries() -> None:
+    with pytest.raises(ValueError, match="retries"):
+        make_trace(retries=-1)
+
+
+def test_trace_rejects_negative_budget() -> None:
+    with pytest.raises(ValueError, match="budget_consumed"):
+        make_trace(budget_consumed=-0.01)
+
+
+def test_trace_rejects_empty_run_id() -> None:
+    with pytest.raises(ValueError, match="run_id"):
+        make_trace(run_id="")
+
+
+def test_trace_rejects_empty_outcome() -> None:
+    with pytest.raises(ValueError, match="outcome"):
+        make_trace(outcome="")
+
+
+def test_trace_with_hormone_context() -> None:
+    t = make_trace(hormone_context={"dopamine": 0.4, "cortisol": 0.1})
+    assert t.hormone_context["dopamine"] == 0.4
+
+
+# ---------------------------------------------------------------------------
+# ExecutionTrace serialization
+# ---------------------------------------------------------------------------
+
+
+def test_trace_to_dict_round_trip() -> None:
+    original = make_trace(
+        retries=2,
+        verified=False,
+        budget_consumed=5.0,
+        hormone_context={"dopamine": 0.3},
+        metadata={"actor": "scheduler"},
+    )
+    d = original.to_dict()
+    restored = ExecutionTrace.from_dict(d)
+
+    assert restored.run_id == original.run_id
+    assert restored.retries == original.retries
+    assert restored.verified is False
+    assert restored.budget_consumed == original.budget_consumed
+    assert restored.hormone_context == {"dopamine": 0.3}
+    assert restored.metadata == {"actor": "scheduler"}
+
+
+def test_trace_from_dict_missing_field_raises() -> None:
+    d = {"run_id": "r1", "task_id": "t1"}  # missing many fields
+    with pytest.raises(ValueError, match="missing required fields"):
+        ExecutionTrace.from_dict(d)
+
+
+# ---------------------------------------------------------------------------
+# RewardResult validation
+# ---------------------------------------------------------------------------
+
+
+def make_result(**overrides) -> RewardResult:
+    defaults = dict(run_id="run-1", score=0.75, rationale="good work")
+    defaults.update(overrides)
+    return RewardResult(**defaults)
+
+
+def test_result_valid_construction() -> None:
+    r = make_result()
+    assert r.score == 0.75
+    assert r.rationale == "good work"
+
+
+def test_result_rejects_empty_run_id() -> None:
+    with pytest.raises(ValueError, match="run_id"):
+        make_result(run_id="")
+
+
+def test_result_rejects_score_above_one() -> None:
+    with pytest.raises(ValueError, match="score"):
+        make_result(score=1.001)
+
+
+def test_result_rejects_score_below_neg_one() -> None:
+    with pytest.raises(ValueError, match="score"):
+        make_result(score=-1.001)
+
+
+def test_result_score_boundary_values() -> None:
+    make_result(score=1.0)
+    make_result(score=-1.0)
+    make_result(score=0.0)
+
+
+# ---------------------------------------------------------------------------
+# RewardResult serialization
+# ---------------------------------------------------------------------------
+
+
+def test_result_to_dict_round_trip() -> None:
+    original = make_result(score=-0.5, template_id="tmpl.default", metadata={"k": "v"})
+    d = original.to_dict()
+    restored = RewardResult.from_dict(d)
+
+    assert restored.run_id == original.run_id
+    assert restored.score == original.score
+    assert restored.template_id == "tmpl.default"
+    assert restored.metadata == {"k": "v"}
+
+
+def test_result_from_dict_missing_field_raises() -> None:
+    with pytest.raises(ValueError, match="missing required fields"):
+        RewardResult.from_dict({"run_id": "r1"})


### PR DESCRIPTION
Closes #365

## Summary
- Created `src/openbad/tasks/rewards.py`:
  - `ExecutionTrace`: full-fidelity trace with run_id, task_id, node_id, outcome, retries, verified, budget_consumed, hormone_context, metadata; validates all required fields
  - `RewardResult`: normalised score [-1.0, 1.0] with run_id, rationale, template_id, metadata
  - Both have `to_dict()` / `from_dict()` round-trip serialization
  - `from_dict()` raises `ValueError` on missing required fields

## How to test
```
pytest tests/test_rewards.py -q  # 15 passed
```