### PR TITLE
#326: Add scheduler heartbeat and task lease dispatch

### DIFF
--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -139,6 +139,9 @@ TASK_STATUS = "agent/task/{task_id}/status"
 TASK_NODE_STATUS = "agent/task/{task_id}/node/{node_id}/status"
 TASK_COMPLETED = "agent/task/{task_id}/completed"
 TASK_FAILED = "agent/task/{task_id}/failed"
+TASK_CONTEXT_REQUIRED = "agent/tasks/context_required"
+TASK_ISOLATED = "agent/tasks/isolated"
+TASK_EVENTS = "agent/tasks/events"
 
 # Wildcard: all task events
 TASK_ALL = "agent/task/#"
@@ -150,6 +153,7 @@ RESEARCH_QUEUED = "agent/research/queued"
 RESEARCH_STARTED = "agent/research/{research_id}/started"
 RESEARCH_COMPLETED = "agent/research/{research_id}/completed"
 RESEARCH_FINDING = "agent/research/{research_id}/finding"
+RESEARCH_DEEP_DIVE = "agent/research/deep_dive"
 
 # Wildcard: all research events
 RESEARCH_ALL = "agent/research/#"
@@ -161,6 +165,9 @@ SCHEDULER_TICK = "agent/scheduler/tick"
 SCHEDULER_WINDOW_START = "agent/scheduler/window/start"
 SCHEDULER_WINDOW_END = "agent/scheduler/window/end"
 SCHEDULER_DISPATCH = "agent/scheduler/dispatch"
+SCHEDULER_WAKE = "agent/scheduler/wake"
+SCHEDULER_SLEEP_WINDOW = "agent/scheduler/sleep_window"
+SCHEDULER_MAINTENANCE = "agent/scheduler/maintenance"
 
 # Wildcard: all scheduler events
 SCHEDULER_ALL = "agent/scheduler/+"

--- a/src/openbad/tasks/heartbeat.py
+++ b/src/openbad/tasks/heartbeat.py
@@ -1,0 +1,168 @@
+"""Persisted heartbeat state for the Phase 9 scheduler subsystem.
+
+:class:`HeartbeatStore` reads and updates a single-row ``heartbeat_state``
+table so the scheduler can resume after process restart without re-dispatching
+already-processed work.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+import time
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class HeartbeatState:
+    """Mutable snapshot of the persisted heartbeat row."""
+
+    last_heartbeat_at: float = 0.0
+    last_triage_at: float = 0.0
+    last_context_required_dispatch_at: float = 0.0
+    last_research_review_at: float = 0.0
+    last_sleep_cycle_at: float = 0.0
+    last_maintenance_at: float = 0.0
+    silent_skip_count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class HeartbeatStore:
+    """Read/write access to the ``heartbeat_state`` table.
+
+    The table is constrained to exactly one row (``id = 1``).  The first call
+    to :meth:`load` creates that row with zeroed timestamps if it does not
+    exist.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def initialize(self) -> None:
+        """Create the ``heartbeat_state`` table if it does not already exist."""
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS heartbeat_state (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                last_heartbeat_at REAL NOT NULL DEFAULT 0.0,
+                last_triage_at REAL NOT NULL DEFAULT 0.0,
+                last_context_required_dispatch_at REAL NOT NULL DEFAULT 0.0,
+                last_research_review_at REAL NOT NULL DEFAULT 0.0,
+                last_sleep_cycle_at REAL NOT NULL DEFAULT 0.0,
+                last_maintenance_at REAL NOT NULL DEFAULT 0.0,
+                silent_skip_count INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def load(self) -> HeartbeatState:
+        """Return the current heartbeat state, inserting defaults on first use."""
+        self._conn.execute(
+            """
+            INSERT OR IGNORE INTO heartbeat_state (id) VALUES (1)
+            """
+        )
+        self._conn.commit()
+        row = self._conn.execute(
+            """
+            SELECT last_heartbeat_at, last_triage_at,
+                   last_context_required_dispatch_at, last_research_review_at,
+                   last_sleep_cycle_at, last_maintenance_at, silent_skip_count
+            FROM heartbeat_state WHERE id = 1
+            """
+        ).fetchone()
+        return HeartbeatState(
+            last_heartbeat_at=row[0],
+            last_triage_at=row[1],
+            last_context_required_dispatch_at=row[2],
+            last_research_review_at=row[3],
+            last_sleep_cycle_at=row[4],
+            last_maintenance_at=row[5],
+            silent_skip_count=row[6],
+        )
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    def record_heartbeat(self, ts: float | None = None) -> None:
+        """Stamp ``last_heartbeat_at`` with *ts* (defaults to ``time.time()``)."""
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_heartbeat_at = ? WHERE id = 1",
+            (ts if ts is not None else time.time(),),
+        )
+        self._conn.commit()
+
+    def record_triage(self, ts: float | None = None) -> None:
+        """Stamp ``last_triage_at``."""
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_triage_at = ? WHERE id = 1",
+            (ts if ts is not None else time.time(),),
+        )
+        self._conn.commit()
+
+    def record_context_required_dispatch(self, ts: float | None = None) -> None:
+        """Stamp ``last_context_required_dispatch_at``."""
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_context_required_dispatch_at = ? WHERE id = 1",
+            (ts if ts is not None else time.time(),),
+        )
+        self._conn.commit()
+
+    def record_research_review(self, ts: float | None = None) -> None:
+        """Stamp ``last_research_review_at``."""
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_research_review_at = ? WHERE id = 1",
+            (ts if ts is not None else time.time(),),
+        )
+        self._conn.commit()
+
+    def record_sleep_cycle(self, ts: float | None = None) -> None:
+        """Stamp ``last_sleep_cycle_at``."""
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_sleep_cycle_at = ? WHERE id = 1",
+            (ts if ts is not None else time.time(),),
+        )
+        self._conn.commit()
+
+    def record_maintenance(self, ts: float | None = None) -> None:
+        """Stamp ``last_maintenance_at``."""
+        self._conn.execute(
+            "UPDATE heartbeat_state SET last_maintenance_at = ? WHERE id = 1",
+            (ts if ts is not None else time.time(),),
+        )
+        self._conn.commit()
+
+    def increment_silent_skip(self) -> int:
+        """Increment ``silent_skip_count`` by one and return the new value."""
+        self._conn.execute(
+            "UPDATE heartbeat_state SET silent_skip_count = silent_skip_count + 1 WHERE id = 1"
+        )
+        self._conn.commit()
+        row = self._conn.execute(
+            "SELECT silent_skip_count FROM heartbeat_state WHERE id = 1"
+        ).fetchone()
+        return int(row[0])
+
+    def reset_silent_skip(self) -> None:
+        """Reset ``silent_skip_count`` to zero when work is dispatched."""
+        self._conn.execute(
+            "UPDATE heartbeat_state SET silent_skip_count = 0 WHERE id = 1"
+        )
+        self._conn.commit()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,196 @@
+"""Tests for openbad.tasks.heartbeat (issue #326)."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from openbad.tasks.heartbeat import HeartbeatState, HeartbeatStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_store() -> HeartbeatStore:
+    conn = sqlite3.connect(":memory:")
+    store = HeartbeatStore(conn)
+    store.initialize()
+    return store
+
+
+# ---------------------------------------------------------------------------
+# HeartbeatState
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatState:
+    def test_defaults_are_zero(self) -> None:
+        state = HeartbeatState()
+        assert state.last_heartbeat_at == 0.0
+        assert state.last_triage_at == 0.0
+        assert state.last_context_required_dispatch_at == 0.0
+        assert state.last_research_review_at == 0.0
+        assert state.last_sleep_cycle_at == 0.0
+        assert state.last_maintenance_at == 0.0
+        assert state.silent_skip_count == 0
+
+
+# ---------------------------------------------------------------------------
+# HeartbeatStore – initialization and load
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatStoreInit:
+    def test_initialize_creates_table(self) -> None:
+        conn = sqlite3.connect(":memory:")
+        store = HeartbeatStore(conn)
+        store.initialize()
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='heartbeat_state'"
+        ).fetchone()
+        assert row is not None
+
+    def test_load_inserts_default_row(self) -> None:
+        store = make_store()
+        state = store.load()
+        assert state.last_heartbeat_at == 0.0
+        assert state.silent_skip_count == 0
+
+    def test_load_is_idempotent(self) -> None:
+        store = make_store()
+        store.load()
+        store.load()  # Should not raise or duplicate
+        state = store.load()
+        assert state.silent_skip_count == 0
+
+    def test_state_survives_reconnect(self) -> None:
+        """Persisted state should be readable after store object is recreated."""
+        conn = sqlite3.connect(":memory:")
+        store = HeartbeatStore(conn)
+        store.initialize()
+        store.load()
+        ts = 1_700_000_000.0
+        store.record_heartbeat(ts)
+
+        # Same connection, new store object
+        store2 = HeartbeatStore(conn)
+        state = store2.load()
+        assert state.last_heartbeat_at == pytest.approx(ts)
+
+
+# ---------------------------------------------------------------------------
+# Timestamp recording
+# ---------------------------------------------------------------------------
+
+
+class TestTimestampRecording:
+    def test_record_heartbeat_updates_field(self) -> None:
+        store = make_store()
+        store.load()
+        ts = 1_710_000_000.0
+        store.record_heartbeat(ts)
+        assert store.load().last_heartbeat_at == pytest.approx(ts)
+
+    def test_record_heartbeat_defaults_to_now(self) -> None:
+        store = make_store()
+        store.load()
+        before = time.time()
+        store.record_heartbeat()
+        after = time.time()
+        state = store.load()
+        assert before <= state.last_heartbeat_at <= after
+
+    def test_record_triage(self) -> None:
+        store = make_store()
+        store.load()
+        ts = 1_720_000_000.0
+        store.record_triage(ts)
+        assert store.load().last_triage_at == pytest.approx(ts)
+
+    def test_record_context_required_dispatch(self) -> None:
+        store = make_store()
+        store.load()
+        ts = 1_720_100_000.0
+        store.record_context_required_dispatch(ts)
+        assert store.load().last_context_required_dispatch_at == pytest.approx(ts)
+
+    def test_record_research_review(self) -> None:
+        store = make_store()
+        store.load()
+        ts = 1_720_200_000.0
+        store.record_research_review(ts)
+        assert store.load().last_research_review_at == pytest.approx(ts)
+
+    def test_record_sleep_cycle(self) -> None:
+        store = make_store()
+        store.load()
+        ts = 1_720_300_000.0
+        store.record_sleep_cycle(ts)
+        assert store.load().last_sleep_cycle_at == pytest.approx(ts)
+
+    def test_record_maintenance(self) -> None:
+        store = make_store()
+        store.load()
+        ts = 1_720_400_000.0
+        store.record_maintenance(ts)
+        assert store.load().last_maintenance_at == pytest.approx(ts)
+
+
+# ---------------------------------------------------------------------------
+# Silent skip counter
+# ---------------------------------------------------------------------------
+
+
+class TestSilentSkipCounter:
+    def test_increment_starts_at_one(self) -> None:
+        store = make_store()
+        store.load()
+        result = store.increment_silent_skip()
+        assert result == 1
+
+    def test_increment_accumulates(self) -> None:
+        store = make_store()
+        store.load()
+        for _ in range(5):
+            store.increment_silent_skip()
+        assert store.load().silent_skip_count == 5
+
+    def test_reset_clears_count(self) -> None:
+        store = make_store()
+        store.load()
+        store.increment_silent_skip()
+        store.increment_silent_skip()
+        store.reset_silent_skip()
+        assert store.load().silent_skip_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Topics constant validation
+# ---------------------------------------------------------------------------
+
+
+class TestTopicsConstants:
+    def test_required_topics_present(self) -> None:
+        from openbad.nervous_system import topics
+
+        assert hasattr(topics, "TASK_CONTEXT_REQUIRED")
+        assert hasattr(topics, "TASK_ISOLATED")
+        assert hasattr(topics, "TASK_EVENTS")
+        assert hasattr(topics, "RESEARCH_DEEP_DIVE")
+        assert hasattr(topics, "SCHEDULER_WAKE")
+        assert hasattr(topics, "SCHEDULER_SLEEP_WINDOW")
+        assert hasattr(topics, "SCHEDULER_MAINTENANCE")
+
+    def test_topic_values_match_spec(self) -> None:
+        from openbad.nervous_system import topics
+
+        assert topics.TASK_CONTEXT_REQUIRED == "agent/tasks/context_required"
+        assert topics.TASK_ISOLATED == "agent/tasks/isolated"
+        assert topics.TASK_EVENTS == "agent/tasks/events"
+        assert topics.RESEARCH_DEEP_DIVE == "agent/research/deep_dive"
+        assert topics.SCHEDULER_WAKE == "agent/scheduler/wake"
+        assert topics.SCHEDULER_SLEEP_WINDOW == "agent/scheduler/sleep_window"
+        assert topics.SCHEDULER_MAINTENANCE == "agent/scheduler/maintenance"


### PR DESCRIPTION
Closes #326

## Summary
- Created `src/openbad/tasks/heartbeat.py`: `HeartbeatState` dataclass + `HeartbeatStore` with full read/write API (record_heartbeat, record_triage, record_context_required_dispatch, record_research_review, record_sleep_cycle, record_maintenance, increment_silent_skip, reset_silent_skip)
- Extended `src/openbad/nervous_system/topics.py` with all 7 required Phase 9 topics: `TASK_CONTEXT_REQUIRED`, `TASK_ISOLATED`, `TASK_EVENTS`, `RESEARCH_DEEP_DIVE`, `SCHEDULER_WAKE`, `SCHEDULER_SLEEP_WINDOW`, `SCHEDULER_MAINTENANCE`

## How to test
```bash
pytest tests/test_heartbeat.py -q
```
17 tests pass.