### PR TITLE
#406: Add DEFERRED_RESOURCES, QUARANTINED, BLOCKED_ON_USER to task/node status enums

### DIFF
--- a/src/openbad/tasks/models.py
+++ b/src/openbad/tasks/models.py
@@ -18,6 +18,7 @@ class TaskStatus(StrEnum):
     PENDING = "pending"
     RUNNING = "running"
     BLOCKED = "blocked"
+    BLOCKED_ON_USER = "blocked_on_user"
     DONE = "done"
     FAILED = "failed"
     CANCELLED = "cancelled"
@@ -29,6 +30,9 @@ class NodeStatus(StrEnum):
     PENDING = "pending"
     RUNNING = "running"
     BLOCKED = "blocked"
+    DEFERRED_RESOURCES = "deferred_resources"
+    QUARANTINED = "quarantined"
+    BLOCKED_ON_USER = "blocked_on_user"
     DONE = "done"
     FAILED = "failed"
     CANCELLED = "cancelled"
@@ -78,9 +82,16 @@ class TaskPriority(int, Enum):
 TASK_TRANSITIONS: dict[TaskStatus, frozenset[TaskStatus]] = {
     TaskStatus.PENDING: frozenset({TaskStatus.RUNNING, TaskStatus.CANCELLED}),
     TaskStatus.RUNNING: frozenset(
-        {TaskStatus.DONE, TaskStatus.FAILED, TaskStatus.BLOCKED, TaskStatus.CANCELLED}
+        {
+            TaskStatus.DONE,
+            TaskStatus.FAILED,
+            TaskStatus.BLOCKED,
+            TaskStatus.BLOCKED_ON_USER,
+            TaskStatus.CANCELLED,
+        }
     ),
     TaskStatus.BLOCKED: frozenset({TaskStatus.RUNNING, TaskStatus.CANCELLED}),
+    TaskStatus.BLOCKED_ON_USER: frozenset({TaskStatus.RUNNING, TaskStatus.CANCELLED}),
     TaskStatus.DONE: frozenset(),
     TaskStatus.FAILED: frozenset(),
     TaskStatus.CANCELLED: frozenset(),
@@ -92,9 +103,20 @@ NODE_TRANSITIONS: dict[NodeStatus, frozenset[NodeStatus]] = {
         {NodeStatus.RUNNING, NodeStatus.BLOCKED, NodeStatus.CANCELLED}
     ),
     NodeStatus.RUNNING: frozenset(
-        {NodeStatus.DONE, NodeStatus.FAILED, NodeStatus.BLOCKED, NodeStatus.CANCELLED}
+        {
+            NodeStatus.DONE,
+            NodeStatus.FAILED,
+            NodeStatus.BLOCKED,
+            NodeStatus.DEFERRED_RESOURCES,
+            NodeStatus.QUARANTINED,
+            NodeStatus.BLOCKED_ON_USER,
+            NodeStatus.CANCELLED,
+        }
     ),
     NodeStatus.BLOCKED: frozenset({NodeStatus.RUNNING, NodeStatus.CANCELLED}),
+    NodeStatus.DEFERRED_RESOURCES: frozenset({NodeStatus.RUNNING, NodeStatus.CANCELLED}),
+    NodeStatus.QUARANTINED: frozenset(),
+    NodeStatus.BLOCKED_ON_USER: frozenset({NodeStatus.RUNNING, NodeStatus.CANCELLED}),
     NodeStatus.DONE: frozenset(),
     NodeStatus.FAILED: frozenset(),
     NodeStatus.CANCELLED: frozenset(),

--- a/tests/test_task_models.py
+++ b/tests/test_task_models.py
@@ -151,3 +151,73 @@ def test_task_terminal_states_have_no_transitions(terminal: TaskStatus) -> None:
 def test_node_terminal_states_have_no_transitions(terminal: NodeStatus) -> None:
     for other in NodeStatus:
         assert not is_valid_node_transition(terminal, other)
+
+
+# ---------------------------------------------------------------------------
+# Phase 10: new status enum values (#406)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase10StatusEnums:
+    def test_task_blocked_on_user_exists(self) -> None:
+        assert TaskStatus.BLOCKED_ON_USER == "blocked_on_user"
+
+    def test_node_deferred_resources_exists(self) -> None:
+        assert NodeStatus.DEFERRED_RESOURCES == "deferred_resources"
+
+    def test_node_quarantined_exists(self) -> None:
+        assert NodeStatus.QUARANTINED == "quarantined"
+
+    def test_node_blocked_on_user_exists(self) -> None:
+        assert NodeStatus.BLOCKED_ON_USER == "blocked_on_user"
+
+    # New valid task transitions
+    @pytest.mark.parametrize(
+        "current, next_status",
+        [
+            (TaskStatus.RUNNING, TaskStatus.BLOCKED_ON_USER),
+            (TaskStatus.BLOCKED_ON_USER, TaskStatus.RUNNING),
+            (TaskStatus.BLOCKED_ON_USER, TaskStatus.CANCELLED),
+        ],
+    )
+    def test_valid_task_transitions_phase10(
+        self, current: TaskStatus, next_status: TaskStatus
+    ) -> None:
+        assert is_valid_task_transition(current, next_status)
+        assert_valid_task_transition(current, next_status)
+
+    # New valid node transitions
+    @pytest.mark.parametrize(
+        "current, next_status",
+        [
+            (NodeStatus.RUNNING, NodeStatus.DEFERRED_RESOURCES),
+            (NodeStatus.DEFERRED_RESOURCES, NodeStatus.RUNNING),
+            (NodeStatus.DEFERRED_RESOURCES, NodeStatus.CANCELLED),
+            (NodeStatus.RUNNING, NodeStatus.QUARANTINED),
+            (NodeStatus.RUNNING, NodeStatus.BLOCKED_ON_USER),
+            (NodeStatus.BLOCKED_ON_USER, NodeStatus.RUNNING),
+            (NodeStatus.BLOCKED_ON_USER, NodeStatus.CANCELLED),
+        ],
+    )
+    def test_valid_node_transitions_phase10(
+        self, current: NodeStatus, next_status: NodeStatus
+    ) -> None:
+        assert is_valid_node_transition(current, next_status)
+        assert_valid_node_transition(current, next_status)
+
+    def test_quarantined_is_terminal(self) -> None:
+        for other in NodeStatus:
+            assert not is_valid_node_transition(NodeStatus.QUARANTINED, other)
+
+    def test_new_values_round_trip_to_string(self) -> None:
+        assert str(TaskStatus.BLOCKED_ON_USER) == "blocked_on_user"
+        assert str(NodeStatus.DEFERRED_RESOURCES) == "deferred_resources"
+        assert str(NodeStatus.QUARANTINED) == "quarantined"
+        assert str(NodeStatus.BLOCKED_ON_USER) == "blocked_on_user"
+
+    def test_blocked_on_user_invalid_task_transitions(self) -> None:
+        # Can't jump straight from BLOCKED_ON_USER to terminal without RUNNING
+        assert not is_valid_task_transition(TaskStatus.BLOCKED_ON_USER, TaskStatus.DONE)
+        assert not is_valid_task_transition(
+            TaskStatus.BLOCKED_ON_USER, TaskStatus.FAILED
+        )


### PR DESCRIPTION
Closes #406

## Summary
- Added `TaskStatus.BLOCKED_ON_USER` for tasks awaiting user input
- Added `NodeStatus.DEFERRED_RESOURCES`, `NodeStatus.QUARANTINED`, `NodeStatus.BLOCKED_ON_USER`
- Updated `TASK_TRANSITIONS` and `NODE_TRANSITIONS` maps with valid Phase 10 state transitions
- QUARANTINED is terminal (no outgoing transitions)

## How to test
`pytest tests/test_task_models.py -q`
52 tests pass.