### PR TITLE
#407: Add fs_tool.py with read_file and write_file

### DIFF
--- a/src/openbad/toolbelt/fs_tool.py
+++ b/src/openbad/toolbelt/fs_tool.py
@@ -1,0 +1,132 @@
+"""Trusted in-process file system operations for Phase 10 toolbelt.
+
+:func:`read_file` and :func:`write_file` provide POSIX file I/O with
+path-safety enforcement.  Both functions:
+
+* Canonicalize the requested path via :func:`os.path.realpath` before any I/O.
+* Reject attempts to escape an allowed root (``ALLOWED_ROOT``, default: the
+  system temporary directory plus the current working directory).
+* Write atomically — content is written to a sibling ``.tmp`` file then
+  renamed, so partial writes never corrupt an existing file.
+
+Security guarantees
+-------------------
+* Symlink traversal is resolved before validation; following a symlink into a
+  restricted area is blocked just like a direct path reference.
+* Directory-traversal sequences (``../``) are neutralised by
+  :func:`os.path.realpath`.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import uuid
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Allowed roots
+# ---------------------------------------------------------------------------
+
+# Default safe root directories.  Callers may extend this list by appending
+# to ALLOWED_ROOTS before invoking the module.
+ALLOWED_ROOTS: list[str] = [
+    tempfile.gettempdir(),
+    str(Path.cwd()),
+]
+
+
+def _is_safe_path(resolved: str) -> bool:
+    """Return True if *resolved* (an absolute, real path) is under an allowed root."""
+    for root in ALLOWED_ROOTS:
+        real_root = os.path.realpath(root)
+        if resolved.startswith(real_root + os.sep) or resolved == real_root:
+            return True
+    return False
+
+
+def _validate(path: str) -> str:
+    """Resolve and validate *path*.
+
+    Returns the resolved absolute path string.
+
+    Raises
+    ------
+    PermissionError
+        If the resolved path is outside all allowed roots.
+    """
+    resolved = os.path.realpath(os.path.abspath(path))
+    if not _is_safe_path(resolved):
+        raise PermissionError(
+            f"Path {path!r} resolves to {resolved!r} which is outside allowed roots."
+        )
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def read_file(path: str, *, encoding: str = "utf-8") -> str:
+    """Read and return the contents of *path* as a string.
+
+    Parameters
+    ----------
+    path:
+        The file path to read.  May be relative.
+    encoding:
+        Text encoding (default ``utf-8``).
+
+    Returns
+    -------
+    str
+        The file contents.
+
+    Raises
+    ------
+    PermissionError
+        If the path is outside allowed roots.
+    FileNotFoundError
+        If the file does not exist.
+    IsADirectoryError
+        If the path points to a directory.
+    """
+    resolved = _validate(path)
+    return Path(resolved).read_text(encoding=encoding)
+
+
+def write_file(path: str, content: str, *, encoding: str = "utf-8") -> None:
+    """Write *content* to *path* atomically.
+
+    The write is performed to a sibling temporary file and then renamed into
+    place, ensuring the target file is never partially written.
+
+    Parameters
+    ----------
+    path:
+        Destination file path.  May be relative.  Parent directory must exist.
+    content:
+        Text to write.
+    encoding:
+        Text encoding (default ``utf-8``).
+
+    Raises
+    ------
+    PermissionError
+        If the path is outside allowed roots.
+    FileNotFoundError
+        If the parent directory does not exist.
+    """
+    resolved = _validate(path)
+    parent = Path(resolved).parent
+    if not parent.exists():
+        raise FileNotFoundError(f"Parent directory does not exist: {parent}")
+
+    tmp_path = parent / f".{uuid.uuid4().hex}.tmp"
+    try:
+        tmp_path.write_text(content, encoding=encoding)
+        tmp_path.rename(resolved)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/tests/test_fs_tool.py
+++ b/tests/test_fs_tool.py
@@ -1,0 +1,111 @@
+"""Tests for openbad.toolbelt.fs_tool (issue #407)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import openbad.toolbelt.fs_tool as fs_tool
+from openbad.toolbelt.fs_tool import read_file, write_file
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def allow_tmp(tmp_path: Path, monkeypatch):
+    """Ensure ALLOWED_ROOTS includes the test's tmp_path."""
+    monkeypatch.setattr(fs_tool, "ALLOWED_ROOTS", [str(tmp_path)])
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# read_file
+# ---------------------------------------------------------------------------
+
+
+class TestReadFile:
+    def test_reads_content(self, tmp_path: Path) -> None:
+        f = tmp_path / "hello.txt"
+        f.write_text("hello world")
+        assert read_file(str(f)) == "hello world"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            read_file(str(tmp_path / "nonexistent.txt"))
+
+    def test_directory_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(IsADirectoryError):
+            read_file(str(tmp_path))
+
+    def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        # Build a path that tries to escape tmp_path
+        evil = str(tmp_path) + "/../../etc/passwd"
+        with pytest.raises(PermissionError):
+            read_file(evil)
+
+    def test_absolute_outside_allowed_rejected(self) -> None:
+        with pytest.raises(PermissionError):
+            read_file("/etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# write_file
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFile:
+    def test_writes_creates_file(self, tmp_path: Path) -> None:
+        dest = tmp_path / "out.txt"
+        write_file(str(dest), "content here")
+        assert dest.read_text() == "content here"
+
+    def test_write_overwrites_existing(self, tmp_path: Path) -> None:
+        dest = tmp_path / "existing.txt"
+        dest.write_text("old")
+        write_file(str(dest), "new")
+        assert dest.read_text() == "new"
+
+    def test_write_is_atomic_no_tmp_left(self, tmp_path: Path) -> None:
+        dest = tmp_path / "atomic.txt"
+        write_file(str(dest), "data")
+        # No .tmp files should remain
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert tmp_files == []
+
+    def test_write_missing_parent_raises(self, tmp_path: Path) -> None:
+        dest = tmp_path / "subdir" / "file.txt"
+        with pytest.raises(FileNotFoundError):
+            write_file(str(dest), "content")
+
+    def test_write_path_traversal_rejected(self, tmp_path: Path) -> None:
+        evil = str(tmp_path) + "/../../etc/profile"
+        with pytest.raises(PermissionError):
+            write_file(evil, "bad")
+
+    def test_write_absolute_outside_allowed_rejected(self) -> None:
+        with pytest.raises(PermissionError):
+            write_file("/etc/evil.conf", "pwned")
+
+
+# ---------------------------------------------------------------------------
+# Symlink escape prevention
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkEscape:
+    def test_symlink_to_outside_rejected(self, tmp_path: Path) -> None:
+        # Create a symlink inside tmp_path that points outside
+        link = tmp_path / "escape_link.txt"
+        link.symlink_to("/etc/passwd")
+        with pytest.raises(PermissionError):
+            read_file(str(link))
+
+    def test_symlink_within_allowed_ok(self, tmp_path: Path) -> None:
+        target = tmp_path / "real.txt"
+        target.write_text("real content")
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+        assert read_file(str(link)) == "real content"


### PR DESCRIPTION
Closes #407

## Summary
- Created `src/openbad/toolbelt/fs_tool.py` with `read_file()` and `write_file()`
- Atomic write via temp file + rename
- Path canonicalization with `os.path.realpath` to resolve symlinks
- Rejects paths outside `ALLOWED_ROOTS` (directory traversal, absolute escapes, symlink escapes)

## How to test
`pytest tests/test_fs_tool.py -q`