### PR TITLE
#412: Add web_fetch function to web_search toolbelt

### DIFF
--- a/src/openbad/toolbelt/web_search.py
+++ b/src/openbad/toolbelt/web_search.py
@@ -2,12 +2,17 @@
 
 Registers under ``ToolRole.WEB_SEARCH`` and provides structured search
 results with rate limiting and health checks.
+
+Also exposes :func:`web_fetch` for downloading and cleaning a single URL
+into sanitised plain text or minimal Markdown.
 """
 
 from __future__ import annotations
 
+import html as _html_mod
 import json as _json
 import logging
+import re
 import time
 import urllib.parse
 import urllib.request
@@ -51,6 +56,109 @@ class _RateLimiter:
             return False
         self._timestamps.append(now)
         return True
+
+
+# ---------------------------------------------------------------------------
+# web_fetch
+# ---------------------------------------------------------------------------
+
+_MAX_FETCH_BYTES = 2 * 1024 * 1024  # 2 MB hard cap
+
+# Tags whose inner content is stripped completely (not converted)
+_DROP_TAGS_RE = re.compile(
+    r"<(script|style|noscript|head|header|footer|nav|aside)[^>]*>.*?</\1>",
+    re.IGNORECASE | re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+_MULTI_BLANK_RE = re.compile(r"\n{3,}")
+
+
+class WebFetchError(OSError):
+    """Raised when :func:`web_fetch` cannot retrieve or decode the resource.
+
+    Attributes
+    ----------
+    status_code:
+        HTTP status code if available, otherwise 0.
+    """
+
+    def __init__(self, message: str, status_code: int = 0) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def web_fetch(
+    url: str,
+    *,
+    timeout: float = 15.0,
+    max_chars: int = 32_000,
+) -> str:
+    """Fetch *url* and return its content as cleaned plain text.
+
+    Parameters
+    ----------
+    url:
+        The HTTP/HTTPS URL to fetch.  Other schemes are rejected.
+    timeout:
+        Request timeout in seconds (default 15).
+    max_chars:
+        Maximum characters returned after cleaning (default 32 000).
+
+    Returns
+    -------
+    str
+        Cleaned text extracted from the response body, truncated to
+        *max_chars* characters.
+
+    Raises
+    ------
+    ValueError
+        If *url* does not use http or https scheme.
+    WebFetchError
+        On HTTP errors (4xx, 5xx), network errors, or decode failures.
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Only http/https URLs are supported, got: {url!r}")
+
+    req = urllib.request.Request(url, headers={"User-Agent": "OpenBaD/1.0"})  # noqa: S310
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            raw: bytes = resp.read(_MAX_FETCH_BYTES)
+            content_type: str = resp.headers.get_content_type() or ""
+    except urllib.error.HTTPError as exc:
+        raise WebFetchError(
+            f"HTTP {exc.code} fetching {url!r}: {exc.reason}", status_code=exc.code
+        ) from exc
+    except Exception as exc:
+        raise WebFetchError(f"Failed to fetch {url!r}: {exc}") from exc
+
+    # Decode bytes
+    try:
+        charset = "utf-8"
+        if "charset=" in content_type:
+            charset = content_type.split("charset=")[-1].strip()
+        text = raw.decode(charset, errors="replace")
+    except Exception as exc:
+        raise WebFetchError(f"Could not decode response from {url!r}: {exc}") from exc
+
+    # Clean HTML if applicable
+    if "html" in content_type:
+        text = _clean_html(text)
+
+    return text[:max_chars]
+
+
+def _clean_html(html: str) -> str:
+    """Strip HTML markup, decode entities, and normalise whitespace."""
+    html = _DROP_TAGS_RE.sub("", html)
+    html = _TAG_RE.sub("\n", html)
+    html = _html_mod.unescape(html)
+    # Collapse whitespace
+    lines = [line.strip() for line in html.splitlines()]
+    text = "\n".join(line for line in lines if line)
+    text = _MULTI_BLANK_RE.sub("\n\n", text)
+    return text.strip()
 
 
 class WebSearchToolAdapter:
@@ -162,8 +270,6 @@ class WebSearchToolAdapter:
             close_a = html.find("</a>", tag_end)
             title = html[tag_end + 1:close_a].strip() if close_a > tag_end else ""
             # Strip HTML tags from title
-            import re
-
             title = re.sub(r"<[^>]+>", "", title)
 
             # Extract snippet

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from openbad.proprioception.registry import ToolRegistry, ToolRole
 from openbad.toolbelt.web_search import (
+    WebFetchError,
     WebSearchConfig,
     WebSearchToolAdapter,
     _RateLimiter,
+    web_fetch,
 )
 
 # ── Helpers ────────────────────────────────────────────────────────── #
@@ -144,3 +150,74 @@ class TestRegistration:
         reg.register("web-search", role=ToolRole.WEB_SEARCH)
         reg.equip(ToolRole.WEB_SEARCH, "web-search")
         assert reg.get_belt()[ToolRole.WEB_SEARCH].name == "web-search"
+
+
+# ---------------------------------------------------------------------------
+# Phase 10: web_fetch (#412)
+# ---------------------------------------------------------------------------
+
+
+class TestWebFetch:
+    def _fake_resp(self, body: bytes, content_type: str = "text/html; charset=utf-8"):
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.headers.get_content_type.return_value = content_type
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_plain_text_returned(self) -> None:
+        body = b"Hello world"
+        with patch("urllib.request.urlopen", return_value=self._fake_resp(body, "text/plain")):
+            result = web_fetch("https://example.com/page")
+        assert "Hello world" in result
+
+    def test_html_tags_stripped(self) -> None:
+        body = b"<html><body><p>Hello <b>world</b></p></body></html>"
+        with patch("urllib.request.urlopen", return_value=self._fake_resp(body)):
+            result = web_fetch("https://example.com/page")
+        assert "Hello" in result
+        assert "<b>" not in result
+
+    def test_script_content_removed(self) -> None:
+        body = b"<html><head><script>alert('evil')</script></head><body>ok</body></html>"
+        with patch("urllib.request.urlopen", return_value=self._fake_resp(body)):
+            result = web_fetch("https://example.com/page")
+        assert "alert" not in result
+        assert "ok" in result
+
+    def test_max_chars_truncated(self) -> None:
+        body = b"<html><body>" + b"A" * 10000 + b"</body></html>"
+        with patch("urllib.request.urlopen", return_value=self._fake_resp(body)):
+            result = web_fetch("https://example.com/page", max_chars=100)
+        assert len(result) <= 100
+
+    def test_http_error_raises_web_fetch_error(self) -> None:
+        err = urllib.error.HTTPError(
+            url="https://example.com/404",
+            code=404,
+            msg="Not Found",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,  # type: ignore[arg-type]
+        )
+        with (
+            patch("urllib.request.urlopen", side_effect=err),
+            pytest.raises(WebFetchError) as exc_info,
+        ):
+            web_fetch("https://example.com/404")
+        assert exc_info.value.status_code == 404
+
+    def test_network_error_raises_web_fetch_error(self) -> None:
+        with (
+            patch("urllib.request.urlopen", side_effect=OSError("timeout")),
+            pytest.raises(WebFetchError),
+        ):
+            web_fetch("https://example.com/page")
+
+    def test_non_http_scheme_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Only http/https"):
+            web_fetch("ftp://example.com/file")
+
+    def test_file_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            web_fetch("file:///etc/passwd")


### PR DESCRIPTION
Closes #412

## Summary
- Added `web_fetch(url, *, timeout, max_chars)` to `web_search.py`
- Added `WebFetchError` exception with `status_code` attribute
- Strips script/style/head/nav/aside tags; removes all HTML markup; decodes entities
- Rejects non-http/https schemes (blocks file://, ftp://, etc.)
- Hard cap: 2 MB read from wire, configurable max_chars for returned string

## How to test
`pytest tests/test_web_search.py -q`