### PR TITLE
#414: Add UserSession presence tracking to WUI bridge

### DIFF
--- a/src/openbad/nervous_system/client.py
+++ b/src/openbad/nervous_system/client.py
@@ -152,6 +152,25 @@ class NervousSystemClient:
         if info.rc != mqtt.MQTT_ERR_SUCCESS:
             logger.error("Publish failed on %s: rc=%d", topic, info.rc)
 
+    def publish_bytes(
+        self,
+        topic: str,
+        payload: bytes,
+        qos: int | None = None,
+        retain: bool | None = None,
+    ) -> None:
+        """Publish raw *payload* bytes to *topic* without protobuf serialization.
+
+        Useful for lightweight status messages (e.g. JSON-encoded presence events).
+        """
+        if qos is None:
+            qos = qos_for(topic)
+        if retain is None:
+            retain = should_retain(topic)
+        info = self._mqtt.publish(topic, payload, qos=qos, retain=retain)
+        if info.rc != mqtt.MQTT_ERR_SUCCESS:
+            logger.error("publish_bytes failed on %s: rc=%d", topic, info.rc)
+
     def subscribe(
         self,
         topic: str,

--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -159,6 +159,11 @@ RESEARCH_DEEP_DIVE = "agent/research/deep_dive"
 RESEARCH_ALL = "agent/research/#"
 
 # ---------------------------------------------------------------------------
+# WUI (web user interface events)
+# ---------------------------------------------------------------------------
+WUI_PRESENCE = "system/wui/presence"
+
+# ---------------------------------------------------------------------------
 # Scheduler (Phase 9)
 # ---------------------------------------------------------------------------
 SCHEDULER_TICK = "agent/scheduler/tick"

--- a/src/openbad/wui/bridge.py
+++ b/src/openbad/wui/bridge.py
@@ -47,6 +47,32 @@ from openbad.nervous_system.schemas.telemetry_pb2 import (
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# User presence tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UserSession:
+    """Singleton that tracks whether a human user is actively connected.
+
+    ``is_active`` is ``True`` whenever at least one WebSocket or SSE client
+    is connected.  ``last_seen`` records the most recent connect/disconnect
+    time so callers can reason about staleness.
+    """
+
+    is_active: bool = False
+    last_seen: datetime | None = None
+
+    def mark_connected(self) -> None:
+        self.is_active = True
+        self.last_seen = datetime.now(tz=UTC)
+
+    def mark_disconnected(self) -> None:
+        self.is_active = False
+        self.last_seen = datetime.now(tz=UTC)
+
+
 TOPIC_PROTO_MAP: dict[str, type] = {
     topics.ENDOCRINE_ALL: EndocrineEvent,
     topics.REFLEX_STATE: ReflexState,
@@ -83,6 +109,7 @@ class MqttWebSocketBridge:
         init=False,
         repr=False,
     )
+    _session: UserSession = field(default_factory=UserSession, init=False, repr=False)
 
     def create_app(self) -> web.Application:
         app = web.Application()
@@ -160,6 +187,7 @@ class MqttWebSocketBridge:
         await response.prepare(request)
         lock = asyncio.Lock()
         self._event_clients[response] = lock
+        self._update_presence(connected=True)
         logger.info("Event stream client connected")
 
         await self._send_sse(
@@ -184,6 +212,7 @@ class MqttWebSocketBridge:
             logger.exception("Event stream handler failed")
         finally:
             self._event_clients.pop(response, None)
+            self._update_presence(connected=False)
             logger.info("Event stream client disconnected")
             with contextlib.suppress(Exception):
                 await response.write_eof()
@@ -194,6 +223,7 @@ class MqttWebSocketBridge:
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         self._clients.add(ws)
+        self._update_presence(connected=True)
         logger.info("WebSocket client connected")
 
         await ws.send_json(
@@ -216,9 +246,46 @@ class MqttWebSocketBridge:
             logger.exception("WebSocket handler failed")
         finally:
             self._clients.discard(ws)
+            self._update_presence(connected=False)
             logger.info("WebSocket client disconnected (close_code=%s)", ws.close_code)
 
         return ws
+
+    @property
+    def user_session(self) -> UserSession:
+        """Return the live user-presence session object."""
+        return self._session
+
+    def _update_presence(self, *, connected: bool) -> None:
+        """Update :attr:`_session` based on current client count and publish.
+
+        A user is considered *present* when at least one WS or SSE client is
+        connected.  The method publishes to :data:`topics.WUI_PRESENCE` when
+        the active state changes.
+        """
+        total = len(self._clients) + len(self._event_clients)
+        was_active = self._session.is_active
+
+        if connected:
+            self._session.mark_connected()
+        else:
+            # Client has already been removed from the set before this call in
+            # the WS handler, but SSE handler removes it just before calling
+            # here too, so total already reflects the post-disconnect state.
+            if total > 0:
+                self._session.mark_connected()
+            else:
+                self._session.mark_disconnected()
+
+        if self._session.is_active != was_active and self._mqtt is not None:
+            payload = json.dumps({
+                "active": self._session.is_active,
+                "ts": self._session.last_seen.isoformat() if self._session.last_seen else None,
+            }).encode()
+            try:
+                self._mqtt.publish_bytes(topics.WUI_PRESENCE, payload)
+            except Exception:
+                logger.debug("Could not publish WUI_PRESENCE, MQTT not ready")
 
     def _on_mqtt(self, topic: str, payload: Any) -> None:
         """MQTT callback: schedule async fanout onto the aiohttp event loop."""

--- a/tests/test_wui_bridge.py
+++ b/tests/test_wui_bridge.py
@@ -11,6 +11,7 @@ import pytest
 from openbad.cognitive.config import ProviderConfig
 from openbad.wui.bridge import (
     MqttWebSocketBridge,
+    UserSession,
     _count_operational_providers_from_config,
     _payload_to_jsonable,
 )
@@ -244,3 +245,89 @@ class TestMqttCallback:
             bridge._on_mqtt("agent/test", {"k": "v"})
 
         submit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Phase 10: UserSession presence tracking (#414)
+# ---------------------------------------------------------------------------
+
+
+class TestUserSession:
+    def test_initial_state_inactive(self) -> None:
+        session = UserSession()
+        assert not session.is_active
+        assert session.last_seen is None
+
+    def test_mark_connected(self) -> None:
+        session = UserSession()
+        session.mark_connected()
+        assert session.is_active
+        assert session.last_seen is not None
+
+    def test_mark_disconnected(self) -> None:
+        session = UserSession()
+        session.mark_connected()
+        session.mark_disconnected()
+        assert not session.is_active
+        assert session.last_seen is not None
+
+    def test_mark_disconnected_updates_last_seen(self) -> None:
+        session = UserSession()
+        session.mark_connected()
+        ts1 = session.last_seen
+        session.mark_disconnected()
+        assert session.last_seen >= ts1  # type: ignore[operator]
+
+
+class TestBridgePresence:
+    def test_user_session_initially_inactive(self) -> None:
+        bridge = MqttWebSocketBridge()
+        assert not bridge.user_session.is_active
+
+    def test_update_presence_single_client_connect(self) -> None:
+        bridge = MqttWebSocketBridge()
+        # Simulate adding one WS client, then calling update
+        ws = MagicMock()
+        bridge._clients.add(ws)
+        bridge._update_presence(connected=True)
+        assert bridge.user_session.is_active
+
+    def test_update_presence_last_client_disconnect(self) -> None:
+        bridge = MqttWebSocketBridge()
+        ws = MagicMock()
+        bridge._clients.add(ws)
+        bridge._update_presence(connected=True)
+        # Now simulate disconnect: remove from set, then call update
+        bridge._clients.discard(ws)
+        bridge._update_presence(connected=False)
+        assert not bridge.user_session.is_active
+
+    def test_update_presence_two_clients_one_leaves(self) -> None:
+        bridge = MqttWebSocketBridge()
+        ws1, ws2 = MagicMock(), MagicMock()
+        bridge._clients.add(ws1)
+        bridge._clients.add(ws2)
+        bridge._update_presence(connected=True)
+        bridge._clients.discard(ws1)
+        bridge._update_presence(connected=False)
+        # second still connected
+        assert bridge.user_session.is_active
+
+    def test_update_presence_publishes_on_change(self) -> None:
+        bridge = MqttWebSocketBridge()
+        mqtt = MagicMock()
+        bridge._mqtt = mqtt
+        ws = MagicMock()
+        bridge._clients.add(ws)
+        bridge._update_presence(connected=True)
+        mqtt.publish_bytes.assert_called_once()
+        args = mqtt.publish_bytes.call_args
+        assert "system/wui/presence" in args[0][0]
+
+    def test_update_presence_no_publish_without_change(self) -> None:
+        bridge = MqttWebSocketBridge()
+        mqtt = MagicMock()
+        bridge._mqtt = mqtt
+        # is_active already False, calling disconnect again should not trigger
+        bridge._update_presence(connected=False)
+        mqtt.publish_bytes.assert_not_called()


### PR DESCRIPTION
Closes #414

## Summary
- Added `WUI_PRESENCE = "system/wui/presence"` to `topics.py`
- Added `UserSession` dataclass with `is_active`, `last_seen`, `mark_connected()`, `mark_disconnected()`
- Added `_session: UserSession` field and `user_session` property to `MqttWebSocketBridge`
- Added `_update_presence(connected)` that updates session and publishes to `WUI_PRESENCE` on state changes
- Wired into `_ws_handler` and `_sse_handler` connect/disconnect paths
- Added `publish_bytes()` to `NervousSystemClient` for raw-bytes MQTT publish

## How to test
`pytest tests/test_wui_bridge.py -q`