### PR TITLE
#420: Wire SemanticMemory into CognitiveEventLoop for context enrichment

### DIFF
--- a/src/openbad/cognitive/event_loop.py
+++ b/src/openbad/cognitive/event_loop.py
@@ -7,12 +7,15 @@ import json
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openbad.cognitive.config import CognitiveSystem
 from openbad.cognitive.context_manager import ContextWindowManager
 from openbad.cognitive.model_router import ModelRouter, Priority
 from openbad.cognitive.reasoning.base import ReasoningStrategy
+
+if TYPE_CHECKING:
+    from openbad.memory.semantic import SemanticMemory
 
 log = logging.getLogger(__name__)
 
@@ -87,12 +90,16 @@ class CognitiveEventLoop:
         strategies: dict[Priority | CognitiveSystem, ReasoningStrategy],
         publish_fn: Any = None,
         validate_fn: Any = None,
+        semantic_memory: SemanticMemory | None = None,
+        memory_top_k: int = 3,
     ) -> None:
         self._router = model_router
         self._ctx = context_manager
         self._strategies = strategies
         self._publish = publish_fn or _noop_publish
         self._validate = validate_fn
+        self._semantic_memory = semantic_memory
+        self._memory_top_k = memory_top_k
         self._running = False
         self._tasks: set[asyncio.Task[None]] = set()
 
@@ -193,11 +200,16 @@ class CognitiveEventLoop:
             request.context, target_tokens=budget.context_tokens,
         )
 
+        # 2a. Prepend semantic memory recall (honours ContextWindowManager budget)
+        enriched_context = self._enrich_with_memory(
+            request.prompt, compressed.text, budget.context_tokens
+        )
+
         # 3. Select and execute reasoning strategy
         strategy = self._select_strategy(request)
         if strategy:
             result = await strategy.reason(
-                request.prompt, compressed.text, self._router,
+                request.prompt, enriched_context, self._router,
             )
             answer = result.final_answer
             tokens = result.total_tokens
@@ -205,7 +217,7 @@ class CognitiveEventLoop:
         else:
             # Direct single-pass call
             completion = await adapter.complete(
-                f"{compressed.text}\n\n{request.prompt}", model=model_id,
+                f"{enriched_context}\n\n{request.prompt}", model=model_id,
             )
             answer = completion.content
             tokens = completion.tokens_used
@@ -226,6 +238,44 @@ class CognitiveEventLoop:
             latency_ms=latency,
             strategy=strategy_name,
         )
+
+    def _enrich_with_memory(
+        self, prompt: str, context: str, budget_tokens: int
+    ) -> str:
+        """Prepend relevant semantic memory facts to *context*.
+
+        Queries :attr:`_semantic_memory` with *prompt* and prepends the top
+        results as a ``## Relevant Memory`` section, truncated so the total
+        remains within the token budget (rough estimate: 1 token ≈ 4 chars).
+        """
+        if self._semantic_memory is None:
+            return context
+
+        try:
+            hits = self._semantic_memory.search(prompt, top_k=self._memory_top_k)
+        except Exception:
+            log.debug("Semantic memory search failed; proceeding without recall")
+            return context
+
+        if not hits:
+            return context
+
+        # Build memory snippet
+        facts = "\n".join(
+            f"- {entry.value}" for entry, _score in hits if entry.value
+        )
+        if not facts:
+            return context
+
+        memory_block = f"## Relevant Memory\n{facts}\n\n"
+
+        # Rough budget check: ensure prepended block + context fits
+        approx_char_budget = budget_tokens * 4
+        if len(memory_block) + len(context) > approx_char_budget:
+            remaining = max(0, approx_char_budget - len(context))
+            memory_block = memory_block[:remaining]
+
+        return memory_block + context
 
     def _select_strategy(
         self,

--- a/tests/test_cognitive_event_loop.py
+++ b/tests/test_cognitive_event_loop.py
@@ -6,6 +6,8 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from openbad.cognitive.config import CognitiveSystem
 from openbad.cognitive.context_manager import (
     CompressedContext,
@@ -30,6 +32,7 @@ from openbad.cognitive.orchestrator import CognitiveOrchestrator
 from openbad.cognitive.providers.base import CompletionResult, HealthStatus, ProviderAdapter
 from openbad.cognitive.providers.registry import ProviderRegistry
 from openbad.cognitive.reasoning.base import ReasoningResult, ReasoningStrategy
+from openbad.memory.base import MemoryEntry, MemoryTier
 
 # ------------------------------------------------------------------ #
 # Helpers
@@ -437,3 +440,85 @@ class TestParseSystem:
 
     def test_enum_passthrough(self) -> None:
         assert _parse_system(CognitiveSystem.SLEEP) is CognitiveSystem.SLEEP
+
+
+# ---------------------------------------------------------------------------
+# Phase 10: semantic memory enrichment (#420)
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticMemoryEnrichment:
+    def _loop_with_memory(self, memory):
+        return CognitiveEventLoop(
+            model_router=_mock_router(),
+            context_manager=_mock_ctx(),
+            strategies={},
+            semantic_memory=memory,
+        )
+
+    @pytest.mark.asyncio
+    async def test_memory_results_prepended_to_context(self) -> None:
+        memory = MagicMock()
+        entry = MemoryEntry(key="k1", value="Important recalled fact", tier=MemoryTier.SEMANTIC)
+        memory.search.return_value = [(entry, 0.9)]
+
+        loop = self._loop_with_memory(memory)
+        req = CognitiveRequest(request_id="r1", prompt="What is X?", context="base ctx")
+        resp = await loop.handle_request(req)
+
+        assert resp.answer == "answer-42"
+        memory.search.assert_called_once_with("What is X?", top_k=3)
+
+    @pytest.mark.asyncio
+    async def test_no_memory_no_enrichment(self) -> None:
+        """Without semantic_memory, context passes through unchanged."""
+        loop = CognitiveEventLoop(
+            model_router=_mock_router(),
+            context_manager=_mock_ctx(),
+            strategies={},
+        )
+        req = CognitiveRequest(request_id="r2", prompt="foo", context="bar")
+        resp = await loop.handle_request(req)
+        assert resp.answer == "answer-42"
+
+    @pytest.mark.asyncio
+    async def test_memory_exception_does_not_break_loop(self) -> None:
+        memory = MagicMock()
+        memory.search.side_effect = RuntimeError("db error")
+
+        loop = self._loop_with_memory(memory)
+        req = CognitiveRequest(request_id="r3", prompt="hi", context="ctx")
+        resp = await loop.handle_request(req)
+        assert resp.answer == "answer-42"
+
+    @pytest.mark.asyncio
+    async def test_empty_memory_results_no_block(self) -> None:
+        memory = MagicMock()
+        memory.search.return_value = []
+
+        loop = self._loop_with_memory(memory)
+        req = CognitiveRequest(request_id="r4", prompt="hi", context="ctx")
+        resp = await loop.handle_request(req)
+        assert resp.answer == "answer-42"
+
+    def test_enrich_with_memory_prepends_header(self) -> None:
+        memory = MagicMock()
+        entry = MemoryEntry(key="k", value="fact one", tier=MemoryTier.SEMANTIC)
+        memory.search.return_value = [(entry, 0.8)]
+
+        loop = self._loop_with_memory(memory)
+        result = loop._enrich_with_memory("my query", "base", budget_tokens=1000)
+        assert "## Relevant Memory" in result
+        assert "fact one" in result
+        assert result.endswith("base")
+
+    def test_enrich_respects_budget(self) -> None:
+        memory = MagicMock()
+        entry = MemoryEntry(key="k", value="x" * 200, tier=MemoryTier.SEMANTIC)
+        memory.search.return_value = [(entry, 0.8)]
+
+        loop = self._loop_with_memory(memory)
+        result = loop._enrich_with_memory("q", "ctx", budget_tokens=1)
+        # With very tight budget, the memory block should be truncated
+        # Total length must not substantially exceed 4 chars (budget * 4)
+        assert len(result) <= 4 + len("ctx")


### PR DESCRIPTION
Closes #420

## Summary
- Added `semantic_memory: SemanticMemory | None` and `memory_top_k: int = 3` parameters to `CognitiveEventLoop.__init__()`
- Added `_enrich_with_memory(prompt, context, budget_tokens)` method that prepends a `## Relevant Memory` block from semantic search results, with token-budget enforcement
- Updated `_process()` to call enrichment between context compression and strategy/adapter steps
- Exception-tolerant: search failures log at DEBUG and fall through silently

## How to test
```
pytest tests/test_cognitive_event_loop.py -q
```
All 26 tests pass.