### PR TITLE
#408: Add FileOperationRule to immune system for FS write gating

### DIFF
--- a/src/openbad/immune_system/rules_engine.py
+++ b/src/openbad/immune_system/rules_engine.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 import re
 import time
 from dataclasses import dataclass, field
@@ -12,6 +14,8 @@ import yaml
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -233,3 +237,93 @@ class RulesEngine:
                 )
         elapsed = (time.monotonic() - t0) * 1000
         return ScanReport(matches=matches, scan_ms=elapsed)
+
+
+# ---------------------------------------------------------------------------
+# File operation immune gate
+# ---------------------------------------------------------------------------
+
+# Canonical restricted path prefixes.  Checked after realpath resolution.
+_RESTRICTED_PREFIXES: tuple[str, ...] = (
+    "/etc/",
+    "/usr/bin/",
+    "/usr/sbin/",
+    "/sbin/",
+    "/bin/",
+    "/proc/",
+    "/sys/",
+    "/boot/",
+    "/dev/",
+)
+
+
+def _restricted_ssh_path(resolved: str) -> bool:
+    """Return True if *resolved* is inside any user's .ssh directory."""
+    parts = Path(resolved).parts
+    return ".ssh" in parts
+
+
+def is_restricted_path(path: str) -> bool:
+    """Return True if *path* (after realpath resolution) is a restricted location."""
+    resolved = os.path.realpath(os.path.abspath(path))
+    for prefix in _RESTRICTED_PREFIXES:
+        if resolved.startswith(prefix) or resolved == prefix.rstrip("/"):
+            return True
+    return bool(_restricted_ssh_path(resolved))
+
+
+class FileOperationRule:
+    """Immune rule that blocks file writes targeting restricted system paths.
+
+    Usage::
+
+        rule = FileOperationRule(nervous_system_client)
+        rule.check_write("/etc/passwd")   # raises PermissionError + publishes alert
+        rule.check_write("/tmp/safe.txt") # passes silently
+    """
+
+    def __init__(self, nervous_system: object | None = None) -> None:
+        self._ns = nervous_system
+
+    def check_write(self, path: str) -> None:
+        """Raise :exc:`PermissionError` and announce an immune alert if *path* is restricted.
+
+        Parameters
+        ----------
+        path:
+            Destination path to evaluate.  May be relative.
+
+        Raises
+        ------
+        PermissionError
+            When *path* resolves to a restricted location.
+        """
+        if not is_restricted_path(path):
+            return
+
+        resolved = os.path.realpath(os.path.abspath(path))
+        log.warning("FileOperationRule: blocked write to restricted path %r", resolved)
+        self._publish_alert(resolved)
+        raise PermissionError(
+            f"FileOperationRule: write to restricted path {resolved!r} is not allowed."
+        )
+
+    def _publish_alert(self, resolved_path: str) -> None:
+        """Publish an IMMUNE_ALERT to the nervous system if one is attached."""
+        if self._ns is None:
+            return
+        try:
+            import json as _json
+
+            from openbad.nervous_system.topics import IMMUNE_ALERT
+
+            payload = _json.dumps(
+                {
+                    "rule": "file_operation_rule",
+                    "severity": "high",
+                    "blocked_path": resolved_path,
+                }
+            )
+            self._ns.publish(IMMUNE_ALERT, payload)
+        except Exception:
+            log.debug("FileOperationRule: could not publish immune alert", exc_info=True)

--- a/src/openbad/toolbelt/fs_tool.py
+++ b/src/openbad/toolbelt/fs_tool.py
@@ -24,6 +24,8 @@ import tempfile
 import uuid
 from pathlib import Path
 
+from openbad.immune_system.rules_engine import FileOperationRule
+
 # ---------------------------------------------------------------------------
 # Allowed roots
 # ---------------------------------------------------------------------------
@@ -34,6 +36,10 @@ ALLOWED_ROOTS: list[str] = [
     tempfile.gettempdir(),
     str(Path.cwd()),
 ]
+
+# Module-level rule instance.  Replace with a wired instance (passing a
+# NervousSystemClient) to enable IMMUNE_ALERT publishing.
+_FILE_OP_RULE: FileOperationRule = FileOperationRule()
 
 
 def _is_safe_path(resolved: str) -> bool:
@@ -119,6 +125,8 @@ def write_file(path: str, content: str, *, encoding: str = "utf-8") -> None:
         If the parent directory does not exist.
     """
     resolved = _validate(path)
+    # Immune gate: block writes to restricted system paths before any I/O.
+    _FILE_OP_RULE.check_write(resolved)
     parent = Path(resolved).parent
     if not parent.exists():
         raise FileNotFoundError(f"Parent directory does not exist: {parent}")

--- a/tests/test_fs_tool.py
+++ b/tests/test_fs_tool.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 import openbad.toolbelt.fs_tool as fs_tool
+from openbad.immune_system.rules_engine import FileOperationRule, is_restricted_path
 from openbad.toolbelt.fs_tool import read_file, write_file
 
 # ---------------------------------------------------------------------------
@@ -109,3 +111,75 @@ class TestSymlinkEscape:
         link = tmp_path / "link.txt"
         link.symlink_to(target)
         assert read_file(str(link)) == "real content"
+
+
+# ---------------------------------------------------------------------------
+# Phase 10: FileOperationRule immune gate (#408)
+# ---------------------------------------------------------------------------
+
+
+class TestIsRestrictedPath:
+    def test_etc_passwd_is_restricted(self) -> None:
+        assert is_restricted_path("/etc/passwd") is True
+
+    def test_ssh_authorized_keys_is_restricted(self) -> None:
+        assert is_restricted_path("/home/user/.ssh/authorized_keys") is True
+
+    def test_proc_is_restricted(self) -> None:
+        assert is_restricted_path("/proc/1/maps") is True
+
+    def test_usr_bin_is_restricted(self) -> None:
+        assert is_restricted_path("/usr/bin/python3") is True
+
+    def test_tmp_dir_not_restricted(self, tmp_path: Path) -> None:
+        assert is_restricted_path(str(tmp_path / "safe.txt")) is False
+
+
+class TestFileOperationRule:
+    def test_restricted_write_raises(self) -> None:
+        rule = FileOperationRule()
+        with pytest.raises(PermissionError, match="restricted path"):
+            rule.check_write("/etc/passwd")
+
+    def test_safe_write_passes(self, tmp_path: Path) -> None:
+        rule = FileOperationRule()
+        # Should not raise for a safe temp path
+        rule.check_write(str(tmp_path / "safe.txt"))
+
+    def test_restricted_write_publishes_alert(self) -> None:
+        ns = MagicMock()
+        rule = FileOperationRule(ns)
+        with pytest.raises(PermissionError):
+            rule.check_write("/etc/hosts")
+        ns.publish.assert_called_once()
+        call_args = ns.publish.call_args[0]
+        assert "agent/immune/alert" in call_args[0]
+
+    def test_no_ns_no_crash_on_restricted(self) -> None:
+        rule = FileOperationRule(nervous_system=None)
+        with pytest.raises(PermissionError):
+            rule.check_write("/sys/kernel/notes")
+
+
+class TestWriteFileImmuneGate:
+    def test_write_to_etc_blocked_via_fs_tool(self, tmp_path: Path) -> None:
+        """write_file should be blocked when target resolves to a restricted path."""
+        # We override ALLOWED_ROOTS to include /etc so the path-safety check passes,
+        # but the immune gate should still block it.
+        with (
+            patch.object(fs_tool, "ALLOWED_ROOTS", ["/etc", str(tmp_path)]),
+            patch.object(
+                fs_tool._FILE_OP_RULE,
+                "check_write",
+                side_effect=PermissionError("blocked"),
+            ) as mock_check,
+        ):
+            with pytest.raises(PermissionError):
+                write_file("/etc/passwd", "hacked")
+            mock_check.assert_called_once()
+
+    def test_safe_write_not_blocked(self, tmp_path: Path) -> None:
+        """write_file succeeds for a safe path without triggering the immune gate."""
+        dest = tmp_path / "output.txt"
+        write_file(str(dest), "hello")
+        assert dest.read_text() == "hello"


### PR DESCRIPTION
Closes #408

## Summary
- Added `FileOperationRule` class to `src/openbad/immune_system/rules_engine.py`
- Added `is_restricted_path()` helper covering `/etc/`, `~/.ssh/`, system binaries, `/proc/`, `/sys/`, `/boot/`, `/dev/`
- Added module-level `_FILE_OP_RULE` instance to `fs_tool.py`; wired into `write_file()` before any I/O
- On block: logs warning, publishes `IMMUNE_ALERT` to nervous system, raises `PermissionError`
- Non-restricted paths pass through unchanged

## How to test
```
pytest tests/test_fs_tool.py -q
```
24 tests pass.