### PR TITLE
#409: Add endocrine throttling to FS tool via disk interoception

### DIFF
--- a/src/openbad/toolbelt/fs_tool.py
+++ b/src/openbad/toolbelt/fs_tool.py
@@ -19,12 +19,20 @@ Security guarantees
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from openbad.immune_system.rules_engine import FileOperationRule
+
+if TYPE_CHECKING:
+    from openbad.endocrine.controller import EndocrineController
+    from openbad.interoception.disk_network import DiskSnapshot
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Allowed roots
@@ -40,6 +48,66 @@ ALLOWED_ROOTS: list[str] = [
 # Module-level rule instance.  Replace with a wired instance (passing a
 # NervousSystemClient) to enable IMMUNE_ALERT publishing.
 _FILE_OP_RULE: FileOperationRule = FileOperationRule()
+
+# ---------------------------------------------------------------------------
+# Endocrine / disk throttling
+# ---------------------------------------------------------------------------
+
+#: Operations larger than this many bytes trigger the disk-saturation check.
+LARGE_OP_THRESHOLD_BYTES: int = 1024 * 1024  # 1 MiB
+
+#: Disk I/O latency (ms) above which the disk is considered saturated.
+DISK_LATENCY_SATURATION_MS: float = 200.0
+
+#: Free-bytes floor below which the disk is considered saturated.
+DISK_FREE_BYTES_MIN: int = 50 * 1024 * 1024  # 50 MiB
+
+#: Cortisol level (0–1) at or above which "high cortisol" is asserted.
+CORTISOL_HIGH_THRESHOLD: float = 0.5
+
+
+def should_defer(
+    byte_count: int,
+    disk_snapshot: DiskSnapshot | None = None,
+    endocrine: EndocrineController | None = None,
+) -> bool:
+    """Return *True* if the operation should be deferred due to resource pressure.
+
+    Parameters
+    ----------
+    byte_count:
+        Approximate size of the pending I/O operation in bytes.
+    disk_snapshot:
+        Current disk metrics (optional).  If *None*, no disk check is performed.
+    endocrine:
+        Endocrine controller to read cortisol level (optional).
+
+    Returns
+    -------
+    bool
+        ``True``  — defer the operation; the caller should raise / return DEFERRED.
+        ``False`` — proceed normally.
+    """
+    if byte_count < LARGE_OP_THRESHOLD_BYTES:
+        return False
+    if disk_snapshot is None or endocrine is None:
+        return False
+    saturated = (
+        disk_snapshot.io_latency_ms >= DISK_LATENCY_SATURATION_MS
+        or disk_snapshot.free_bytes < DISK_FREE_BYTES_MIN
+    )
+    if not saturated:
+        return False
+    high_cortisol = endocrine.level("cortisol") >= CORTISOL_HIGH_THRESHOLD
+    return high_cortisol
+
+
+class ResourceDeferredError(OSError):
+    """Raised when an FS operation is deferred due to disk saturation + high cortisol.
+
+    Callers should set the associated task node to ``NodeStatus.DEFERRED_RESOURCES``
+    and reschedule the operation.
+    """
 
 
 def _is_safe_path(resolved: str) -> bool:
@@ -74,7 +142,13 @@ def _validate(path: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def read_file(path: str, *, encoding: str = "utf-8") -> str:
+def read_file(
+    path: str,
+    *,
+    encoding: str = "utf-8",
+    disk_snapshot: DiskSnapshot | None = None,
+    endocrine: EndocrineController | None = None,
+) -> str:
     """Read and return the contents of *path* as a string.
 
     Parameters
@@ -83,6 +157,10 @@ def read_file(path: str, *, encoding: str = "utf-8") -> str:
         The file path to read.  May be relative.
     encoding:
         Text encoding (default ``utf-8``).
+    disk_snapshot:
+        Optional current disk snapshot for endocrine throttling.
+    endocrine:
+        Optional endocrine controller for cortisol check.
 
     Returns
     -------
@@ -97,12 +175,27 @@ def read_file(path: str, *, encoding: str = "utf-8") -> str:
         If the file does not exist.
     IsADirectoryError
         If the path points to a directory.
+    ResourceDeferredError
+        If disk is saturated and cortisol is high; the operation should be retried later.
     """
     resolved = _validate(path)
+    byte_estimate = Path(resolved).stat().st_size if Path(resolved).exists() else 0
+    if should_defer(byte_estimate, disk_snapshot=disk_snapshot, endocrine=endocrine):
+        log.info("fs_tool.read_file: deferring large read due to resource saturation")
+        raise ResourceDeferredError(
+            f"read_file deferred: disk saturated (path={resolved!r})"
+        )
     return Path(resolved).read_text(encoding=encoding)
 
 
-def write_file(path: str, content: str, *, encoding: str = "utf-8") -> None:
+def write_file(
+    path: str,
+    content: str,
+    *,
+    encoding: str = "utf-8",
+    disk_snapshot: DiskSnapshot | None = None,
+    endocrine: EndocrineController | None = None,
+) -> None:
     """Write *content* to *path* atomically.
 
     The write is performed to a sibling temporary file and then renamed into
@@ -116,14 +209,26 @@ def write_file(path: str, content: str, *, encoding: str = "utf-8") -> None:
         Text to write.
     encoding:
         Text encoding (default ``utf-8``).
+    disk_snapshot:
+        Optional current disk snapshot for endocrine throttling.
+    endocrine:
+        Optional endocrine controller for cortisol check.
 
     Raises
     ------
     PermissionError
-        If the path is outside allowed roots.
+        If the path is outside allowed roots or is a restricted system path.
     FileNotFoundError
         If the parent directory does not exist.
+    ResourceDeferredError
+        If disk is saturated and cortisol is high; the operation should be retried later.
     """
+    byte_count = len(content.encode(encoding))
+    if should_defer(byte_count, disk_snapshot=disk_snapshot, endocrine=endocrine):
+        log.info("fs_tool.write_file: deferring large write due to resource saturation")
+        raise ResourceDeferredError(
+            f"write_file deferred: disk saturated (path={path!r})"
+        )
     resolved = _validate(path)
     # Immune gate: block writes to restricted system paths before any I/O.
     _FILE_OP_RULE.check_write(resolved)

--- a/tests/test_fs_tool.py
+++ b/tests/test_fs_tool.py
@@ -9,7 +9,16 @@ import pytest
 
 import openbad.toolbelt.fs_tool as fs_tool
 from openbad.immune_system.rules_engine import FileOperationRule, is_restricted_path
-from openbad.toolbelt.fs_tool import read_file, write_file
+from openbad.toolbelt.fs_tool import (
+    CORTISOL_HIGH_THRESHOLD,
+    DISK_FREE_BYTES_MIN,
+    DISK_LATENCY_SATURATION_MS,
+    LARGE_OP_THRESHOLD_BYTES,
+    ResourceDeferredError,
+    read_file,
+    should_defer,
+    write_file,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -183,3 +192,88 @@ class TestWriteFileImmuneGate:
         dest = tmp_path / "output.txt"
         write_file(str(dest), "hello")
         assert dest.read_text() == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Phase 10: endocrine throttling (#409)
+# ---------------------------------------------------------------------------
+
+
+def _disk(latency_ms: float = 0.0, free_bytes: int = 500 * 1024 * 1024) -> MagicMock:
+    snap = MagicMock()
+    snap.io_latency_ms = latency_ms
+    snap.free_bytes = free_bytes
+    return snap
+
+
+def _endocrine(cortisol: float = 0.0) -> MagicMock:
+    ec = MagicMock()
+    ec.level.return_value = cortisol
+    return ec
+
+
+class TestShouldDefer:
+    def test_small_op_never_defers(self) -> None:
+        disk = _disk(latency_ms=9999.0, free_bytes=0)
+        ec = _endocrine(cortisol=1.0)
+        assert should_defer(100, disk_snapshot=disk, endocrine=ec) is False
+
+    def test_no_disk_snapshot_no_defer(self) -> None:
+        result = should_defer(
+            LARGE_OP_THRESHOLD_BYTES + 1, disk_snapshot=None, endocrine=_endocrine(1.0)
+        )
+        assert result is False
+
+    def test_no_endocrine_no_defer(self) -> None:
+        disk = _disk(latency_ms=DISK_LATENCY_SATURATION_MS + 1)
+        result = should_defer(
+            LARGE_OP_THRESHOLD_BYTES + 1, disk_snapshot=disk, endocrine=None
+        )
+        assert result is False
+
+    def test_healthy_disk_no_defer(self) -> None:
+        disk = _disk(latency_ms=10.0, free_bytes=DISK_FREE_BYTES_MIN + 1)
+        ec = _endocrine(cortisol=1.0)
+        result = should_defer(
+            LARGE_OP_THRESHOLD_BYTES + 1, disk_snapshot=disk, endocrine=ec
+        )
+        assert result is False
+
+    def test_saturated_disk_high_cortisol_defers(self) -> None:
+        disk = _disk(latency_ms=DISK_LATENCY_SATURATION_MS + 1)
+        ec = _endocrine(cortisol=CORTISOL_HIGH_THRESHOLD)
+        result = should_defer(
+            LARGE_OP_THRESHOLD_BYTES + 1, disk_snapshot=disk, endocrine=ec
+        )
+        assert result is True
+
+    def test_low_free_bytes_high_cortisol_defers(self) -> None:
+        disk = _disk(free_bytes=DISK_FREE_BYTES_MIN - 1)
+        ec = _endocrine(cortisol=CORTISOL_HIGH_THRESHOLD)
+        result = should_defer(
+            LARGE_OP_THRESHOLD_BYTES + 1, disk_snapshot=disk, endocrine=ec
+        )
+        assert result is True
+
+    def test_saturated_disk_low_cortisol_no_defer(self) -> None:
+        disk = _disk(latency_ms=DISK_LATENCY_SATURATION_MS + 1)
+        ec = _endocrine(cortisol=CORTISOL_HIGH_THRESHOLD - 0.01)
+        result = should_defer(LARGE_OP_THRESHOLD_BYTES + 1, disk_snapshot=disk, endocrine=ec)
+        assert result is False
+
+
+class TestWriteFileDeferral:
+    def test_large_saturated_write_defers(self, tmp_path: Path) -> None:
+        disk = _disk(latency_ms=DISK_LATENCY_SATURATION_MS + 1)
+        ec = _endocrine(cortisol=CORTISOL_HIGH_THRESHOLD)
+        big = "x" * (LARGE_OP_THRESHOLD_BYTES + 1)
+        with pytest.raises(ResourceDeferredError):
+            write_file(str(tmp_path / "big.txt"), big, disk_snapshot=disk, endocrine=ec)
+
+    def test_normal_write_passes(self, tmp_path: Path) -> None:
+        dest = tmp_path / "out.txt"
+        disk = _disk(latency_ms=DISK_LATENCY_SATURATION_MS + 1)
+        ec = _endocrine(cortisol=CORTISOL_HIGH_THRESHOLD)
+        # Small content should not trigger deferral regardless of disk state
+        write_file(str(dest), "small content", disk_snapshot=disk, endocrine=ec)
+        assert dest.read_text() == "small content"


### PR DESCRIPTION
Closes #409

## Summary
- Added `should_defer(byte_count, disk_snapshot, endocrine)` function to `fs_tool.py`
- Added `ResourceDeferredError(OSError)` — callers should set node to `NodeStatus.DEFERRED_RESOURCES`
- Added configurable thresholds: `LARGE_OP_THRESHOLD_BYTES` (1 MiB), `DISK_LATENCY_SATURATION_MS` (200 ms), `DISK_FREE_BYTES_MIN` (50 MiB), `CORTISOL_HIGH_THRESHOLD` (0.5)
- `read_file()` and `write_file()` accept optional `disk_snapshot` and `endocrine` kwargs; raise `ResourceDeferredError` when disk is saturated AND cortisol is high for large ops
- Small operations (<1 MiB) always proceed without an overhead check

## How to test
```
pytest tests/test_fs_tool.py -q
```
33 tests pass.