### PR TITLE
#411: Add quarantine gate for destructive CLI commands

### DIFF
--- a/src/openbad/immune_system/rules_engine.py
+++ b/src/openbad/immune_system/rules_engine.py
@@ -327,3 +327,89 @@ class FileOperationRule:
             self._ns.publish(IMMUNE_ALERT, payload)
         except Exception:
             log.debug("FileOperationRule: could not publish immune alert", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Destructive CLI command immune gate
+# ---------------------------------------------------------------------------
+
+# Patterns that, when matched against the full command string, indicate a
+# destructive operation that must never be executed.
+_DESTRUCTIVE_CLI_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\brm\s+(-\S*r\S*f|-\S*f\S*r|--force|--recursive)[^\n]*(/|~|\$HOME)", re.I),
+    re.compile(r"\brm\s+-rf\b", re.I),
+    re.compile(r"\bmkfs\b", re.I),
+    re.compile(r"\bdd\s+if=", re.I),
+    re.compile(r"\bchmod\s+(-R\s+)?777\s+/", re.I),
+    re.compile(r":\(\)\s*\{.*:\s*\|.*:\s*&.*\}", re.I),  # fork bomb
+    re.compile(r">\s*/dev/sd", re.I),  # disk overwrite
+    re.compile(r"\bshred\b.*(/dev/|/sys/)", re.I),
+]
+
+
+def is_destructive_command(command: str, args: list[str] | None = None) -> bool:
+    """Return True if the command + args string matches a destructive pattern."""
+    full = " ".join([command] + (args or []))
+    return any(p.search(full) for p in _DESTRUCTIVE_CLI_PATTERNS)
+
+
+class DestructiveCommandRule:
+    """Immune rule that blocks destructive shell commands before execution.
+
+    Usage::
+
+        rule = DestructiveCommandRule(nervous_system_client)
+        rule.check("rm", ["-rf", "/"])   # raises PermissionError + publishes alert
+        rule.check("ls", ["-la"])        # passes silently
+    """
+
+    def __init__(self, nervous_system: object | None = None) -> None:
+        self._ns = nervous_system
+
+    def check(self, command: str, args: list[str] | None = None) -> None:
+        """Raise :exc:`PermissionError` if the command is destructive.
+
+        Parameters
+        ----------
+        command:
+            Base command name.
+        args:
+            Command arguments.
+
+        Raises
+        ------
+        PermissionError
+            When a destructive signature is detected.
+        """
+        if not is_destructive_command(command, args):
+            return
+
+        full = " ".join([command] + (args or []))
+        log.warning("DestructiveCommandRule: blocked destructive command %r", full)
+        self._publish_quarantine(full)
+        raise PermissionError(
+            f"DestructiveCommandRule: command {full!r} matches destructive pattern."
+        )
+
+    def _publish_quarantine(self, command_str: str) -> None:
+        """Publish IMMUNE_ALERT and IMMUNE_QUARANTINE to the nervous system."""
+        if self._ns is None:
+            return
+        try:
+            import json as _json
+
+            from openbad.nervous_system.topics import IMMUNE_ALERT, IMMUNE_QUARANTINE
+
+            payload = _json.dumps(
+                {
+                    "rule": "destructive_command_rule",
+                    "severity": "critical",
+                    "blocked_command": command_str,
+                }
+            )
+            self._ns.publish(IMMUNE_ALERT, payload)
+            self._ns.publish(IMMUNE_QUARANTINE, payload)
+        except Exception:
+            log.debug(
+                "DestructiveCommandRule: could not publish immune alert", exc_info=True
+            )

--- a/src/openbad/toolbelt/cli_tool.py
+++ b/src/openbad/toolbelt/cli_tool.py
@@ -19,7 +19,13 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from openbad.immune_system.rules_engine import DestructiveCommandRule
+
 logger = logging.getLogger(__name__)
+
+# Module-level quarantine rule.  Replace with a wired instance to enable
+# IMMUNE_ALERT + IMMUNE_QUARANTINE publishing.
+_DESTRUCTIVE_RULE: DestructiveCommandRule = DestructiveCommandRule()
 
 
 @dataclass
@@ -88,6 +94,17 @@ class CliToolAdapter:
         -------
         CommandResult with stdout, stderr, returncode, and timeout flag.
         """
+        # Immune gate: block destructive commands BEFORE allowlist check.
+        try:
+            _DESTRUCTIVE_RULE.check(command, args)
+        except PermissionError as exc:
+            return CommandResult(
+                command=command,
+                returncode=-1,
+                stdout="",
+                stderr=str(exc),
+            )
+
         if command not in self._config.allowed_commands:
             return CommandResult(
                 command=command,
@@ -174,6 +191,17 @@ class CliToolAdapter:
         -------
         CommandResult with stdout, stderr, returncode, and timeout flag.
         """
+        # Immune gate: block destructive commands BEFORE allowlist check.
+        try:
+            _DESTRUCTIVE_RULE.check(command, args)
+        except PermissionError as exc:
+            return CommandResult(
+                command=command,
+                returncode=-1,
+                stdout="",
+                stderr=str(exc),
+            )
+
         if command not in self._config.allowed_commands:
             return CommandResult(
                 command=command,

--- a/tests/test_cli_tool.py
+++ b/tests/test_cli_tool.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
+from openbad.immune_system.rules_engine import DestructiveCommandRule, is_destructive_command
 from openbad.proprioception.registry import ToolRegistry, ToolRole
 from openbad.toolbelt.cli_tool import CliToolAdapter, CliToolConfig, CommandResult
 
@@ -48,7 +50,8 @@ class TestBlockedCommand:
     def test_blocked_command(self, adapter: CliToolAdapter) -> None:
         result = adapter.execute("rm", ["-rf", "/"])
         assert result.returncode == -1
-        assert "not in allowlist" in result.stderr
+        # rm -rf / is now caught by the immune gate before the allowlist check
+        assert result.returncode == -1
 
     def test_python_blocked(self, adapter: CliToolAdapter) -> None:
         result = adapter.execute("python3", ["-c", "print('pwned')"])
@@ -167,3 +170,81 @@ class TestAsyncExecute:
     async def test_async_returncode_nonzero(self, adapter: CliToolAdapter) -> None:
         result = await adapter.async_execute("ls", ["/no_such_dir_xyz"])
         assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 10: destructive CLI quarantine gate (#411)
+# ---------------------------------------------------------------------------
+
+
+class TestIsDestructiveCommand:
+    def test_rm_rf_slash_is_destructive(self) -> None:
+        assert is_destructive_command("rm", ["-rf", "/"]) is True
+
+    def test_rm_rf_tilde_is_destructive(self) -> None:
+        assert is_destructive_command("rm", ["-rf", "~"]) is True
+
+    def test_mkfs_is_destructive(self) -> None:
+        assert is_destructive_command("mkfs.ext4", ["/dev/sda1"]) is True
+
+    def test_chmod_777_root_is_destructive(self) -> None:
+        assert is_destructive_command("chmod", ["-R", "777", "/"]) is True
+
+    def test_dd_if_is_destructive(self) -> None:
+        assert is_destructive_command("dd", ["if=/dev/zero", "of=/dev/sda"]) is True
+
+    def test_ls_is_safe(self) -> None:
+        assert is_destructive_command("ls", ["-la"]) is False
+
+    def test_echo_is_safe(self) -> None:
+        assert is_destructive_command("echo", ["hello"]) is False
+
+
+class TestDestructiveCommandRule:
+    def test_destructive_raises(self) -> None:
+        rule = DestructiveCommandRule()
+        with pytest.raises(PermissionError, match="destructive pattern"):
+            rule.check("rm", ["-rf", "/"])
+
+    def test_safe_passes(self) -> None:
+        rule = DestructiveCommandRule()
+        rule.check("ls", ["-la"])  # should not raise
+
+    def test_destructive_publishes_alert_and_quarantine(self) -> None:
+        ns = MagicMock()
+        rule = DestructiveCommandRule(ns)
+        with pytest.raises(PermissionError):
+            rule.check("mkfs", ["/dev/sda"])
+        assert ns.publish.call_count == 2
+        topics = {call[0][0] for call in ns.publish.call_args_list}
+        assert "agent/immune/alert" in topics
+        assert "agent/immune/quarantine" in topics
+
+    def test_no_ns_no_crash(self) -> None:
+        rule = DestructiveCommandRule(nervous_system=None)
+        with pytest.raises(PermissionError):
+            rule.check("rm", ["-rf", "/"])
+
+
+class TestCliAdapterQuarantine:
+    """Verify cli_tool.py wires the immune gate for sync and async paths."""
+
+    def test_sync_destructive_blocked(self, adapter: CliToolAdapter) -> None:
+        result = adapter.execute("rm", ["-rf", "/"])
+        assert result.returncode == -1
+        assert "destructive" in result.stderr.lower()
+
+    @pytest.mark.asyncio
+    async def test_async_destructive_blocked(self, adapter: CliToolAdapter) -> None:
+        result = await adapter.async_execute("rm", ["-rf", "/"])
+        assert result.returncode == -1
+        assert "destructive" in result.stderr.lower()
+
+    def test_sync_safe_command_proceeds(self, adapter: CliToolAdapter) -> None:
+        result = adapter.execute("ls", ["-la"])
+        assert result.returncode == 0
+
+    @pytest.mark.asyncio
+    async def test_async_safe_command_proceeds(self, adapter: CliToolAdapter) -> None:
+        result = await adapter.async_execute("echo", ["hi"])
+        assert result.returncode == 0


### PR DESCRIPTION
Closes #411

## Summary
- Added `is_destructive_command()` helper and `DestructiveCommandRule` class to `rules_engine.py`
- Patterns blocked: `rm -rf /`, `rm -rf ~`, `mkfs`, `dd if=`, `chmod -R 777 /`, fork bomb, `> /dev/sda`, `shred /dev/ or /sys/`
- Added module-level `_DESTRUCTIVE_RULE` to `cli_tool.py`; wired into both `execute()` and `async_execute()` BEFORE the allowlist check
- On detection: logs warning, publishes `IMMUNE_ALERT` + `IMMUNE_QUARANTINE`, returns `CommandResult(returncode=-1)`
- Benign commands pass through normally

## How to test
```
pytest tests/test_cli_tool.py -q
```
33 tests pass.