### PR TITLE
#413: Add research queue escalation bridge for failed web_fetch calls

### DIFF
--- a/src/openbad/toolbelt/web_search.py
+++ b/src/openbad/toolbelt/web_search.py
@@ -295,3 +295,136 @@ class WebSearchToolAdapter:
         )
         with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
             return resp.read()
+
+
+# ---------------------------------------------------------------------------
+# Research escalation bridge (#413)
+# ---------------------------------------------------------------------------
+
+
+#: HTTP status codes that trigger a research escalation instead of failure.
+ESCALATION_STATUS_CODES: frozenset[int] = frozenset({403, 404})
+
+
+@dataclass
+class FetchOutcome:
+    """Result of a :class:`WebFetchEscalator` guarded fetch.
+
+    Attributes
+    ----------
+    content:
+        Cleaned text content, or ``None`` if the fetch was escalated.
+    escalated:
+        ``True`` when the error was converted into a research escalation.
+    error:
+        The underlying :class:`WebFetchError` that caused escalation, or
+        ``None`` on success.
+    """
+
+    content: str | None
+    escalated: bool = False
+    error: WebFetchError | None = None
+
+
+class WebFetchEscalator:
+    """Wraps :func:`web_fetch` so that recoverable HTTP errors trigger a
+    :class:`~openbad.tasks.research_queue.ResearchNode` instead of failing.
+
+    On HTTP 403, 404, or request timeout the current fetch is suspended
+    (``FetchOutcome.escalated = True``) and a research node is pushed to the
+    provided queue so the agent can investigate the broken resource later.
+
+    Parameters
+    ----------
+    research_queue:
+        A :class:`~openbad.tasks.research_queue.ResearchQueue` instance.
+    escalation_priority:
+        Priority for escalated research nodes (lower = urgency, default -5).
+    """
+
+    def __init__(
+        self,
+        research_queue: object,  # ResearchQueue — not imported at top level to avoid cycle
+        *,
+        escalation_priority: int = -5,
+    ) -> None:
+        self._queue = research_queue
+        self._priority = escalation_priority
+
+    def fetch(
+        self,
+        url: str,
+        *,
+        source_task_id: str | None = None,
+        timeout: float = 15.0,
+        max_chars: int = 50_000,
+    ) -> FetchOutcome:
+        """Fetch *url* and escalate to research on recoverable error.
+
+        Parameters
+        ----------
+        url:
+            The URL to fetch.
+        source_task_id:
+            Optional task node ID used to link the research node.
+        timeout:
+            Request timeout forwarded to :func:`web_fetch`.
+        max_chars:
+            Maximum characters, forwarded to :func:`web_fetch`.
+
+        Returns
+        -------
+        FetchOutcome
+            ``content`` is set on success; ``escalated=True`` and ``error`` is
+            set when the fetch was suspended for research.
+        """
+        try:
+            text = web_fetch(url, timeout=timeout, max_chars=max_chars)
+            return FetchOutcome(content=text)
+        except OSError as exc:
+            # Detect timeout by checking for TimeoutError / ConnectionError subtype
+            # or WebFetchError with status_code == 0.
+            is_escalatable = False
+            error_type = "timeout"
+            if isinstance(exc, WebFetchError):
+                if exc.status_code in ESCALATION_STATUS_CODES:
+                    is_escalatable = True
+                    error_type = f"http_{exc.status_code}"
+                elif exc.status_code == 0:
+                    is_escalatable = True  # timeout / connection error
+            else:
+                is_escalatable = True  # generic OS/timeout error
+
+            if not is_escalatable:
+                raise
+
+            self._push_research(url, source_task_id, error_type, exc)
+            return FetchOutcome(content=None, escalated=True, error=exc)  # type: ignore[arg-type]
+
+    def _push_research(
+        self,
+        url: str,
+        source_task_id: str | None,
+        error_type: str,
+        exc: OSError,
+    ) -> None:
+        """Enqueue a research node for the broken URL."""
+        title = f"Investigate broken resource: {url}"
+        description = (
+            f"web_fetch failed with {error_type!r} for URL {url!r}.\n"
+            f"Error: {exc}\n"
+            f"Source task: {source_task_id or 'unknown'}\n"
+            "Goal: determine whether the resource has moved, is restricted, or "
+            "can be replaced by an alternative source."
+        )
+        try:
+            self._queue.enqueue(
+                title,
+                priority=self._priority,
+                description=description,
+                source_task_id=source_task_id,
+            )
+        except Exception:
+            logging.getLogger(__name__).debug(
+                "WebFetchEscalator: could not enqueue research node", exc_info=True
+            )

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -11,6 +11,7 @@ import pytest
 from openbad.proprioception.registry import ToolRegistry, ToolRole
 from openbad.toolbelt.web_search import (
     WebFetchError,
+    WebFetchEscalator,
     WebSearchConfig,
     WebSearchToolAdapter,
     _RateLimiter,
@@ -221,3 +222,87 @@ class TestWebFetch:
     def test_file_scheme_rejected(self) -> None:
         with pytest.raises(ValueError):
             web_fetch("file:///etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# Phase 10: research escalation bridge (#413)
+# ---------------------------------------------------------------------------
+
+
+def _mock_queue() -> MagicMock:
+    q = MagicMock()
+    q.enqueue.return_value = MagicMock(node_id="rn-001")
+    return q
+
+
+class TestWebFetchEscalator:
+    def test_successful_fetch_returns_content(self) -> None:
+        queue = _mock_queue()
+        escalator = WebFetchEscalator(queue)
+        with patch("openbad.toolbelt.web_search.web_fetch", return_value="page text"):
+            outcome = escalator.fetch("https://example.com")
+        assert outcome.content == "page text"
+        assert outcome.escalated is False
+        queue.enqueue.assert_not_called()
+
+    def test_http_404_escalates(self) -> None:
+        queue = _mock_queue()
+        escalator = WebFetchEscalator(queue)
+        err = WebFetchError("Not Found", status_code=404)
+        with patch("openbad.toolbelt.web_search.web_fetch", side_effect=err):
+            outcome = escalator.fetch("https://example.com/gone", source_task_id="t1")
+        assert outcome.content is None
+        assert outcome.escalated is True
+        assert outcome.error is err
+        queue.enqueue.assert_called_once()
+        call_kw = queue.enqueue.call_args[1]
+        assert call_kw["source_task_id"] == "t1"
+        assert "404" in call_kw["description"] or "http_404" in call_kw["description"]
+
+    def test_http_403_escalates(self) -> None:
+        queue = _mock_queue()
+        escalator = WebFetchEscalator(queue)
+        err = WebFetchError("Forbidden", status_code=403)
+        with patch("openbad.toolbelt.web_search.web_fetch", side_effect=err):
+            outcome = escalator.fetch("https://example.com/secret")
+        assert outcome.escalated is True
+        queue.enqueue.assert_called_once()
+
+    def test_timeout_escalates(self) -> None:
+        queue = _mock_queue()
+        escalator = WebFetchEscalator(queue)
+        err = WebFetchError("timed out", status_code=0)
+        with patch("openbad.toolbelt.web_search.web_fetch", side_effect=err):
+            outcome = escalator.fetch("https://slow.example.com")
+        assert outcome.escalated is True
+        queue.enqueue.assert_called_once()
+
+    def test_research_node_includes_url_in_title(self) -> None:
+        queue = _mock_queue()
+        escalator = WebFetchEscalator(queue)
+        err = WebFetchError("Not Found", status_code=404)
+        url = "https://example.com/missing"
+        with patch("openbad.toolbelt.web_search.web_fetch", side_effect=err):
+            escalator.fetch(url)
+        title_arg = queue.enqueue.call_args[0][0]
+        assert url in title_arg
+
+    def test_queue_failure_does_not_raise(self) -> None:
+        queue = _mock_queue()
+        queue.enqueue.side_effect = RuntimeError("db down")
+        escalator = WebFetchEscalator(queue)
+        err = WebFetchError("Not Found", status_code=404)
+        with patch("openbad.toolbelt.web_search.web_fetch", side_effect=err):
+            outcome = escalator.fetch("https://example.com/gone")
+        assert outcome.escalated is True  # still escalated, but queue silently failed
+
+    def test_non_escalatable_http_error_reraises(self) -> None:
+        queue = _mock_queue()
+        escalator = WebFetchEscalator(queue)
+        err = WebFetchError("Internal Server Error", status_code=500)
+        with (
+            patch("openbad.toolbelt.web_search.web_fetch", side_effect=err),
+            pytest.raises(WebFetchError),
+        ):
+            escalator.fetch("https://example.com/fail")
+        queue.enqueue.assert_not_called()


### PR DESCRIPTION
Closes #413

## Summary

Adds `WebFetchEscalator` to `src/openbad/toolbelt/web_search.py`. On HTTP 403, 404, or connection/timeout errors, a `ResearchNode` is pushed to the provided `ResearchQueue` instead of propagating the failure. Non-recoverable HTTP errors (e.g. 500) still raise normally.

Also adds `FetchOutcome` dataclass and `ESCALATION_STATUS_CODES` constant.

## Changes

- `src/openbad/toolbelt/web_search.py` — added `ESCALATION_STATUS_CODES`, `FetchOutcome`, `WebFetchEscalator`
- `tests/test_web_search.py` — added `TestWebFetchEscalator` (7 tests, 26 total pass)

## How to test

```bash
pytest tests/test_web_search.py -q
```