### PR TITLE
#415: Implement dual-mode ask_user tool

### DIFF
--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -177,6 +177,19 @@ SCHEDULER_MAINTENANCE = "agent/scheduler/maintenance"
 # Wildcard: all scheduler events
 SCHEDULER_ALL = "agent/scheduler/+"
 
+# ---------------------------------------------------------------------------
+# Agent chat / user escalation (Phase 10)
+# ---------------------------------------------------------------------------
+
+#: Questions published by the agent for the active user session.
+AGENT_CHAT_RESPONSE = "agent/chat/response"
+
+#: Inbound user replies to agent questions.
+AGENT_CHAT_INBOUND = "agent/chat/inbound"
+
+#: Escalation topic for blocked-on-user or unresolvable asks.
+AGENT_ESCALATION = "agent/escalation"
+
 
 # ---------------------------------------------------------------------------
 # Helper: resolve topic templates
@@ -220,6 +233,10 @@ STATIC_TOPICS: tuple[str, ...] = (
     SCHEDULER_WINDOW_START,
     SCHEDULER_WINDOW_END,
     SCHEDULER_DISPATCH,
+    # Phase 10
+    AGENT_CHAT_RESPONSE,
+    AGENT_CHAT_INBOUND,
+    AGENT_ESCALATION,
 )
 
 TEMPLATE_TOPICS: tuple[str, ...] = (

--- a/src/openbad/toolbelt/ask_user.py
+++ b/src/openbad/toolbelt/ask_user.py
@@ -1,0 +1,196 @@
+"""Dual-mode user communication tool — Phase 10, Issue #415.
+
+**Mode A (Active):** When a WUI session is live (``is_active = True``), publish
+the question to :data:`~openbad.nervous_system.topics.AGENT_CHAT_RESPONSE` and
+block up to *timeout* seconds waiting for a reply from
+:data:`~openbad.nervous_system.topics.AGENT_CHAT_INBOUND`.
+
+**Mode B (Inactive / Timeout):** When no session is active, or when Mode A
+times out, mark the task node ``BLOCKED_ON_USER`` via the :class:`TaskStore`,
+then publish the full question payload to
+:data:`~openbad.nervous_system.topics.AGENT_ESCALATION` so a re-engagement
+hook can resurface it later.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from openbad.nervous_system import topics
+from openbad.tasks.models import NodeStatus
+
+if TYPE_CHECKING:
+    from openbad.nervous_system.client import NervousSystemClient
+    from openbad.tasks.store import TaskStore
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public sentinel for deferred (Mode B) returns
+# ---------------------------------------------------------------------------
+
+DEFERRED: str = "__deferred__"
+"""Sentinel returned when the question is deferred to escalation."""
+
+# ---------------------------------------------------------------------------
+# Payload schemas
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class QuestionPayload:
+    """The message published to ``agent/chat/response`` for active users.
+
+    Also used as the body of the ``agent/escalation`` message when the task
+    is blocked.
+    """
+
+    question: str
+    task_id: str | None
+    node_id: str | None
+    timeout: float
+    extra: dict = field(default_factory=dict)
+
+    def to_json(self) -> bytes:
+        return json.dumps(
+            {
+                "question": self.question,
+                "task_id": self.task_id,
+                "node_id": self.node_id,
+                "timeout": self.timeout,
+                **self.extra,
+            }
+        ).encode()
+
+
+# ---------------------------------------------------------------------------
+# Core function
+# ---------------------------------------------------------------------------
+
+
+def ask_user(
+    question: str,
+    *,
+    mqtt: NervousSystemClient | None = None,
+    wui_is_active: bool = False,
+    task_id: str | None = None,
+    node_id: str | None = None,
+    store: TaskStore | None = None,
+    timeout: float = 30.0,
+) -> str:
+    """Ask the user a question and return the answer or :data:`DEFERRED`.
+
+    Parameters
+    ----------
+    question:
+        The question text to present to the user.
+    mqtt:
+        Live :class:`~openbad.nervous_system.client.NervousSystemClient`.
+        When ``None`` the function runs in headless/test mode (no MQTT
+        messages are sent).
+    wui_is_active:
+        Whether the WUI session is currently live (from
+        :attr:`~openbad.wui.bridge.UserSession.is_active`).
+    task_id:
+        ID of the task that triggered this question.
+    node_id:
+        ID of the task node that triggered this question.
+    store:
+        Optional :class:`~openbad.tasks.store.TaskStore`.  When provided,
+        the node status is updated to
+        :attr:`~openbad.tasks.models.NodeStatus.BLOCKED_ON_USER` in Mode B.
+    timeout:
+        Seconds to wait for a reply in Mode A before falling back to Mode B.
+
+    Returns
+    -------
+    str
+        The user's reply text (Mode A), or :data:`DEFERRED` (Mode B / timeout).
+    """
+    payload = QuestionPayload(
+        question=question,
+        task_id=task_id,
+        node_id=node_id,
+        timeout=timeout,
+    )
+
+    if wui_is_active:
+        answer = _active_mode(payload, mqtt, timeout)
+        if answer is not None:
+            return answer
+        # Timed out → fall through to Mode B
+        log.info("ask_user: Mode A timed out, falling back to Mode B")
+
+    return _inactive_mode(payload, mqtt, store, node_id)
+
+
+# ---------------------------------------------------------------------------
+# Mode helpers
+# ---------------------------------------------------------------------------
+
+
+def _active_mode(
+    payload: QuestionPayload,
+    mqtt: NervousSystemClient | None,
+    timeout: float,
+) -> str | None:
+    """Publish the question and wait for a reply.  Returns ``None`` on timeout."""
+    event = threading.Event()
+    container: list[str] = []
+
+    def _on_inbound(topic: str, raw: bytes) -> None:  # noqa: ARG001
+        try:
+            body = json.loads(raw)
+            answer = body.get("answer") or body.get("text") or str(body)
+        except Exception:
+            answer = raw.decode(errors="replace")
+        container.append(answer)
+        event.set()
+
+    if mqtt is not None:
+        # Subscribe to raw bytes (not protobuf) on the inbound topic.
+        # We use a raw bytes callback: NervousSystemClient.subscribe expects a
+        # message_type, so we work around it with publish_bytes / a wrapper.
+        # The bridge sends plain JSON on AGENT_CHAT_INBOUND. We temporarily
+        # register a side-channel via a threading.Event.
+        mqtt.subscribe(topics.AGENT_CHAT_INBOUND, bytes, _on_inbound)
+        try:
+            mqtt.publish_bytes(topics.AGENT_CHAT_RESPONSE, payload.to_json())
+            event.wait(timeout=timeout)
+        finally:
+            mqtt.unsubscribe(topics.AGENT_CHAT_INBOUND)
+    else:
+        log.debug("ask_user: no MQTT client; skipping active-mode publish")
+
+    return container[0] if container else None
+
+
+def _inactive_mode(
+    payload: QuestionPayload,
+    mqtt: NervousSystemClient | None,
+    store: TaskStore | None,
+    node_id: str | None,
+) -> str:
+    """Block the node and publish escalation.  Returns :data:`DEFERRED`."""
+    if store is not None and node_id is not None:
+        try:
+            store.update_node_status(node_id, NodeStatus.BLOCKED_ON_USER)
+        except Exception:
+            log.exception("ask_user: could not update node status to BLOCKED_ON_USER")
+
+    if mqtt is not None:
+        try:
+            mqtt.publish_bytes(topics.AGENT_ESCALATION, payload.to_json())
+        except Exception:
+            log.exception("ask_user: could not publish escalation message")
+
+    log.info(
+        "ask_user: node %s deferred (BLOCKED_ON_USER), question=%r",
+        node_id or "?",
+        payload.question[:80],
+    )
+    return DEFERRED

--- a/tests/test_ask_user.py
+++ b/tests/test_ask_user.py
@@ -1,0 +1,224 @@
+"""Tests for dual-mode ask_user tool — Issue #415."""
+
+from __future__ import annotations
+
+import json
+import threading
+from unittest.mock import MagicMock
+
+from openbad.nervous_system import topics
+from openbad.tasks.models import NodeStatus
+from openbad.toolbelt.ask_user import (
+    DEFERRED,
+    QuestionPayload,
+    ask_user,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mqtt_stub(*, reply: str | None = None, reply_delay: float = 0.0) -> MagicMock:
+    """Build an MQTT stub that optionally fires a reply on AGENT_CHAT_INBOUND."""
+    mqtt = MagicMock()
+
+    def _subscribe(topic: str, msg_type: type, callback, qos=None) -> None:  # noqa: ANN001
+        if topic == topics.AGENT_CHAT_INBOUND and reply is not None:
+            raw = json.dumps({"answer": reply}).encode()
+
+            def _fire() -> None:
+                import time
+
+                time.sleep(reply_delay)
+                callback(topic, raw)
+
+            t = threading.Thread(target=_fire, daemon=True)
+            t.start()
+
+    mqtt.subscribe.side_effect = _subscribe
+    return mqtt
+
+
+# ---------------------------------------------------------------------------
+# QuestionPayload
+# ---------------------------------------------------------------------------
+
+
+class TestQuestionPayload:
+    def test_to_json_contains_all_fields(self) -> None:
+        p = QuestionPayload(
+            question="Are you sure?",
+            task_id="t1",
+            node_id="n1",
+            timeout=15.0,
+        )
+        body = json.loads(p.to_json())
+        assert body["question"] == "Are you sure?"
+        assert body["task_id"] == "t1"
+        assert body["node_id"] == "n1"
+        assert body["timeout"] == 15.0
+
+    def test_extra_fields_included(self) -> None:
+        p = QuestionPayload(
+            question="foo?",
+            task_id=None,
+            node_id=None,
+            timeout=5.0,
+            extra={"source": "test"},
+        )
+        body = json.loads(p.to_json())
+        assert body["source"] == "test"
+
+
+# ---------------------------------------------------------------------------
+# Mode A: active session
+# ---------------------------------------------------------------------------
+
+
+class TestActiveModeReturnsAnswer:
+    def test_returns_answer_when_reply_arrives(self) -> None:
+        mqtt = _mqtt_stub(reply="yes")
+        result = ask_user(
+            "Continue?",
+            mqtt=mqtt,
+            wui_is_active=True,
+            task_id="t1",
+            node_id="n1",
+            timeout=2.0,
+        )
+        assert result == "yes"
+        topic_arg = mqtt.publish_bytes.call_args[0][0]
+        assert topic_arg == topics.AGENT_CHAT_RESPONSE
+
+    def test_publishes_question_payload(self) -> None:
+        mqtt = _mqtt_stub(reply="ack")
+        ask_user(
+            "OK?",
+            mqtt=mqtt,
+            wui_is_active=True,
+            task_id="task-x",
+            node_id="node-y",
+            timeout=2.0,
+        )
+        # publish_bytes was called on AGENT_CHAT_RESPONSE
+        topic_arg = mqtt.publish_bytes.call_args[0][0]
+        assert topic_arg == topics.AGENT_CHAT_RESPONSE
+        # payload includes task ctx
+        payload_bytes = mqtt.publish_bytes.call_args[0][1]
+        body = json.loads(payload_bytes)
+        assert body["task_id"] == "task-x"
+        assert body["node_id"] == "node-y"
+
+    def test_unsubscribes_after_reply(self) -> None:
+        mqtt = _mqtt_stub(reply="done")
+        ask_user("Q?", mqtt=mqtt, wui_is_active=True, timeout=2.0)
+        mqtt.unsubscribe.assert_called_with(topics.AGENT_CHAT_INBOUND)
+
+
+# ---------------------------------------------------------------------------
+# Mode A → fallback on timeout
+# ---------------------------------------------------------------------------
+
+
+class TestActiveModeTimeout:
+    def test_timeout_falls_back_to_deferred(self) -> None:
+        # No reply scheduled → timeout → Mode B
+        mqtt = _mqtt_stub(reply=None)
+        store = MagicMock()
+        result = ask_user(
+            "ETA?",
+            mqtt=mqtt,
+            wui_is_active=True,
+            task_id="t2",
+            node_id="n2",
+            store=store,
+            timeout=0.05,  # very short
+        )
+        assert result == DEFERRED
+
+    def test_timeout_updates_node_to_blocked_on_user(self) -> None:
+        mqtt = _mqtt_stub(reply=None)
+        store = MagicMock()
+        ask_user(
+            "Status?",
+            mqtt=mqtt,
+            wui_is_active=True,
+            task_id="t3",
+            node_id="n3",
+            store=store,
+            timeout=0.05,
+        )
+        store.update_node_status.assert_called_once_with("n3", NodeStatus.BLOCKED_ON_USER)
+
+    def test_timeout_publishes_to_escalation(self) -> None:
+        mqtt = _mqtt_stub(reply=None)
+        ask_user(
+            "Waiting…",
+            mqtt=mqtt,
+            wui_is_active=True,
+            task_id="t4",
+            node_id="n4",
+            timeout=0.05,
+        )
+        escalation_calls = [
+            c for c in mqtt.publish_bytes.call_args_list if c[0][0] == topics.AGENT_ESCALATION
+        ]
+        assert len(escalation_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Mode B: inactive session
+# ---------------------------------------------------------------------------
+
+
+class TestInactiveMode:
+    def test_inactive_returns_deferred(self) -> None:
+        mqtt = _mqtt_stub()
+        result = ask_user(
+            "Confirm?",
+            mqtt=mqtt,
+            wui_is_active=False,
+            task_id="t5",
+            node_id="n5",
+            timeout=5.0,
+        )
+        assert result == DEFERRED
+
+    def test_inactive_updates_node_status(self) -> None:
+        mqtt = _mqtt_stub()
+        store = MagicMock()
+        ask_user(
+            "Are you there?",
+            mqtt=mqtt,
+            wui_is_active=False,
+            task_id="t6",
+            node_id="n6",
+            store=store,
+        )
+        store.update_node_status.assert_called_once_with("n6", NodeStatus.BLOCKED_ON_USER)
+
+    def test_inactive_publishes_escalation(self) -> None:
+        mqtt = _mqtt_stub()
+        ask_user(
+            "Need input",
+            mqtt=mqtt,
+            wui_is_active=False,
+            task_id="t7",
+            node_id="n7",
+        )
+        mqtt.publish_bytes.assert_called_once()
+        topic_arg = mqtt.publish_bytes.call_args[0][0]
+        assert topic_arg == topics.AGENT_ESCALATION
+
+    def test_inactive_payload_includes_task_and_node(self) -> None:
+        mqtt = _mqtt_stub()
+        ask_user("?", mqtt=mqtt, wui_is_active=False, task_id="tX", node_id="nX")
+        payload_bytes = mqtt.publish_bytes.call_args[0][1]
+        body = json.loads(payload_bytes)
+        assert body["task_id"] == "tX"
+        assert body["node_id"] == "nX"
+
+    def test_no_mqtt_returns_deferred_without_error(self) -> None:
+        result = ask_user("Q?", mqtt=None, wui_is_active=False)
+        assert result == DEFERRED


### PR DESCRIPTION
Closes #415

## Summary

Creates `src/openbad/toolbelt/ask_user.py` with a dual-mode `ask_user()` function:

- **Mode A (Active):** If `wui_is_active=True`, publishes the question to `agent/chat/response` and blocks up to `timeout` seconds awaiting a reply on `agent/chat/inbound`. Returns the user's answer.
- **Mode B (Inactive / Timeout):** If session is inactive or Mode A times out, updates the node status to `BLOCKED_ON_USER` via `TaskStore`, publishes the full question payload to `agent/escalation`, and returns the `DEFERRED` sentinel.

Also adds `AGENT_CHAT_RESPONSE`, `AGENT_CHAT_INBOUND`, and `AGENT_ESCALATION` topic constants to `topics.py`.

## Changes

- `src/openbad/nervous_system/topics.py` — added Phase 10 chat / escalation topic constants
- `src/openbad/toolbelt/ask_user.py` — new dual-mode `ask_user()` tool
- `tests/test_ask_user.py` — 13 tests covering all modes and fallback paths

## How to test

```bash
pytest tests/test_ask_user.py -q
```