### PR TITLE
#416: Add re-engagement hook for BLOCKED_ON_USER tasks on WUI reconnect

### DIFF
--- a/src/openbad/reflex_arc/chat_activator.py
+++ b/src/openbad/reflex_arc/chat_activator.py
@@ -34,6 +34,8 @@ import yaml
 if TYPE_CHECKING:
     from openbad.nervous_system.client import NervousSystemClient
     from openbad.reflex_arc.fsm import AgentFSM
+    from openbad.tasks.models import NodeModel
+    from openbad.tasks.store import TaskStore
 
 logger = logging.getLogger(__name__)
 
@@ -197,3 +199,172 @@ class ChatActivator:
                     "ChatActivator: idle timeout but FSM not ACTIVE (state=%s)",
                     current_state,
                 )
+
+
+# ---------------------------------------------------------------------------
+# Re-engagement hook (Phase 10, Issue #416)
+# ---------------------------------------------------------------------------
+
+
+class ReEngagementHook:
+    """Surfaces BLOCKED_ON_USER questions when the WUI reconnects.
+
+    On a WUI presence flip to ``active=True``, queries the ``TaskStore`` for
+    all nodes in the ``BLOCKED_ON_USER`` state and publishes their pending
+    questions to ``agent/chat/response`` *before* the standard greeting.
+
+    When the user answers, the reply published to ``agent/chat/inbound``
+    transitions the first pending node from ``BLOCKED_ON_USER`` to
+    ``RUNNING``.
+
+    Parameters
+    ----------
+    client:
+        Live :class:`~openbad.nervous_system.client.NervousSystemClient`.
+    store:
+        :class:`~openbad.tasks.store.TaskStore` backed by the task database.
+    greeting:
+        Optional greeting message sent after pending questions.
+    """
+
+    def __init__(
+        self,
+        client: NervousSystemClient,
+        store: TaskStore,
+        *,
+        greeting: str = "Hello — I'm back. What would you like to work on?",
+    ) -> None:
+        self._client = client
+        self._store = store
+        self._greeting = greeting
+        self._pending: list[NodeModel] = []
+        self._lock = threading.Lock()
+        self._running = False
+
+    def start(self) -> None:
+        """Subscribe to presence events and inbound chat replies."""
+        from openbad.nervous_system import topics
+
+        self._running = True
+        self._client.subscribe(topics.WUI_PRESENCE, bytes, self._on_presence)
+        self._client.subscribe(topics.AGENT_CHAT_INBOUND, bytes, self._on_inbound)
+        logger.info("ReEngagementHook started")
+
+    def stop(self) -> None:
+        """Unsubscribe and clear pending queue."""
+        from openbad.nervous_system import topics
+
+        self._running = False
+        self._client.unsubscribe(topics.WUI_PRESENCE)
+        self._client.unsubscribe(topics.AGENT_CHAT_INBOUND)
+        with self._lock:
+            self._pending.clear()
+        logger.info("ReEngagementHook stopped")
+
+    # ------------------------------------------------------------------
+    # Internal handlers
+    # ------------------------------------------------------------------
+
+    def _on_presence(self, _topic: str, payload: bytes) -> None:
+        """Handle WUI_PRESENCE events; re-engage on active=True."""
+        if not self._running:
+            return
+        try:
+            body = json.loads(payload)
+            if not body.get("active", False):
+                return
+        except Exception:
+            logger.debug("ReEngagementHook: could not parse presence payload")
+            return
+
+        self._load_pending()
+        self._surface_pending()
+
+    def _on_inbound(self, _topic: str, payload: bytes) -> None:
+        """Handle user reply; unblock the first pending node."""
+        if not self._running:
+            return
+
+        with self._lock:
+            if not self._pending:
+                return
+            node = self._pending.pop(0)
+
+        try:
+            self._store.update_node_status(node.node_id, _RUNNING)
+            logger.info(
+                "ReEngagementHook: node %s unblocked (→ RUNNING)", node.node_id
+            )
+        except Exception:
+            logger.exception(
+                "ReEngagementHook: could not update node %s to RUNNING", node.node_id
+            )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _load_pending(self) -> None:
+        """Query the store for BLOCKED_ON_USER nodes, ordered by priority."""
+        from openbad.tasks.models import NodeStatus
+
+        try:
+            nodes = self._store.list_nodes_by_status(NodeStatus.BLOCKED_ON_USER)
+        except Exception:
+            logger.exception("ReEngagementHook: could not query pending nodes")
+            return
+
+        with self._lock:
+            # Sort by task priority proxy (node_id is UUID — use created_at ordering
+            # already returned DESC from the store; reverse to oldest-first so we
+            # surface the earliest blocked question first).
+            self._pending = list(reversed(nodes))
+
+    def _surface_pending(self) -> None:
+        """Publish pending questions to the chat feed, then send the greeting."""
+        from openbad.nervous_system import topics
+
+        with self._lock:
+            pending_snapshot = list(self._pending)
+
+        for node in pending_snapshot:
+            payload = json.dumps(
+                {
+                    "question": node.title,
+                    "task_id": node.task_id,
+                    "node_id": node.node_id,
+                    "type": "pending_question",
+                }
+            ).encode()
+            try:
+                self._client.publish_bytes(topics.AGENT_CHAT_RESPONSE, payload)
+            except Exception:
+                logger.exception(
+                    "ReEngagementHook: could not publish question for node %s",
+                    node.node_id,
+                )
+
+        if not pending_snapshot:
+            # No blocked questions — send standard greeting directly.
+            self._send_greeting()
+        else:
+            # Greeting follows after questions.
+            self._send_greeting()
+
+    def _send_greeting(self) -> None:
+        from openbad.nervous_system import topics
+
+        payload = json.dumps({"text": self._greeting, "type": "greeting"}).encode()
+        try:
+            self._client.publish_bytes(topics.AGENT_CHAT_RESPONSE, payload)
+        except Exception:
+            logger.debug("ReEngagementHook: could not send greeting")
+
+
+# Shorthand used within the hook — resolved at import time.
+try:
+    from openbad.tasks.models import NodeStatus as _NodeStatus
+
+    _RUNNING = _NodeStatus.RUNNING
+except ImportError:  # pragma: no cover
+    _RUNNING = "running"  # type: ignore[assignment]

--- a/src/openbad/tasks/store.py
+++ b/src/openbad/tasks/store.py
@@ -125,6 +125,16 @@ class TaskStore:
         ).fetchall()
         return [_node_from_row(r) for r in rows]
 
+    def list_nodes_by_status(
+        self, status: NodeStatus, *, limit: int = 100
+    ) -> list[NodeModel]:
+        """Return nodes in *status* ordered by creation time, newest first."""
+        rows = self._conn.execute(
+            "SELECT * FROM task_nodes WHERE status = ? ORDER BY created_at DESC LIMIT ?",
+            (status.value, limit),
+        ).fetchall()
+        return [_node_from_row(r) for r in rows]
+
     # ------------------------------------------------------------------
     # Event operations (append-only)
     # ------------------------------------------------------------------

--- a/tests/test_chat_activator.py
+++ b/tests/test_chat_activator.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 from openbad.nervous_system import topics
-from openbad.reflex_arc.chat_activator import ChatActivator, load_config
+from openbad.reflex_arc.chat_activator import ChatActivator, ReEngagementHook, load_config
 
 if TYPE_CHECKING:
     pass
@@ -351,3 +351,107 @@ def test_ignores_events_after_stop() -> None:
 
     # Should not call fire after stopped
     mock_fsm.fire.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Phase 10: ReEngagementHook tests (Issue #416)
+# ---------------------------------------------------------------------------
+
+
+def _make_node(node_id: str, task_id: str = "t1", title: str = "default question") -> Mock:
+    """Build a minimal mock NodeModel."""
+    node = Mock()
+    node.node_id = node_id
+    node.task_id = task_id
+    node.title = title
+    return node
+
+
+def _make_hook(pending: list) -> tuple[ReEngagementHook, Mock, Mock]:
+    """Return (hook, client_mock, store_mock)."""
+
+    client = Mock()
+    store = Mock()
+    store.list_nodes_by_status.return_value = pending
+    hook = ReEngagementHook(client, store)
+    return hook, client, store
+
+
+def _presence_payload(*, active: bool) -> bytes:
+    return json.dumps({"active": active}).encode()
+
+
+def _inbound_payload(answer: str = "yes") -> bytes:
+    return json.dumps({"answer": answer}).encode()
+
+
+class TestReEngagementHookReconnect:
+    def test_surfaces_blocked_questions_on_reconnect(self) -> None:
+        node = _make_node("n1", title="Are you sure?")
+        hook, client, store = _make_hook([node])
+        hook.start()
+        hook._on_presence("system/wui/presence", _presence_payload(active=True))
+        # Should publish the pending question + greeting
+        assert client.publish_bytes.call_count >= 2
+        chat_responses = [
+            c for c in client.publish_bytes.call_args_list
+            if c[0][0] == topics.AGENT_CHAT_RESPONSE
+        ]
+        assert len(chat_responses) >= 1
+        first_payload = json.loads(chat_responses[0][0][1])
+        assert first_payload["node_id"] == "n1"
+
+    def test_no_pending_sends_greeting_only(self) -> None:
+        hook, client, store = _make_hook([])
+        hook.start()
+        hook._on_presence("system/wui/presence", _presence_payload(active=True))
+        assert client.publish_bytes.call_count == 1
+        body = json.loads(client.publish_bytes.call_args[0][1])
+        assert body["type"] == "greeting"
+
+    def test_inactive_presence_does_not_trigger(self) -> None:
+        hook, client, store = _make_hook([_make_node("n2")])
+        hook.start()
+        hook._on_presence("system/wui/presence", _presence_payload(active=False))
+        client.publish_bytes.assert_not_called()
+
+    def test_multiple_pending_ordered_oldest_first(self) -> None:
+        nodes = [_make_node(f"n{i}", title=f"Q{i}") for i in range(3)]
+        hook, client, store = _make_hook(nodes)
+        hook.start()
+        hook._on_presence("system/wui/presence", _presence_payload(active=True))
+        chat_qs = [
+            json.loads(c[0][1])
+            for c in client.publish_bytes.call_args_list
+            if json.loads(c[0][1]).get("type") == "pending_question"
+        ]
+        assert [q["node_id"] for q in chat_qs] == ["n2", "n1", "n0"]
+
+
+class TestReEngagementHookUnblock:
+    def test_answering_transitions_node_to_running(self) -> None:
+        from openbad.tasks.models import NodeStatus
+
+        node = _make_node("n10")
+        hook, client, store = _make_hook([node])
+        hook.start()
+        # Simulate reconnect to load pending
+        hook._on_presence("system/wui/presence", _presence_payload(active=True))
+        # Simulate user reply
+        hook._on_inbound(topics.AGENT_CHAT_INBOUND, _inbound_payload("ok"))
+        store.update_node_status.assert_called_with("n10", NodeStatus.RUNNING)
+
+    def test_inbound_with_no_pending_does_not_crash(self) -> None:
+        hook, client, store = _make_hook([])
+        hook.start()
+        # No presence event → no pending loaded
+        hook._on_inbound(topics.AGENT_CHAT_INBOUND, _inbound_payload("hello"))
+        store.update_node_status.assert_not_called()
+
+    def test_stop_prevents_processing(self) -> None:
+        node = _make_node("nx")
+        hook, client, store = _make_hook([node])
+        hook.start()
+        hook.stop()
+        hook._on_presence("system/wui/presence", _presence_payload(active=True))
+        client.publish_bytes.assert_not_called()


### PR DESCRIPTION
Closes #416

## Summary

Adds `ReEngagementHook` to `src/openbad/reflex_arc/chat_activator.py`. When WUI presence flips to `active=True`, the hook queries `TaskStore` for all `BLOCKED_ON_USER` nodes and publishes their pending questions to `agent/chat/response` before the standard greeting. When the user answers (on `agent/chat/inbound`), the first pending node is transitioned to `RUNNING`.

Also adds `TaskStore.list_nodes_by_status()` to support cross-task status queries.

## Changes

- `src/openbad/reflex_arc/chat_activator.py` — added `ReEngagementHook` class
- `src/openbad/tasks/store.py` — added `list_nodes_by_status()` method
- `tests/test_chat_activator.py` — added 7 ReEngagementHook tests (21 total pass)

## How to test

```bash
pytest tests/test_chat_activator.py -q
```