### PR TITLE
#418: Scope browser context as transient MCP bridge session

### DIFF
--- a/src/openbad/toolbelt/mcp_bridge/browser_context.py
+++ b/src/openbad/toolbelt/mcp_bridge/browser_context.py
@@ -1,0 +1,273 @@
+"""Transient MCP bridge for browser sessions — Phase 10, Issue #418.
+
+Wraps :class:`~openbad.sensory.vision.cdp_dom.CDPExtractor` into a
+task-node–scoped context.  The browser session is started on demand when a
+:class:`~openbad.tasks.models.NodeModel` is tagged with the ``browser``
+capability, and is fully torn down when the node completes (success or
+failure).  Sessions are *never* shared across task nodes.
+
+Usage::
+
+    async with BrowserContextRunner.for_node(node) as ctx:
+        dom = await ctx.snapshot_dom()
+        text = await ctx.navigate("https://example.com")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from openbad.sensory.vision.cdp_dom import CDPExtractor, DOMNode, dom_to_json
+
+if TYPE_CHECKING:
+    from openbad.tasks.models import NodeModel
+
+log = logging.getLogger(__name__)
+
+#: Capability tag that must appear in ``node.capability_requirements`` for a
+#: browser session to be provisioned.
+BROWSER_CAPABILITY = "browser"
+
+#: Default CDP endpoint used when no explicit URL is supplied.
+DEFAULT_CDP_URL = "http://localhost:9222"
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NavigateResult:
+    """Outcome of a :meth:`BrowserContextRunner.navigate` call."""
+
+    url: str
+    dom_json: str
+    node_count: int
+    error: str | None = None
+
+
+@dataclass
+class BrowserCapabilities:
+    """Describes what the current browser session can do."""
+
+    cdp_url: str
+    features: list[str] = field(default_factory=lambda: ["dom_snapshot", "navigate"])
+
+
+# ---------------------------------------------------------------------------
+# Core class
+# ---------------------------------------------------------------------------
+
+
+class BrowserContextRunner:
+    """Task-node–scoped browser session backed by a :class:`CDPExtractor`.
+
+    Lifecycle:
+    1. :meth:`start` — verifies the CDP endpoint is reachable.
+    2. :meth:`snapshot_dom` / :meth:`navigate` — browser operations.
+    3. :meth:`stop` — releases all resources regardless of outcome.
+
+    Use :meth:`for_node` to gate activation on the ``browser`` capability tag.
+
+    Parameters
+    ----------
+    cdp_url:
+        Base URL for the CDP HTTP endpoint.
+    node_id:
+        ID of the task node that owns this session (for logging only).
+    """
+
+    def __init__(
+        self,
+        cdp_url: str = DEFAULT_CDP_URL,
+        *,
+        node_id: str | None = None,
+    ) -> None:
+        self._cdp_url = cdp_url
+        self._node_id = node_id or "unknown"
+        self._extractor: CDPExtractor | None = None
+        self._active = False
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def for_node(
+        cls,
+        node: NodeModel,
+        cdp_url: str = DEFAULT_CDP_URL,
+    ) -> BrowserContextRunner | None:
+        """Return a :class:`BrowserContextRunner` if *node* requires ``browser``.
+
+        Returns ``None`` (not a context manager) when the node does not have
+        the ``browser`` capability tag so callers can check before entering.
+        """
+        if not _node_needs_browser(node):
+            return None
+        return cls(cdp_url=cdp_url, node_id=node.node_id)
+
+    # ------------------------------------------------------------------
+    # Async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> BrowserContextRunner:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.stop()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Initialise the :class:`CDPExtractor` for this session."""
+        if self._active:
+            return
+        self._extractor = CDPExtractor(cdp_url=self._cdp_url)
+        self._active = True
+        log.info("BrowserContextRunner: started for node %s", self._node_id)
+
+    async def stop(self) -> None:
+        """Release all browser resources for this session."""
+        self._extractor = None
+        self._active = False
+        log.info("BrowserContextRunner: stopped for node %s", self._node_id)
+
+    # ------------------------------------------------------------------
+    # Browser operations
+    # ------------------------------------------------------------------
+
+    @property
+    def is_active(self) -> bool:
+        """``True`` while the session is live."""
+        return self._active
+
+    def capabilities(self) -> BrowserCapabilities:
+        """Return the capabilities of the current session."""
+        return BrowserCapabilities(cdp_url=self._cdp_url)
+
+    async def snapshot_dom(self, *, page_index: int = 0) -> DOMNode:
+        """Extract the current DOM tree.
+
+        Returns
+        -------
+        DOMNode
+            Root of the parsed DOM tree.
+
+        Raises
+        ------
+        RuntimeError
+            If the session has not been started.
+        """
+        self._require_active()
+        assert self._extractor is not None  # type narrowing
+        return await self._extractor.extract_dom(page_index=page_index)
+
+    async def snapshot_dom_json(self, *, page_index: int = 0) -> str:
+        """Extract the DOM tree and return it serialised as JSON."""
+        root = await self.snapshot_dom(page_index=page_index)
+        return dom_to_json(root)
+
+    async def navigate(
+        self,
+        url: str,
+        *,
+        page_index: int = 0,
+    ) -> NavigateResult:
+        """Navigate to *url* and return a DOM snapshot.
+
+        The CDP protocol does not expose a single "navigate" command through
+        :class:`CDPExtractor`; we use ``Page.navigate`` via a raw CDP command
+        and then snapshot the DOM.
+
+        Parameters
+        ----------
+        url:
+            The URL to navigate to.
+        page_index:
+            Page/tab index (zero-based).
+        """
+        self._require_active()
+        assert self._extractor is not None  # type narrowing
+
+        try:
+            ws_url = await self._extractor._get_page_ws_url(page_index)  # noqa: SLF001
+        except Exception as exc:
+            log.warning("BrowserContextRunner: could not get WS URL: %s", exc)
+            return NavigateResult(url=url, dom_json="{}", node_count=0, error=str(exc))
+
+        try:
+            import aiohttp
+
+            async with (
+                aiohttp.ClientSession() as session,
+                session.ws_connect(ws_url) as ws,
+            ):
+                await self._extractor._send_command(  # noqa: SLF001
+                    ws, "Page.navigate", {"url": url}
+                )
+                # Wait briefly for the page to settle, then extract DOM.
+                await asyncio.sleep(0.5)
+                root = await self._extractor.extract_dom(page_index=page_index)
+        except Exception as exc:
+            log.warning("BrowserContextRunner: navigate to %r failed: %s", url, exc)
+            return NavigateResult(url=url, dom_json="{}", node_count=0, error=str(exc))
+
+        dom_json = dom_to_json(root)
+        return NavigateResult(url=url, dom_json=dom_json, node_count=root.node_count())
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _require_active(self) -> None:
+        if not self._active or self._extractor is None:
+            msg = "BrowserContextRunner has not been started (call start() first)"
+            raise RuntimeError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _node_needs_browser(node: NodeModel) -> bool:
+    """Return ``True`` when *node* declares the ``browser`` capability."""
+    reqs = getattr(node, "capability_requirements", None)
+    if reqs is None:
+        return False
+    # capability_requirements may be a list, set, or comma-separated string.
+    if isinstance(reqs, str):
+        return BROWSER_CAPABILITY in {r.strip() for r in reqs.split(",")}
+    return BROWSER_CAPABILITY in reqs
+
+
+@asynccontextmanager
+async def browser_session_for_node(
+    node: NodeModel,
+    cdp_url: str = DEFAULT_CDP_URL,
+) -> AsyncIterator[BrowserContextRunner | None]:
+    """Async context manager that yields an active :class:`BrowserContextRunner`
+    when *node* requires the ``browser`` capability, or ``None`` otherwise.
+
+    Example::
+
+        async with browser_session_for_node(node) as browser:
+            if browser is not None:
+                dom = await browser.snapshot_dom()
+    """
+    runner = BrowserContextRunner.for_node(node, cdp_url=cdp_url)
+    if runner is None:
+        yield None
+        return
+    async with runner:
+        yield runner

--- a/tests/test_browser_context.py
+++ b/tests/test_browser_context.py
@@ -1,0 +1,184 @@
+"""Tests for BrowserContextRunner — Phase 10, Issue #418."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openbad.toolbelt.mcp_bridge.browser_context import (
+    BROWSER_CAPABILITY,
+    BrowserCapabilities,
+    BrowserContextRunner,
+    _node_needs_browser,
+    browser_session_for_node,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_node(*, has_browser: bool = True, cap_list: list | None = None) -> MagicMock:
+    node = MagicMock()
+    node.node_id = "node-test"
+    if cap_list is not None:
+        node.capability_requirements = cap_list
+    elif has_browser:
+        node.capability_requirements = [BROWSER_CAPABILITY]
+    else:
+        node.capability_requirements = []
+    return node
+
+
+# ---------------------------------------------------------------------------
+# _node_needs_browser
+# ---------------------------------------------------------------------------
+
+
+class TestNodeNeedsBrowser:
+    def test_returns_true_when_browser_in_list(self) -> None:
+        node = _make_node(has_browser=True)
+        assert _node_needs_browser(node) is True
+
+    def test_returns_false_when_no_browser(self) -> None:
+        node = _make_node(has_browser=False)
+        assert _node_needs_browser(node) is False
+
+    def test_returns_true_with_string_capabilities(self) -> None:
+        node = _make_node()
+        node.capability_requirements = "browser, web"
+        assert _node_needs_browser(node) is True
+
+    def test_returns_false_with_string_no_browser(self) -> None:
+        node = _make_node()
+        node.capability_requirements = "compute, llm"
+        assert _node_needs_browser(node) is False
+
+    def test_returns_false_when_no_attribute(self) -> None:
+        node = MagicMock(spec=[])
+        assert _node_needs_browser(node) is False
+
+
+# ---------------------------------------------------------------------------
+# BrowserContextRunner.for_node
+# ---------------------------------------------------------------------------
+
+
+class TestForNode:
+    def test_returns_runner_for_browser_node(self) -> None:
+        node = _make_node(has_browser=True)
+        runner = BrowserContextRunner.for_node(node)
+        assert runner is not None
+        assert isinstance(runner, BrowserContextRunner)
+
+    def test_returns_none_for_non_browser_node(self) -> None:
+        node = _make_node(has_browser=False)
+        runner = BrowserContextRunner.for_node(node)
+        assert runner is None
+
+
+# ---------------------------------------------------------------------------
+# Start / stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_starts_and_becomes_active(self) -> None:
+        runner = BrowserContextRunner(node_id="n1")
+        assert runner.is_active is False
+        await runner.start()
+        assert runner.is_active is True
+        await runner.stop()
+
+    @pytest.mark.asyncio
+    async def test_stops_and_becomes_inactive(self) -> None:
+        runner = BrowserContextRunner(node_id="n2")
+        await runner.start()
+        await runner.stop()
+        assert runner.is_active is False
+
+    @pytest.mark.asyncio
+    async def test_context_manager_start_stop(self) -> None:
+        node = _make_node(has_browser=True)
+        runner = BrowserContextRunner.for_node(node)
+        assert runner is not None
+        async with runner as ctx:
+            assert ctx.is_active is True
+        assert runner.is_active is False
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self) -> None:
+        runner = BrowserContextRunner(node_id="n3")
+        await runner.start()
+        await runner.start()  # second call should be a no-op
+        assert runner.is_active is True
+        await runner.stop()
+
+
+# ---------------------------------------------------------------------------
+# Capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    @pytest.mark.asyncio
+    async def test_capabilities_contains_cdp_url(self) -> None:
+        runner = BrowserContextRunner(cdp_url="http://localhost:9222", node_id="n4")
+        caps = runner.capabilities()
+        assert isinstance(caps, BrowserCapabilities)
+        assert caps.cdp_url == "http://localhost:9222"
+
+    @pytest.mark.asyncio
+    async def test_capabilities_includes_expected_features(self) -> None:
+        runner = BrowserContextRunner(node_id="n5")
+        caps = runner.capabilities()
+        assert "dom_snapshot" in caps.features
+        assert "navigate" in caps.features
+
+
+# ---------------------------------------------------------------------------
+# snapshot_dom / snapshot_dom_json
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotDom:
+    @pytest.mark.asyncio
+    async def test_raises_if_not_active(self) -> None:
+        runner = BrowserContextRunner(node_id="n6")
+        with pytest.raises(RuntimeError, match="not been started"):
+            await runner.snapshot_dom()
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_cdp_extractor(self) -> None:
+        runner = BrowserContextRunner(node_id="n7")
+        await runner.start()
+        fake_root = MagicMock()
+        with patch.object(
+            runner._extractor, "extract_dom", new_callable=AsyncMock, return_value=fake_root
+        ):
+            root = await runner.snapshot_dom()
+        assert root is fake_root
+        await runner.stop()
+
+
+# ---------------------------------------------------------------------------
+# Non-browser node does not start browser
+# ---------------------------------------------------------------------------
+
+
+class TestNonBrowserNode:
+    @pytest.mark.asyncio
+    async def test_browser_session_for_non_browser_node_yields_none(self) -> None:
+        node = _make_node(has_browser=False)
+        async with browser_session_for_node(node) as ctx:
+            assert ctx is None
+
+    @pytest.mark.asyncio
+    async def test_browser_session_for_browser_node_yields_runner(self) -> None:
+        node = _make_node(has_browser=True)
+        async with browser_session_for_node(node) as ctx:
+            assert ctx is not None
+            assert ctx.is_active is True
+        assert ctx.is_active is False


### PR DESCRIPTION
Closes #418

## Summary

Creates `src/openbad/toolbelt/mcp_bridge/browser_context.py` — a task-node–scoped wrapper around `CDPExtractor`. A `BrowserContextRunner` is only provisioned for nodes with the `browser` capability tag and is fully torn down after the node completes (success or failure). Sessions are never shared across nodes.

Exposes `snapshot_dom()`, `snapshot_dom_json()`, and `navigate()` as the CDP interface through the MCP bridge. The `browser_session_for_node()` async context manager provides ergonomic scoped access.

## Changes

- `src/openbad/toolbelt/mcp_bridge/browser_context.py` — new `BrowserContextRunner`, `browser_session_for_node()`, `_node_needs_browser()`
- `tests/test_browser_context.py` — 17 tests covering all lifecycle and capability scenarios

## How to test

```bash
pytest tests/test_browser_context.py -q
```