### PR TITLE
#419: Add interoceptive governor for MCP bridge launches

### DIFF
--- a/src/openbad/toolbelt/mcp_bridge/mcp_governor.py
+++ b/src/openbad/toolbelt/mcp_bridge/mcp_governor.py
@@ -1,0 +1,192 @@
+"""Interoceptive governor for MCP bridge launches — Phase 10, Issue #419.
+
+Before an isolated MCP bridge is started, this module queries the
+interoception layer (:mod:`openbad.interoception.monitor`) for current
+RAM and CPU states.  If system limits are breached the governor:
+
+1. Refuses the MCP launch and returns :attr:`GovernorDecision.DEFERRED`.
+2. Publishes an endocrine hormone event on the nervous system bus:
+   - **CRITICAL** priority → Adrenaline (urgent, short burst).
+   - Otherwise → Cortisol (sustained high-load signal).
+
+Thresholds are configurable at construction time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from openbad.interoception.monitor import CpuSnapshot, MemorySnapshot, collect_cpu, collect_memory
+from openbad.nervous_system import topics
+from openbad.tasks.models import TaskPriority
+
+if TYPE_CHECKING:
+    from openbad.nervous_system.client import NervousSystemClient
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configurable defaults
+# ---------------------------------------------------------------------------
+
+#: RAM usage % above which MCP launch is deferred.
+DEFAULT_RAM_THRESHOLD_PCT: float = 90.0
+
+#: CPU usage % above which MCP launch is deferred.
+DEFAULT_CPU_THRESHOLD_PCT: float = 95.0
+
+
+# ---------------------------------------------------------------------------
+# Public API types
+# ---------------------------------------------------------------------------
+
+
+class GovernorDecision(StrEnum):
+    """Outcome of a :class:`McpGovernor` resource check."""
+
+    ALLOW = "allow"
+    DEFERRED = "deferred"
+
+
+@dataclass(frozen=True)
+class GovernorResult:
+    """Result of :meth:`McpGovernor.check`.
+
+    Attributes
+    ----------
+    decision:
+        :attr:`GovernorDecision.ALLOW` or :attr:`GovernorDecision.DEFERRED`.
+    reason:
+        Human-readable explanation (empty string on ALLOW).
+    cpu_snapshot:
+        The :class:`~openbad.interoception.monitor.CpuSnapshot` used.
+    memory_snapshot:
+        The :class:`~openbad.interoception.monitor.MemorySnapshot` used.
+    """
+
+    decision: GovernorDecision
+    reason: str
+    cpu_snapshot: CpuSnapshot
+    memory_snapshot: MemorySnapshot
+
+
+# ---------------------------------------------------------------------------
+# Governor class
+# ---------------------------------------------------------------------------
+
+
+class McpGovernor:
+    """Resource gate for MCP bridge launches.
+
+    Parameters
+    ----------
+    mqtt:
+        Live :class:`~openbad.nervous_system.client.NervousSystemClient`.
+        When ``None``, endocrine events are not published (useful in tests).
+    ram_threshold_pct:
+        RAM usage percentage ceiling; above this the launch is deferred.
+    cpu_threshold_pct:
+        CPU usage percentage ceiling; above this the launch is deferred.
+    cpu_collector:
+        Callable that returns a :class:`CpuSnapshot`.  Defaults to
+        :func:`~openbad.interoception.monitor.collect_cpu`.
+    memory_collector:
+        Callable that returns a :class:`MemorySnapshot`.  Defaults to
+        :func:`~openbad.interoception.monitor.collect_memory`.
+    """
+
+    def __init__(
+        self,
+        mqtt: NervousSystemClient | None = None,
+        *,
+        ram_threshold_pct: float = DEFAULT_RAM_THRESHOLD_PCT,
+        cpu_threshold_pct: float = DEFAULT_CPU_THRESHOLD_PCT,
+        cpu_collector=collect_cpu,      # noqa: ANN001
+        memory_collector=collect_memory,  # noqa: ANN001
+    ) -> None:
+        self._mqtt = mqtt
+        self._ram_threshold = ram_threshold_pct
+        self._cpu_threshold = cpu_threshold_pct
+        self._cpu_collector = cpu_collector
+        self._memory_collector = memory_collector
+
+    def check(self, *, task_priority: int = TaskPriority.NORMAL) -> GovernorResult:
+        """Check current resource state and decide whether to allow an MCP launch.
+
+        Parameters
+        ----------
+        task_priority:
+            Priority of the requesting task node.  Use
+            :class:`~openbad.tasks.models.TaskPriority` constants.
+
+        Returns
+        -------
+        GovernorResult
+            Contains :attr:`GovernorDecision.ALLOW` or
+            :attr:`GovernorDecision.DEFERRED` plus snapshots.
+        """
+        cpu = self._cpu_collector()
+        mem = self._memory_collector()
+
+        breach_reasons: list[str] = []
+
+        if mem.usage_percent >= self._ram_threshold:
+            breach_reasons.append(
+                f"RAM {mem.usage_percent:.1f}% ≥ threshold {self._ram_threshold:.1f}%"
+            )
+
+        if cpu.usage_percent >= self._cpu_threshold:
+            breach_reasons.append(
+                f"CPU {cpu.usage_percent:.1f}% ≥ threshold {self._cpu_threshold:.1f}%"
+            )
+
+        if not breach_reasons:
+            return GovernorResult(
+                decision=GovernorDecision.ALLOW,
+                reason="",
+                cpu_snapshot=cpu,
+                memory_snapshot=mem,
+            )
+
+        reason = "; ".join(breach_reasons)
+        log.warning("McpGovernor: deferring MCP launch — %s", reason)
+
+        self._publish_endocrine(task_priority, reason)
+
+        return GovernorResult(
+            decision=GovernorDecision.DEFERRED,
+            reason=reason,
+            cpu_snapshot=cpu,
+            memory_snapshot=mem,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _publish_endocrine(self, task_priority: int, reason: str) -> None:
+        """Publish an Adrenaline or Cortisol event depending on priority."""
+        if self._mqtt is None:
+            return
+
+        is_critical = task_priority >= int(TaskPriority.CRITICAL)
+        topic = topics.ENDOCRINE_ADRENALINE if is_critical else topics.ENDOCRINE_CORTISOL
+        hormone = "adrenaline" if is_critical else "cortisol"
+
+        payload = json.dumps(
+            {
+                "trigger": "mcp_resource_breach",
+                "hormone": hormone,
+                "reason": reason,
+            }
+        ).encode()
+
+        try:
+            self._mqtt.publish_bytes(topic, payload)
+            log.info("McpGovernor: published %s event (priority=%d)", hormone, task_priority)
+        except Exception:
+            log.exception("McpGovernor: could not publish endocrine event")

--- a/tests/test_mcp_governor.py
+++ b/tests/test_mcp_governor.py
@@ -1,0 +1,172 @@
+"""Tests for McpGovernor — Phase 10, Issue #419."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from openbad.interoception.monitor import CpuSnapshot, MemorySnapshot
+from openbad.nervous_system import topics
+from openbad.tasks.models import TaskPriority
+from openbad.toolbelt.mcp_bridge.mcp_governor import (
+    DEFAULT_CPU_THRESHOLD_PCT,
+    DEFAULT_RAM_THRESHOLD_PCT,
+    GovernorDecision,
+    McpGovernor,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cpu(usage: float = 10.0) -> CpuSnapshot:
+    return CpuSnapshot(
+        usage_percent=usage,
+        system_percent=2.0,
+        user_percent=8.0,
+        core_count=4,
+        load_avg_1m=0.5,
+    )
+
+
+def _mem(usage: float = 50.0) -> MemorySnapshot:
+    total = 8 * 1024**3  # 8 GiB
+    used = int(total * usage / 100)
+    return MemorySnapshot(
+        usage_percent=usage,
+        used_bytes=used,
+        total_bytes=total,
+        available_bytes=total - used,
+        swap_percent=0.0,
+    )
+
+
+def _governor(
+    *,
+    ram: float = 50.0,
+    cpu: float = 10.0,
+    mqtt: MagicMock | None = None,
+    ram_threshold: float = DEFAULT_RAM_THRESHOLD_PCT,
+    cpu_threshold: float = DEFAULT_CPU_THRESHOLD_PCT,
+) -> McpGovernor:
+    return McpGovernor(
+        mqtt=mqtt,
+        ram_threshold_pct=ram_threshold,
+        cpu_threshold_pct=cpu_threshold,
+        cpu_collector=lambda: _cpu(cpu),
+        memory_collector=lambda: _mem(ram),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Healthy system
+# ---------------------------------------------------------------------------
+
+
+class TestHealthySystem:
+    def test_allows_launch_when_resources_healthy(self) -> None:
+        gov = _governor(ram=50.0, cpu=20.0)
+        result = gov.check()
+        assert result.decision == GovernorDecision.ALLOW
+
+    def test_no_endocrine_event_on_allow(self) -> None:
+        mqtt = MagicMock()
+        gov = _governor(ram=30.0, cpu=15.0, mqtt=mqtt)
+        gov.check()
+        mqtt.publish_bytes.assert_not_called()
+
+    def test_allow_result_has_empty_reason(self) -> None:
+        gov = _governor(ram=50.0, cpu=30.0)
+        result = gov.check()
+        assert result.reason == ""
+
+
+# ---------------------------------------------------------------------------
+# RAM saturation
+# ---------------------------------------------------------------------------
+
+
+class TestRamSaturation:
+    def test_defers_when_ram_at_threshold(self) -> None:
+        gov = _governor(ram=DEFAULT_RAM_THRESHOLD_PCT, cpu=10.0)
+        result = gov.check()
+        assert result.decision == GovernorDecision.DEFERRED
+
+    def test_defers_when_ram_above_threshold(self) -> None:
+        gov = _governor(ram=95.0, cpu=10.0)
+        result = gov.check()
+        assert result.decision == GovernorDecision.DEFERRED
+
+    def test_deferred_reason_mentions_ram(self) -> None:
+        gov = _governor(ram=92.0, cpu=10.0)
+        result = gov.check()
+        assert "RAM" in result.reason
+
+    def test_non_critical_triggers_cortisol(self) -> None:
+        mqtt = MagicMock()
+        gov = _governor(ram=92.0, cpu=10.0, mqtt=mqtt)
+        gov.check(task_priority=TaskPriority.NORMAL)
+        mqtt.publish_bytes.assert_called_once()
+        topic_arg = mqtt.publish_bytes.call_args[0][0]
+        assert topic_arg == topics.ENDOCRINE_CORTISOL
+
+
+# ---------------------------------------------------------------------------
+# CPU saturation
+# ---------------------------------------------------------------------------
+
+
+class TestCpuSaturation:
+    def test_defers_when_cpu_at_threshold(self) -> None:
+        gov = _governor(ram=50.0, cpu=DEFAULT_CPU_THRESHOLD_PCT)
+        result = gov.check()
+        assert result.decision == GovernorDecision.DEFERRED
+
+    def test_deferred_reason_mentions_cpu(self) -> None:
+        gov = _governor(ram=50.0, cpu=98.0)
+        result = gov.check()
+        assert "CPU" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL priority → Adrenaline
+# ---------------------------------------------------------------------------
+
+
+class TestCriticalPriority:
+    def test_critical_triggers_adrenaline(self) -> None:
+        mqtt = MagicMock()
+        gov = _governor(ram=92.0, cpu=10.0, mqtt=mqtt)
+        gov.check(task_priority=TaskPriority.CRITICAL)
+        mqtt.publish_bytes.assert_called_once()
+        topic_arg = mqtt.publish_bytes.call_args[0][0]
+        assert topic_arg == topics.ENDOCRINE_ADRENALINE
+
+    def test_adrenaline_not_triggered_on_allow(self) -> None:
+        mqtt = MagicMock()
+        gov = _governor(ram=50.0, cpu=10.0, mqtt=mqtt)
+        gov.check(task_priority=TaskPriority.CRITICAL)
+        mqtt.publish_bytes.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Miscellaneous
+# ---------------------------------------------------------------------------
+
+
+class TestGovernorMisc:
+    def test_no_mqtt_does_not_raise(self) -> None:
+        gov = _governor(ram=95.0, cpu=10.0, mqtt=None)
+        result = gov.check()
+        assert result.decision == GovernorDecision.DEFERRED
+
+    def test_result_includes_snapshots(self) -> None:
+        gov = _governor(ram=60.0, cpu=20.0)
+        result = gov.check()
+        assert isinstance(result.cpu_snapshot, CpuSnapshot)
+        assert isinstance(result.memory_snapshot, MemorySnapshot)
+
+    def test_custom_thresholds_respected(self) -> None:
+        gov = _governor(ram=75.0, cpu=10.0, ram_threshold=70.0)
+        result = gov.check()
+        assert result.decision == GovernorDecision.DEFERRED


### PR DESCRIPTION
Closes #419

## Summary

Creates `src/openbad/toolbelt/mcp_bridge/mcp_governor.py` — an interoceptive resource gate that runs before every MCP bridge launch.

`McpGovernor.check()` samples current CPU and RAM usage via `collect_cpu()` / `collect_memory()`. If either breaches a configurable threshold:
- Returns `GovernorDecision.DEFERRED` (caller should set the node to `DEFERRED_RESOURCES`)
- **CRITICAL priority** → publishes `ENDOCRINE_ADRENALINE` event
- **Normal priority** → publishes `ENDOCRINE_CORTISOL` event

Healthy resources → `GovernorDecision.ALLOW` with no endocrine event.

## Changes

- `src/openbad/toolbelt/mcp_bridge/mcp_governor.py` — new `McpGovernor`, `GovernorDecision`, `GovernorResult`
- `tests/test_mcp_governor.py` — 14 tests covering all decision paths

## How to test

```bash
pytest tests/test_mcp_governor.py -q
```