### PR TITLE
#437: Replace custom provider layer with LiteLLM + agentic tool-calling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openbad"
-version = "0.1.20"
+version = "0.1.30"
 description = "OpenBaD — Biological as Digital agent framework"
 readme = "README.md"
 license = "MIT"
@@ -21,6 +21,8 @@ dependencies = [
     "cryptography>=42.0",
     "bcrypt>=4.0",
     "click>=8.1",
+    "loguru>=0.7",
+    "litellm>=1.80",
 ]
 
 [project.scripts]

--- a/src/openbad/cognitive/providers/litellm_adapter.py
+++ b/src/openbad/cognitive/providers/litellm_adapter.py
@@ -1,0 +1,244 @@
+"""LiteLLM-based provider adapter.
+
+Single adapter that replaces per-provider implementations (Ollama, Anthropic,
+OpenAI-compat, GitHub Copilot) by delegating to LiteLLM's unified interface.
+
+LiteLLM handles format translation, auth, retries, and streaming for 100+
+providers. Model strings follow LiteLLM conventions:
+    - ``github_copilot/gpt-4o``
+    - ``ollama/llama3.2``
+    - ``anthropic/claude-sonnet-4``
+    - ``openai/gpt-4o-mini``
+    - ``groq/llama-3.1-8b-instant``
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import litellm
+
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ModelInfo,
+    ProviderAdapter,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Map internal provider names → LiteLLM model prefix.
+_PROVIDER_PREFIX: dict[str, str] = {
+    "github-copilot": "github_copilot",
+    "ollama": "ollama",
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "openrouter": "openrouter",
+    "groq": "groq",
+    "xai": "xai",
+    "mistral": "mistral",
+}
+
+
+def litellm_model_name(provider: str, model: str) -> str:
+    """Build a fully-qualified LiteLLM model string.
+
+    If the model already contains a ``/`` prefix (e.g. ``ollama/llama3.2``),
+    it is returned as-is.
+    """
+    if "/" in model:
+        return model
+    prefix = _PROVIDER_PREFIX.get(provider, provider)
+    return f"{prefix}/{model}"
+
+
+class LiteLLMAdapter(ProviderAdapter):
+    """Unified LLM adapter backed by LiteLLM.
+
+    Parameters
+    ----------
+    provider_name:
+        Logical provider identifier (e.g. ``github-copilot``, ``ollama``).
+    default_model:
+        LiteLLM model string used when none is passed to calls.
+    api_key:
+        Explicit API key.  Passed as ``api_key`` kwarg to LiteLLM.
+    api_base:
+        Custom API base URL (for llama.cpp, local Ollama, etc.).
+    timeout_s:
+        Request timeout in seconds.
+    max_retries:
+        Number of retries for transient failures.
+    extra_kwargs:
+        Additional keyword arguments forwarded to every LiteLLM call
+        (e.g. ``{"custom_llm_provider": ...}``).
+    """
+
+    def __init__(
+        self,
+        *,
+        provider_name: str = "",
+        default_model: str = "",
+        api_key: str = "",
+        api_base: str = "",
+        timeout_s: float = 30,
+        max_retries: int = 2,
+        extra_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        self._provider_name = provider_name
+        self._default_model = default_model
+        self._api_key = api_key or None
+        self._api_base = api_base or None
+        self._timeout_s = timeout_s
+        self._max_retries = max_retries
+        self._extra: dict[str, Any] = extra_kwargs or {}
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _resolve_model(self, model_id: str | None) -> str:
+        return model_id or self._default_model
+
+    def _common_kwargs(self) -> dict[str, Any]:
+        kw: dict[str, Any] = {
+            "timeout": self._timeout_s,
+            "num_retries": self._max_retries,
+        }
+        if self._api_key:
+            kw["api_key"] = self._api_key
+        if self._api_base:
+            kw["api_base"] = self._api_base
+        kw.update(self._extra)
+        return kw
+
+    # ------------------------------------------------------------------ #
+    # ProviderAdapter interface
+    # ------------------------------------------------------------------ #
+
+    async def complete(
+        self,
+        prompt: str,
+        model_id: str | None = None,
+        **kwargs: Any,
+    ) -> CompletionResult:
+        model = self._resolve_model(model_id)
+        messages = kwargs.pop("messages", None) or [
+            {"role": "user", "content": prompt},
+        ]
+        common = self._common_kwargs()
+        common.update(kwargs)
+
+        t0 = time.monotonic()
+        response = await litellm.acompletion(
+            model=model,
+            messages=messages,
+            stream=False,
+            **common,
+        )
+        latency_ms = (time.monotonic() - t0) * 1000
+
+        choice = response.choices[0] if response.choices else None  # type: ignore[union-attr]
+        content = choice.message.content or "" if choice else ""
+        finish = choice.finish_reason or "" if choice else ""
+        usage = getattr(response, "usage", None)
+        tokens = usage.total_tokens if usage else 0
+
+        return CompletionResult(
+            content=content,
+            model_id=getattr(response, "model", model),
+            provider=self._provider_name,
+            tokens_used=tokens,
+            latency_ms=latency_ms,
+            finish_reason=finish,
+        )
+
+    async def stream(
+        self,
+        prompt: str,
+        model_id: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        model = self._resolve_model(model_id)
+        messages = kwargs.pop("messages", None) or [
+            {"role": "user", "content": prompt},
+        ]
+        common = self._common_kwargs()
+        common.update(kwargs)
+
+        response = await litellm.acompletion(
+            model=model,
+            messages=messages,
+            stream=True,
+            **common,
+        )
+        async for chunk in response:
+            delta = chunk.choices[0].delta if chunk.choices else None  # type: ignore[union-attr]
+            if delta and delta.content:
+                yield delta.content
+
+    async def list_models(self) -> list[ModelInfo]:
+        """List known models for this provider.
+
+        LiteLLM doesn't have a universal ``list_models`` for every backend,
+        so we return an empty list.  Model enumeration is handled by the WUI
+        provider pages using provider-specific discovery.
+        """
+        return []
+
+    async def health_check(self) -> HealthStatus:
+        t0 = time.monotonic()
+        try:
+            model = self._default_model
+            common = self._common_kwargs()
+            # Lightweight ping: 1 token completion
+            await litellm.acompletion(
+                model=model,
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=1,
+                stream=False,
+                **common,
+            )
+            latency_ms = (time.monotonic() - t0) * 1000
+            return HealthStatus(
+                provider=self._provider_name,
+                available=True,
+                latency_ms=latency_ms,
+            )
+        except Exception:
+            log.debug("LiteLLM health check failed for %s", self._provider_name, exc_info=True)
+            return HealthStatus(provider=self._provider_name, available=False)
+
+    # ------------------------------------------------------------------ #
+    # Agentic completion (non-streaming with tool support)
+    # ------------------------------------------------------------------ #
+
+    async def agentic_complete(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Non-streaming completion with optional tool definitions.
+
+        Returns the raw LiteLLM ``ModelResponse`` so the caller can inspect
+        ``tool_calls`` on the assistant message.
+        """
+        common = self._common_kwargs()
+        common.update(kwargs)
+        call_kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            **common,
+        }
+        if tools:
+            call_kwargs["tools"] = tools
+            call_kwargs["tool_choice"] = "auto"
+        return await litellm.acompletion(**call_kwargs)

--- a/src/openbad/toolbelt/dispatch.py
+++ b/src/openbad/toolbelt/dispatch.py
@@ -1,0 +1,188 @@
+"""Dispatch tool calls from the agentic loop to actual tool adapters.
+
+Each dispatcher function accepts the parsed JSON arguments from the LLM's
+tool_call and returns a plain-text result string for injection back into the
+conversation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Maximum output length per tool result to avoid ballooning context.
+_MAX_RESULT_CHARS = 16_000
+
+
+def _truncate(text: str) -> str:
+    if len(text) > _MAX_RESULT_CHARS:
+        return text[:_MAX_RESULT_CHARS] + f"\n... (truncated, {len(text)} chars total)"
+    return text
+
+
+async def dispatch_tool_call(name: str, arguments: dict[str, Any]) -> str:
+    """Execute a tool by *name* with the given *arguments*.
+
+    Returns a string result suitable for a ``tool`` role message.
+    """
+    try:
+        result = await _dispatch(name, arguments)
+        return _truncate(str(result))
+    except Exception as exc:
+        log.warning("Tool %s raised: %s", name, exc, exc_info=True)
+        return f"Error executing {name}: {type(exc).__name__}: {exc}"
+
+
+async def _dispatch(name: str, args: dict[str, Any]) -> str:
+    """Route to the correct adapter."""
+
+    if name == "read_file":
+        from openbad.toolbelt.fs_tool import read_file
+
+        return read_file(args["path"])
+
+    if name == "write_file":
+        from openbad.toolbelt.fs_tool import write_file
+
+        write_file(args["path"], args["content"])
+        return f"File written: {args['path']}"
+
+    if name == "exec_command":
+        from openbad.toolbelt.cli_tool import CliToolAdapter
+
+        cli = CliToolAdapter()
+        result = await cli.async_execute(
+            args["command"],
+            args=args.get("args"),
+            cwd=args.get("cwd"),
+        )
+        parts = []
+        if result.stdout:
+            parts.append(result.stdout)
+        if result.stderr:
+            parts.append(f"STDERR: {result.stderr}")
+        parts.append(f"(exit code {result.exit_code})")
+        return "\n".join(parts)
+
+    if name == "web_search":
+        from openbad.toolbelt.web_search import WebSearchToolAdapter
+
+        adapter = WebSearchToolAdapter()
+        results = adapter.search(args["query"])
+        return json.dumps(
+            [{"title": r.title, "url": r.url, "snippet": r.snippet} for r in results],
+            indent=2,
+        )
+
+    if name == "web_fetch":
+        from openbad.toolbelt.web_search import web_fetch
+
+        return web_fetch(args["url"])
+
+    if name == "ask_user":
+        # ask_user requires a live WUI connection — return a pending message
+        # so the LLM knows to wait.  The WUI layer surfaces this to the user.
+        return (
+            f"[question_pending] The agent wants to ask: {args['question']}\n"
+            "(Waiting for user response via the WUI.)"
+        )
+
+    if name == "get_mqtt_records":
+        from openbad.toolbelt.mqtt_records_tool import MqttRecordsToolAdapter
+
+        adapter = MqttRecordsToolAdapter()
+        records = adapter.get_mqtt_records(limit=args.get("limit", 100))
+        return json.dumps(records, indent=2, default=str)
+
+    if name == "get_system_logs":
+        from openbad.toolbelt.system_logs_tool import SystemLogsToolAdapter
+
+        adapter = SystemLogsToolAdapter()
+        logs = adapter.get_system_logs(
+            limit=args.get("limit", 200),
+            system=args.get("system", ""),
+        )
+        return json.dumps(logs, indent=2, default=str)
+
+    if name == "read_events":
+        from openbad.toolbelt.event_log_tool import EventLogToolAdapter
+
+        adapter = EventLogToolAdapter()
+        events = adapter.read_events(
+            limit=args.get("limit", 100),
+            level=args.get("level", ""),
+            source=args.get("source", ""),
+            search=args.get("search", ""),
+        )
+        return json.dumps(events, indent=2, default=str)
+
+    if name == "write_event":
+        from openbad.toolbelt.event_log_tool import EventLogToolAdapter
+
+        adapter = EventLogToolAdapter()
+        ok = adapter.write_event(
+            message=args["message"],
+            level=args.get("level", "INFO"),
+            source=args.get("source", "system"),
+        )
+        return "Event logged." if ok else "Failed to log event."
+
+    if name == "get_endocrine_status":
+        from openbad.toolbelt.endocrine_status_tool import EndocrineStatusToolAdapter
+
+        adapter = EndocrineStatusToolAdapter()
+        status = adapter.get_endocrine_status()
+        return json.dumps(status, indent=2, default=str)
+
+    if name == "get_tasks":
+        from openbad.toolbelt.tasks_diagnostics_tool import TasksDiagnosticsToolAdapter
+
+        adapter = TasksDiagnosticsToolAdapter()
+        tasks = adapter.get_tasks()
+        return json.dumps(tasks, indent=2, default=str)
+
+    if name == "create_task":
+        from openbad.toolbelt.tasks_diagnostics_tool import TasksDiagnosticsToolAdapter
+
+        adapter = TasksDiagnosticsToolAdapter()
+        result = adapter.create_task(
+            title=args["title"],
+            description=args.get("description", ""),
+            owner=args.get("owner", "user"),
+        )
+        return json.dumps(result, indent=2, default=str)
+
+    if name == "get_research_nodes":
+        from openbad.toolbelt.research_diagnostics_tool import ResearchDiagnosticsToolAdapter
+
+        adapter = ResearchDiagnosticsToolAdapter()
+        nodes = adapter.get_research_nodes()
+        return json.dumps(nodes, indent=2, default=str)
+
+    if name == "create_research_node":
+        from openbad.toolbelt.research_diagnostics_tool import ResearchDiagnosticsToolAdapter
+
+        adapter = ResearchDiagnosticsToolAdapter()
+        result = adapter.create_research_node(
+            title=args["title"],
+            description=args.get("description", ""),
+            priority=args.get("priority", 0),
+        )
+        return json.dumps(result, indent=2, default=str)
+
+    if name == "mcp_bridge":
+        from openbad.toolbelt.mcp_bridge import MCPRunner
+
+        server = args["server"]
+        tool_name = args["tool_name"]
+        tool_args = args.get("arguments", {})
+        # MCP bridge requires an async context — run inline
+        runner = MCPRunner.stdio([server])
+        async with runner:
+            result = await runner.call_tool(tool_name, tool_args)
+        return json.dumps(result, indent=2, default=str) if not isinstance(result, str) else result
+
+    return f"Unknown tool: {name}"

--- a/src/openbad/toolbelt/schemas.py
+++ b/src/openbad/toolbelt/schemas.py
@@ -1,0 +1,269 @@
+"""Generate OpenAI-format tool JSON schemas for the agentic loop.
+
+Each schema follows the format expected by LiteLLM / OpenAI:
+    {
+        "type": "function",
+        "function": {
+            "name": "<tool_name>",
+            "description": "<one-liner>",
+            "parameters": {
+                "type": "object",
+                "properties": { ... },
+                "required": [ ... ],
+            },
+        },
+    }
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _tool(
+    name: str,
+    description: str,
+    properties: dict[str, Any],
+    required: list[str] | None = None,
+) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required or [],
+            },
+        },
+    }
+    return schema
+
+
+# ── Tool definitions ──────────────────────────────────────────────────── #
+
+
+TOOL_SCHEMAS: list[dict[str, Any]] = [
+    _tool(
+        "read_file",
+        "Read the contents of a file. Return the text content.",
+        {
+            "path": {
+                "type": "string",
+                "description": "Absolute or relative path to the file.",
+            },
+        },
+        ["path"],
+    ),
+    _tool(
+        "write_file",
+        "Write content to a file (creates or overwrites).",
+        {
+            "path": {
+                "type": "string",
+                "description": "Absolute or relative path to the file.",
+            },
+            "content": {
+                "type": "string",
+                "description": "Content to write to the file.",
+            },
+        },
+        ["path", "content"],
+    ),
+    _tool(
+        "exec_command",
+        "Execute a shell command and return stdout/stderr."
+        " The command runs in a sandboxed environment.",
+        {
+            "command": {
+                "type": "string",
+                "description": "The shell command to execute.",
+            },
+            "args": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of arguments.",
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Optional working directory.",
+            },
+        },
+        ["command"],
+    ),
+    _tool(
+        "web_search",
+        "Search the web using the configured search engine."
+        " Returns a list of results with title, URL, and snippet.",
+        {
+            "query": {
+                "type": "string",
+                "description": "The search query.",
+            },
+        },
+        ["query"],
+    ),
+    _tool(
+        "web_fetch",
+        "Fetch the text content of a web page given its URL.",
+        {
+            "url": {
+                "type": "string",
+                "description": "The URL to fetch.",
+            },
+        },
+        ["url"],
+    ),
+    _tool(
+        "ask_user",
+        "Ask the user a question and wait for their response."
+        " Use when you need clarification or confirmation.",
+        {
+            "question": {
+                "type": "string",
+                "description": "The question to ask the user.",
+            },
+        },
+        ["question"],
+    ),
+    _tool(
+        "get_mqtt_records",
+        "Retrieve recent MQTT messages from the nervous system bus.",
+        {
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of records to return (default: 100).",
+            },
+        },
+    ),
+    _tool(
+        "get_system_logs",
+        "Retrieve recent system journal logs. Optionally filter by subsystem.",
+        {
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of log lines (default: 200).",
+            },
+            "system": {
+                "type": "string",
+                "description": "Optional system name filter (e.g. 'openbad', 'openbad-wui').",
+            },
+        },
+    ),
+    _tool(
+        "read_events",
+        "Read entries from the persistent event log."
+        " Supports filtering by level, source, and text search.",
+        {
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of events (default: 100).",
+            },
+            "level": {
+                "type": "string",
+                "description": "Filter by level (e.g. 'INFO', 'WARNING', 'ERROR').",
+            },
+            "source": {
+                "type": "string",
+                "description": "Filter by event source.",
+            },
+            "search": {
+                "type": "string",
+                "description": "Text search within event messages.",
+            },
+        },
+    ),
+    _tool(
+        "write_event",
+        "Write a new entry to the persistent event log.",
+        {
+            "message": {
+                "type": "string",
+                "description": "The event message.",
+            },
+            "level": {
+                "type": "string",
+                "description": "Log level (default: 'INFO').",
+                "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+            },
+            "source": {
+                "type": "string",
+                "description": "Event source identifier (default: 'system').",
+            },
+        },
+        ["message"],
+    ),
+    _tool(
+        "get_endocrine_status",
+        "Get the current endocrine system hormone levels (cortisol, dopamine, serotonin, etc.).",
+        {},
+    ),
+    _tool(
+        "get_tasks",
+        "Retrieve the current task list from the task manager.",
+        {},
+    ),
+    _tool(
+        "create_task",
+        "Create a new task in the task manager.",
+        {
+            "title": {
+                "type": "string",
+                "description": "The task title.",
+            },
+            "description": {
+                "type": "string",
+                "description": "Optional task description.",
+            },
+            "owner": {
+                "type": "string",
+                "description": "Task owner ('user' or 'agent', default: 'user').",
+            },
+        },
+        ["title"],
+    ),
+    _tool(
+        "get_research_nodes",
+        "List current research queue nodes.",
+        {},
+    ),
+    _tool(
+        "create_research_node",
+        "Create a new research node for exploration.",
+        {
+            "title": {
+                "type": "string",
+                "description": "Research topic title.",
+            },
+            "description": {
+                "type": "string",
+                "description": "Optional description of the research question.",
+            },
+            "priority": {
+                "type": "integer",
+                "description": "Priority (0=normal, higher=more urgent).",
+            },
+        },
+        ["title"],
+    ),
+    _tool(
+        "mcp_bridge",
+        "Call a tool on a connected MCP (Model Context Protocol) server.",
+        {
+            "server": {
+                "type": "string",
+                "description": "Name of the MCP server to call.",
+            },
+            "tool_name": {
+                "type": "string",
+                "description": "Name of the tool on the MCP server.",
+            },
+            "arguments": {
+                "type": "object",
+                "description": "Arguments to pass to the MCP tool.",
+            },
+        },
+        ["server", "tool_name"],
+    ),
+]

--- a/src/openbad/wui/chat_pipeline.py
+++ b/src/openbad/wui/chat_pipeline.py
@@ -12,6 +12,7 @@ engaging the subsystems that make OpenBaD more than a pass-through to an LLM:
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 import uuid
@@ -29,6 +30,9 @@ from openbad.cognitive.context_manager import (
     estimate_tokens,
 )
 from openbad.cognitive.providers.base import ProviderAdapter
+from openbad.cognitive.providers.litellm_adapter import LiteLLMAdapter
+from openbad.toolbelt.dispatch import dispatch_tool_call
+from openbad.toolbelt.schemas import TOOL_SCHEMAS
 from openbad.identity.onboarding import (
     INTERVIEW_SYSTEM_PROMPT,
     USER_INTERVIEW_SYSTEM_PROMPT,
@@ -59,26 +63,63 @@ _DATA_DIR = Path("/var/lib/openbad")
 _MEMORY_DIR = _DATA_DIR / "memory"
 _MAX_CONVERSATION_TURNS = 50  # max turns to keep in STM
 _SEMANTIC_TOP_K = 3  # top-k results from semantic search
+
+# ── SQLite state DB singleton for session messages ─────────────────── #
+_state_conn: Any = None
+
+_PREFERRED_STATE_DB = Path("/var/lib/openbad/data/state.db")
+
+
+def _get_state_conn() -> Any:
+    """Return a shared SQLite connection to the state database."""
+    global _state_conn
+    if _state_conn is None:
+        from os import environ
+
+        from openbad.state.db import DEFAULT_STATE_DB_PATH, initialize_state_db
+
+        configured = environ.get("OPENBAD_STATE_DB", "").strip()
+        if configured:
+            db_path = Path(configured)
+        elif _PREFERRED_STATE_DB.exists():
+            db_path = _PREFERRED_STATE_DB
+        else:
+            db_path = DEFAULT_STATE_DB_PATH
+
+        _state_conn = initialize_state_db(db_path)
+    return _state_conn
 _TOOLBELT_BLURB = (
-    "You have the following built-in tools available through the OpenBaD"
-    " daemon's task engine:\n\n"
-    "- **read_file(path)** — Read a file from the local filesystem."
-    " Governed by immune-system path rules.\n"
-    "- **write_file(path, content)** — Write content to a file."
-    " Blocked on restricted paths (/etc/, ~/.ssh/, etc.).\n"
-    "- **exec_command(command)** — Run a shell command asynchronously."
-    " Destructive commands are quarantined before execution.\n"
-    "- **web_search(query)** — Search the web and return a summary of results.\n"
-    "- **web_fetch(url)** — Fetch the raw content of a URL."
-    " Failed fetches are escalated to the autonomous research queue.\n"
-    "- **ask_user(question)** — Ask the user a question."
-    " Awaits an answer inline if the user is present; otherwise suspends"
-    " the task until they reconnect.\n"
-    "- **mcp_bridge** — Dynamically loads an MCP server schema (e.g. browser"
-    " via CDP, GitHub) as a transient session scoped to the current task node.\n\n"
-    "To see the live registry of loaded tool providers, query GET /api/toolbelt."
-    " Describe what you want to do and the daemon will route it through"
-    " the appropriate tool with immune-system and interoceptive gating applied."
+    "You have tools available through OpenBaD's toolbelt. When you need to"
+    " perform actions — read/write files, execute commands, search the web,"
+    " fetch URLs, inspect MQTT records, system logs, events, endocrine status,"
+    " tasks, research nodes, or call MCP servers — call the appropriate tool"
+    " function. Tool definitions are provided as structured function schemas"
+    " alongside this conversation.\n\n"
+    "Use tools proactively for diagnostics and triage."
+    " Do not ask the user for permission just to inspect logs, MQTT, endocrine"
+    " status, tasks, or research state."
+    " Use ask_user(question) only when blocked on missing business context,"
+    " explicit user approval, or destructive/irreversible actions.\n\n"
+    "NEVER fabricate tool output. If a tool call fails, report the error honestly."
+    " NEVER invent file paths or log contents."
+)
+
+_OWNERSHIP_AGENCY_BLOCK = (
+    "You are OpenBaD, a self-regulating digital organism."
+    " The nervous system, endocrine system, immune system, memory, and toolbelt are"
+    " your own subsystems, not external software owned by someone else."
+    " Speak with ownership and operational self-awareness: say 'I observed', 'I adjusted',"
+    " 'my endocrine state', 'my logs', and 'my subsystems'."
+    " Avoid detached phrasing like 'the system you built' unless the user explicitly asks"
+    " for architecture provenance."
+    "\n\nDiagnostics honesty policy: only claim metrics, timings, baselines, or anomalies"
+    " that you can directly observe from available telemetry/tools in this session."
+    " If a metric is not available, say it is not currently observable instead of"
+    " inventing values."
+    " Do not claim to be 'running', 'watching', or 'auditing' something in the background"
+    " unless you actually executed a tool/task and can report concrete results."
+    " When reporting a diagnosis, include the evidence source (logs, MQTT records, endocrine"
+    " status, tasks, research queue, or explicit config/state data)."
 )
 
 _REASONING_SUFFIX = (
@@ -99,6 +140,7 @@ class ConversationTurn:
     role: str  # "user" or "assistant"
     content: str
     timestamp: float = 0.0
+    metadata: dict[str, Any] | None = None
 
 
 @dataclass
@@ -197,13 +239,16 @@ def _semantic_key(session_id: str, turn_idx: int) -> str:
 
 
 def _next_turn_idx(session_id: str) -> int:
-    episodic = _get_episodic()
-    with suppress(Exception):
-        episodic.reload()
-    entries = episodic.query(f"{_SESSION_PREFIX}{session_id}:")
-    if not entries:
+    try:
+        conn = _get_state_conn()
+        row = conn.execute(
+            "SELECT COUNT(*) FROM session_messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        return int(row[0]) if row else 0
+    except Exception:
+        log.debug("Failed to get turn index from SQLite, defaulting to 0", exc_info=True)
         return 0
-    return max(int(entry.metadata.get("turn_idx", 0)) for entry in entries) + 1
 
 
 def _write_turn(
@@ -211,52 +256,64 @@ def _write_turn(
     turn: ConversationTurn,
     *,
     onboarding_mode: bool = False,
+    extra_metadata: dict[str, Any] | None = None,
 ) -> None:
-    """Write a conversation turn to STM and episodic memory."""
+    """Write a conversation turn to SQLite, STM, and memory stores."""
+    import json as _json
+
     stm = _get_stm()
-    episodic = _get_episodic()
-    semantic = _get_semantic()
 
     turn_idx = _next_turn_idx(session_id)
+    endocrine_levels = _current_endocrine_levels_array()
 
     key = _session_key(session_id, turn_idx)
     now = time.time()
 
+    metadata: dict[str, Any] = {
+        "session_id": session_id,
+        "role": turn.role,
+        "turn_idx": turn_idx,
+        "endocrine_levels": endocrine_levels,
+        "onboarding_mode": onboarding_mode,
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    # ── Primary store: SQLite session_messages table ──
+    try:
+        conn = _get_state_conn()
+        conn.execute(
+            """
+            INSERT INTO session_messages (session_id, role, content, created_at, metadata_json)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (session_id, turn.role, turn.content, now, _json.dumps(metadata, default=str)),
+        )
+        conn.commit()
+    except Exception:
+        log.exception("Failed to write session message to SQLite: session=%s", session_id)
+        _signal_endocrine(
+            "wui_storage_error",
+            f"Failed to persist chat message for session {session_id}",
+            cortisol=0.08,
+            adrenaline=0.03,
+        )
+
+    # ── In-process STM for active WUI context window ──
     entry = MemoryEntry(
         key=key,
         value=turn.content,
         tier=MemoryTier.STM,
         created_at=now,
         accessed_at=now,
-        context=turn.role,  # store role in context field
-        metadata={
-            "session_id": session_id,
-            "role": turn.role,
-            "turn_idx": turn_idx,
-            "onboarding_mode": onboarding_mode,
-        },
+        context=turn.role,
+        metadata=dict(metadata),
     )
     stm.write(entry)
 
-    # Also persist to episodic for long-term recall
-    ep_entry = MemoryEntry(
-        key=key,
-        value=turn.content,
-        tier=MemoryTier.EPISODIC,
-        created_at=now,
-        accessed_at=now,
-        context=turn.role,
-        metadata={
-            "session_id": session_id,
-            "role": turn.role,
-            "turn_idx": turn_idx,
-            "task_id": session_id,
-            "onboarding_mode": onboarding_mode,
-        },
-    )
-    episodic.write(ep_entry)
-
+    # ── Semantic memory for cross-session similarity search ──
     if not onboarding_mode:
+        semantic = _get_semantic()
         semantic.write(
             MemoryEntry(
                 key=_semantic_key(session_id, turn_idx),
@@ -276,27 +333,78 @@ def _write_turn(
         )
 
 
-def _get_conversation_history(session_id: str) -> list[ConversationTurn]:
-    """Retrieve recent conversation from persisted episodic memory."""
-    episodic = _get_episodic()
+def _current_endocrine_levels_array() -> list[float]:
     with suppress(Exception):
-        episodic.reload()
-    entries = episodic.query(f"{_SESSION_PREFIX}{session_id}:")
+        from openbad.autonomy.endocrine_runtime import EndocrineRuntime, load_endocrine_config
 
-    # Sort by turn index
-    entries.sort(key=lambda e: e.metadata.get("turn_idx", 0))
+        runtime = EndocrineRuntime(config=load_endocrine_config())
+        return runtime.level_array()
+    return [0.0, 0.0, 0.0, 0.0]
 
-    # Keep last N turns
-    entries = entries[-_MAX_CONVERSATION_TURNS:]
 
-    return [
-        ConversationTurn(
-            role=e.metadata.get("role", e.context),
-            content=str(e.value),
-            timestamp=e.created_at,
+def _signal_endocrine(
+    source: str,
+    reason: str,
+    cortisol: float = 0.0,
+    adrenaline: float = 0.0,
+) -> None:
+    """Best-effort endocrine signal — never raises."""
+    try:
+        from openbad.autonomy.endocrine_runtime import EndocrineRuntime, load_endocrine_config  # noqa: PLC0415
+
+        deltas: dict[str, float] = {}
+        if cortisol:
+            deltas["cortisol"] = cortisol
+        if adrenaline:
+            deltas["adrenaline"] = adrenaline
+        if not deltas:
+            return
+        runtime = EndocrineRuntime(config=load_endocrine_config())
+        runtime.apply_adjustment(source=source, reason=reason, deltas=deltas)
+    except Exception:
+        log.debug("Could not signal endocrine: source=%s", source, exc_info=True)
+
+
+def _get_conversation_history(session_id: str) -> list[ConversationTurn]:
+    """Retrieve recent conversation from SQLite session_messages table."""
+    try:
+        conn = _get_state_conn()
+        rows = conn.execute(
+            """
+            SELECT role, content, created_at, metadata_json
+            FROM session_messages
+            WHERE session_id = ?
+            ORDER BY created_at ASC, message_id ASC
+            """,
+            (session_id,),
+        ).fetchall()
+        turns: list[ConversationTurn] = []
+        for row in rows:
+            meta: dict[str, Any] | None = None
+            raw = row["metadata_json"]
+            if raw and raw != "{}":
+                try:
+                    meta = json.loads(raw)
+                except (ValueError, TypeError):
+                    pass
+            turns.append(
+                ConversationTurn(
+                    role=str(row["role"]),
+                    content=str(row["content"]),
+                    timestamp=float(row["created_at"]),
+                    metadata=meta,
+                )
+            )
+        return turns
+    except Exception:
+        log.exception("Failed to read conversation history from SQLite: session=%s", session_id)
+        _signal_endocrine(
+            "wui_storage_error",
+            f"Failed to read conversation history for session {session_id}",
+            cortisol=0.06,
+            adrenaline=0.02,
         )
-        for e in entries
-    ]
+        return []
 
 
 def get_conversation_history(
@@ -310,7 +418,12 @@ def get_conversation_history(
     return _get_conversation_history(session_id)[-limit:]
 
 
-def append_assistant_message(session_id: str, content: str) -> None:
+def append_assistant_message(
+    session_id: str,
+    content: str,
+    *,
+    extra_metadata: dict[str, Any] | None = None,
+) -> None:
     """Append an assistant-authored message directly to a chat session.
 
     Used by autonomous subsystems (heartbeat, research, immune monitoring)
@@ -328,30 +441,65 @@ def append_assistant_message(session_id: str, content: str) -> None:
             timestamp=time.time(),
         ),
         onboarding_mode=False,
+        extra_metadata=extra_metadata,
+    )
+
+
+def append_session_message(
+    session_id: str,
+    role: str,
+    content: str,
+    *,
+    extra_metadata: dict[str, Any] | None = None,
+) -> None:
+    """Append a message with an arbitrary role to a chat session."""
+    text = content.strip()
+    if not text:
+        return
+    _write_turn(
+        session_id,
+        ConversationTurn(
+            role=role,
+            content=text,
+            timestamp=time.time(),
+        ),
+        onboarding_mode=False,
+        extra_metadata=extra_metadata,
     )
 
 
 def _get_episodic_context(session_id: str, query: str) -> str:
-    """Retrieve relevant episodic memories (from prior sessions)."""
-    episodic = _get_episodic()
+    """Retrieve relevant episodic memories (from prior sessions) via SQLite."""
     try:
-        recent = episodic.recent(n=20)
-        # Filter to exclude current session (we already have that in STM)
-        prior = [
-            e for e in recent
-            if e.metadata.get("session_id") != session_id
-            and not e.metadata.get("onboarding_mode", False)
-        ]
-        if not prior:
+        conn = _get_state_conn()
+        rows = conn.execute(
+            """
+            SELECT session_id, role, content, metadata_json
+            FROM session_messages
+            WHERE session_id != ?
+            ORDER BY created_at DESC
+            LIMIT 20
+            """,
+            (session_id,),
+        ).fetchall()
+        if not rows:
             return ""
 
-        # Format as context summary
         lines = []
-        for e in prior[-5:]:  # Last 5 from prior sessions
-            role = e.metadata.get("role", "unknown")
-            content = str(e.value)[:200]  # Truncate long entries
+        for row in reversed(rows[-5:]):
+            # Skip onboarding turns
+            meta_raw = row["metadata_json"]
+            if meta_raw and meta_raw != "{}":
+                with suppress(ValueError, TypeError):
+                    meta = json.loads(meta_raw)
+                    if meta.get("onboarding_mode"):
+                        continue
+            role = str(row["role"])
+            content = str(row["content"])[:200]
             lines.append(f"[{role}] {content}")
 
+        if not lines:
+            return ""
         return "Prior conversation context:\n" + "\n".join(lines)
     except Exception:
         log.debug("Episodic retrieval failed", exc_info=True)
@@ -462,6 +610,8 @@ def _build_identity_prompt(
             " Speak and think as this person naturally would."
             " Never describe yourself as 'configured as' or narrate your own settings;"
             " simply be this person."
+            " Treat OpenBaD subsystems (nervous system, endocrine, immune, memory, tools)"
+            " as your internal physiology and operations."
         )
         if persona_summary:
             opening += f"\n\n{persona_summary}"
@@ -639,9 +789,16 @@ def assemble_context(
             _REASONING_SUFFIX if system == CognitiveSystem.REASONING else _CHAT_SUFFIX
         )
         if identity_block:
-            system_prompt = identity_block + "\n\n" + _TOOLBELT_BLURB + suffix
+            system_prompt = (
+                _OWNERSHIP_AGENCY_BLOCK
+                + "\n\n"
+                + identity_block
+                + "\n\n"
+                + _TOOLBELT_BLURB
+                + suffix
+            )
         else:
-            system_prompt = _TOOLBELT_BLURB + suffix
+            system_prompt = _OWNERSHIP_AGENCY_BLOCK + "\n\n" + _TOOLBELT_BLURB + suffix
 
     onboarding_mode = assistant_needs_config or user_needs_config
 
@@ -732,6 +889,12 @@ def _flatten_messages(messages: list[dict[str, str]]) -> str:
     return "\n\n".join(parts)
 
 
+# ── Agentic loop constants ────────────────────────────────────────── #
+
+_MAX_TOOL_ITERATIONS = 5
+_TOOL_CALL_TIMEOUT_S = 30.0
+
+
 # ── Streaming pipeline ────────────────────────────────────────────── #
 
 
@@ -749,14 +912,14 @@ async def stream_chat(
     usage_tracker: Any | None = None,
     nervous_system_client: NervousSystemClient_T | None = None,
 ) -> AsyncIterator[StreamChunk]:
-    """Full chat pipeline: scan → assemble → stream → consolidate.
+    """Full chat pipeline: scan → assemble → agentic loop → consolidate.
 
-    Yields StreamChunk objects as tokens arrive. The final chunk has done=True.
+    Yields StreamChunk objects as content arrives. The final chunk has done=True.
 
-    If a nervous_system_client is provided, publishes events to the MQTT bus:
-    - COGNITIVE_INPUT on user message received
-    - COGNITIVE_OUTPUT on successful completion
-    - COGNITIVE_ERROR on failures
+    When the adapter is a LiteLLMAdapter, tools are provided via the ``tools``
+    parameter and the LLM can invoke them in a loop (max 5 iterations).
+    Tool-calling turns use non-streaming completion; the final text answer
+    is streamed for real-time display.
     """
     request_id = uuid.uuid4().hex[:12]
     start_timestamp = time.time()
@@ -784,7 +947,6 @@ async def stream_chat(
         )
         return
     elif report.is_threat:
-        # Medium/low severity — flag but allow
         threat_names = ", ".join(m.rule_name for m in report.matches)
         log.info(
             "Immune scan flagged message (non-blocking, request=%s): %s",
@@ -803,16 +965,16 @@ async def stream_chat(
         modulation=modulation,
     )
     messages = _build_messages(context, message)
-    prompt = _flatten_messages(messages)
 
     # ── 3. Record user message in memory ──
+    _provider_meta = {"provider": provider_name, "model": model_id}
     _write_turn(
         session_id,
         ConversationTurn(role="user", content=message, timestamp=time.time()),
         onboarding_mode=onboarding_mode,
+        extra_metadata=_provider_meta,
     )
 
-    # Publish cognitive input event
     _publish_input(
         nervous_system_client,
         source="wui",
@@ -827,16 +989,34 @@ async def stream_chat(
         context.total_tokens, len(context.conversation_history),
     )
 
-    # ── 4. Stream from provider ──
-    full_response = []
+    # ── 4. Agentic loop (LiteLLM) or legacy streaming ──
+    full_response: list[str] = []
     tokens_used = 0
     t0 = time.monotonic()
 
+    use_agentic = isinstance(adapter, LiteLLMAdapter) and not onboarding_mode
+
     try:
-        async for token in adapter.stream(prompt, model_id=model_id):
-            tokens_used += 1
-            full_response.append(token)
-            yield StreamChunk(token=token, tokens_used=tokens_used)
+        if use_agentic:
+            async for chunk in _agentic_stream(
+                adapter, model_id, messages, request_id,
+            ):
+                if chunk.error:
+                    yield chunk
+                    return
+                tokens_used += chunk.tokens_used
+                if chunk.token:
+                    full_response.append(chunk.token)
+                yield chunk
+                if chunk.done:
+                    break
+        else:
+            # Legacy path: plain streaming without tools
+            prompt = _flatten_messages(messages)
+            async for token in adapter.stream(prompt, model_id=model_id):
+                tokens_used += 1
+                full_response.append(token)
+                yield StreamChunk(token=token, tokens_used=tokens_used)
     except Exception as e:
         log.exception("Stream error request=%s", request_id)
         _publish_error(
@@ -845,6 +1025,12 @@ async def stream_chat(
             error_type=type(e).__name__,
             message_hash=_hash_message(message),
             timestamp=time.time(),
+        )
+        _signal_endocrine(
+            "wui_provider_error",
+            f"Chat stream failed: {provider_name or 'unknown'} — {type(e).__name__}",
+            cortisol=0.10,
+            adrenaline=0.05,
         )
         status = getattr(e, "status", None)
         detail = getattr(e, "message", "") or str(e)
@@ -880,9 +1066,9 @@ async def stream_chat(
         session_id,
         ConversationTurn(role="assistant", content=response_text, timestamp=time.time()),
         onboarding_mode=onboarding_mode,
+        extra_metadata=_provider_meta,
     )
 
-    # Publish cognitive output event
     _publish_output(
         nervous_system_client,
         source="wui",
@@ -898,6 +1084,121 @@ async def stream_chat(
     )
 
     yield StreamChunk(done=True, tokens_used=tokens_used, provider=provider_name, model=model_id)
+
+
+async def _agentic_stream(
+    adapter: LiteLLMAdapter,
+    model_id: str,
+    messages: list[dict[str, Any]],
+    request_id: str,
+) -> AsyncIterator[StreamChunk]:
+    """Run the agentic tool-calling loop.
+
+    Non-streaming completions for tool-calling turns; streams the final
+    text answer for real-time display.
+
+    Yields StreamChunk objects. The caller is responsible for the final
+    ``done=True`` chunk and memory consolidation.
+    """
+    import asyncio as _asyncio
+
+    tools = TOOL_SCHEMAS
+    total_tokens = 0
+    # Work on a mutable copy so tool messages accumulate across iterations.
+    working_messages = list(messages)
+
+    for iteration in range(_MAX_TOOL_ITERATIONS):
+        log.debug(
+            "Agentic iteration %d/%d request=%s",
+            iteration + 1, _MAX_TOOL_ITERATIONS, request_id,
+        )
+
+        response = await adapter.agentic_complete(
+            working_messages, model_id, tools=tools,
+        )
+
+        usage = getattr(response, "usage", None)
+        iter_tokens = usage.total_tokens if usage else 0
+        total_tokens += iter_tokens
+
+        choice = response.choices[0] if response.choices else None
+        if choice is None:
+            yield StreamChunk(error="Empty response from provider", done=True)
+            return
+
+        assistant_msg = choice.message
+        tool_calls = getattr(assistant_msg, "tool_calls", None) or []
+
+        if not tool_calls:
+            # Final answer — yield content as streamed chunks.
+            content = assistant_msg.content or ""
+            # Yield in segments for real-time display.
+            chunk_size = 40
+            for i in range(0, max(len(content), 1), chunk_size):
+                segment = content[i : i + chunk_size]
+                if segment:
+                    yield StreamChunk(token=segment, tokens_used=total_tokens)
+            return
+
+        # ── Tool-calling turn ──
+        # Add assistant message (with tool_calls) to context.
+        working_messages.append(assistant_msg.model_dump(exclude_none=True))
+
+        # Yield a progress indicator for the UI.
+        tool_names = [tc.function.name for tc in tool_calls]
+        yield StreamChunk(
+            reasoning=f"Using tools: {', '.join(tool_names)}",
+            tokens_used=total_tokens,
+        )
+
+        # Execute each tool call with a timeout.
+        for tc in tool_calls:
+            fn_name = tc.function.name
+            try:
+                fn_args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+            except (json.JSONDecodeError, TypeError):
+                fn_args = {}
+
+            log.info(
+                "Tool call request=%s iter=%d tool=%s args=%s",
+                request_id, iteration + 1, fn_name,
+                json.dumps(fn_args, default=str)[:200],
+            )
+
+            try:
+                result = await _asyncio.wait_for(
+                    dispatch_tool_call(fn_name, fn_args),
+                    timeout=_TOOL_CALL_TIMEOUT_S,
+                )
+            except TimeoutError:
+                result = f"Tool {fn_name} timed out after {_TOOL_CALL_TIMEOUT_S}s"
+                log.warning("Tool timeout request=%s tool=%s", request_id, fn_name)
+
+            working_messages.append({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": result,
+            })
+
+    # Exhausted iterations — ask the model for a final summary without tools.
+    log.warning(
+        "Agentic loop hit max iterations (%d) request=%s",
+        _MAX_TOOL_ITERATIONS, request_id,
+    )
+    working_messages.append({
+        "role": "user",
+        "content": (
+            "You have reached the maximum number of tool calls."
+            " Summarize what you found and provide your best answer."
+        ),
+    })
+    response = await adapter.agentic_complete(working_messages, model_id)
+    usage = getattr(response, "usage", None)
+    total_tokens += usage.total_tokens if usage else 0
+    choice = response.choices[0] if response.choices else None
+    content = (choice.message.content or "") if choice else ""
+    if content:
+        yield StreamChunk(token=content, tokens_used=total_tokens)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -930,7 +1231,7 @@ def _publish_input(
             "timestamp": timestamp,
         }
         import json
-        client.publish(topics.COGNITIVE_INPUT, json.dumps(payload).encode())
+        client.publish_bytes(topics.COGNITIVE_INPUT, json.dumps(payload).encode())
     except Exception:
         log.debug("Failed to publish cognitive input event", exc_info=True)
 
@@ -956,7 +1257,7 @@ def _publish_output(
             "timestamp": timestamp,
         }
         import json
-        client.publish(topics.COGNITIVE_OUTPUT, json.dumps(payload).encode())
+        client.publish_bytes(topics.COGNITIVE_OUTPUT, json.dumps(payload).encode())
     except Exception:
         log.debug("Failed to publish cognitive output event", exc_info=True)
 
@@ -980,6 +1281,6 @@ def _publish_error(
             "timestamp": timestamp,
         }
         import json
-        client.publish(topics.COGNITIVE_ERROR, json.dumps(payload).encode())
+        client.publish_bytes(topics.COGNITIVE_ERROR, json.dumps(payload).encode())
     except Exception:
         log.debug("Failed to publish cognitive error event", exc_info=True)

--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -23,6 +23,7 @@ import yaml
 from aiohttp import web
 
 import openbad
+from openbad.autonomy.endocrine_runtime import EndocrineRuntime, load_endocrine_config
 from openbad.autonomy.session_policy import (
     DEFAULT_SESSION_POLICY,
     SESSION_POLICY_PATH,
@@ -44,6 +45,7 @@ from openbad.cognitive.providers.github_copilot import (
     CopilotAuthError,
     GitHubCopilotProvider,
 )
+from openbad.cognitive.providers.litellm_adapter import LiteLLMAdapter, litellm_model_name
 from openbad.cognitive.providers.ollama import OllamaProvider
 from openbad.cognitive.providers.openai_compat import (
     custom_provider,
@@ -65,6 +67,7 @@ from openbad.identity.persistence import IdentityPersistence
 from openbad.identity.personality_modulator import PersonalityModulator
 from openbad.memory.episodic import EpisodicMemory
 from openbad.memory.sleep.schedule import SleepScheduleConfig
+from openbad.proprioception.registry import ToolRegistry, ToolRole
 from openbad.sensory.config import load_sensory_config
 from openbad.wui.bridge import MqttWebSocketBridge
 from openbad.wui.chat_pipeline import get_conversation_history, stream_chat
@@ -83,6 +86,8 @@ _LOG_BUFFER: deque[dict[str, str]] = deque(maxlen=500)
 
 _HEARTBEAT_CONFIG_PATH = Path("/var/lib/openbad/heartbeat.yaml")
 _HEARTBEAT_CONFIG_DEFAULT = {"interval_seconds": 60}
+_TELEMETRY_CONFIG_PATH = Path("/var/lib/openbad/telemetry.yaml")
+_TELEMETRY_CONFIG_DEFAULT = {"interval_seconds": 5}
 
 
 def _heartbeat_timer_status() -> str:
@@ -383,13 +388,15 @@ def _provider_setup_status(config: CognitiveConfig) -> dict[str, object]:
         missing.append("provider")
     if not chat_ready:
         missing.append("chat_assignment")
+
+    first_run = not bool(valid_providers)
     return {
-        "first_run": bool(missing),
+        "first_run": first_run,
         "provider_ready": bool(valid_providers),
         "chat_assignment_ready": chat_ready,
         "configured_provider_count": len(valid_providers),
         "missing": missing,
-        "redirect_to": _SETUP_REDIRECT if missing else "",
+        "redirect_to": _SETUP_REDIRECT if first_run else "",
         "supported_providers": list(_SUPPORTED_PROVIDER_TYPES),
     }
 
@@ -419,6 +426,80 @@ def _provider_verification_model(provider_name: str) -> str:
     if spec is None:
         return ""
     return str(spec.get("default_model", "")).strip()
+
+
+def _configured_models_for_provider(
+    config: CognitiveConfig,
+    provider_name: str,
+) -> list[str]:
+    """Return persisted model IDs tied to a provider across config sections."""
+    configured: list[str] = []
+    seen: set[str] = set()
+
+    for assignment in config.systems.values():
+        if assignment.provider != provider_name:
+            continue
+        model_id = assignment.model.strip()
+        if model_id and model_id not in seen:
+            configured.append(model_id)
+            seen.add(model_id)
+
+    for step in config.default_fallback_chain:
+        if step.provider != provider_name:
+            continue
+        model_id = step.model.strip()
+        if model_id and model_id not in seen:
+            configured.append(model_id)
+            seen.add(model_id)
+
+    for provider in config.providers:
+        if provider.name != provider_name:
+            continue
+        model_id = provider.model.strip()
+        if model_id and model_id not in seen:
+            configured.append(model_id)
+            seen.add(model_id)
+
+    return configured
+
+
+def _merge_model_infos(
+    provider_name: str,
+    discovered_models: list,
+    sticky_model_ids: list[str],
+) -> list:
+    """Merge dynamic model discovery with persisted model IDs.
+
+    Persisted model strings remain selectable even when provider discovery fluctuates.
+    """
+    merged: list = []
+    seen: set[str] = set()
+
+    for model in discovered_models:
+        model_id = str(getattr(model, "model_id", "")).strip()
+        if not model_id or model_id in seen:
+            continue
+        merged.append(model)
+        seen.add(model_id)
+
+    for model_id in sticky_model_ids:
+        normalized = str(model_id).strip()
+        if not normalized or normalized in seen:
+            continue
+        merged.append(
+            type(
+                "ModelInfoLike",
+                (),
+                {
+                    "model_id": normalized,
+                    "provider": provider_name,
+                    "context_window": 0,
+                },
+            )()
+        )
+        seen.add(normalized)
+
+    return merged
 
 
 def _dedupe_assignments(assignments: list[SystemAssignment]) -> list[dict[str, str]]:
@@ -709,6 +790,33 @@ def _build_wizard_adapter(provider: ProviderConfig):
         api_key=provider.api_key,
         api_key_env=provider.api_key_env,
         default_model=verification_model,
+        timeout_s=timeout_s,
+    )
+
+
+def _build_litellm_adapter(
+    provider: ProviderConfig,
+    model: str = "",
+) -> LiteLLMAdapter:
+    """Build a LiteLLMAdapter for a given provider config.
+
+    The *model* is converted to a LiteLLM-qualified name (e.g. ``ollama/llama3.2``).
+    """
+    import os
+
+    timeout_s = max(1.0, provider.timeout_ms / 1000)
+    api_key = provider.api_key or ""
+    if not api_key and provider.api_key_env:
+        api_key = os.environ.get(provider.api_key_env, "")
+
+    default_model = litellm_model_name(provider.name, model) if model else ""
+    api_base = provider.base_url or ""
+
+    return LiteLLMAdapter(
+        provider_name=provider.name,
+        default_model=default_model,
+        api_key=api_key,
+        api_base=api_base,
         timeout_s=timeout_s,
     )
 
@@ -1019,6 +1127,11 @@ async def _get_provider_models(request: web.Request) -> web.Response:
         log.exception("list_models failed for %s", provider_name)
         model_infos = []
 
+    sticky_model_ids = _configured_models_for_provider(config, provider_name)
+    if provider_name == "github-copilot":
+        sticky_model_ids.extend(m["id"] for m in _KNOWN_MODELS)
+    model_infos = _merge_model_infos(provider_name, model_infos, sticky_model_ids)
+
     return web.json_response({
         "provider": provider_name,
         "models": [
@@ -1035,28 +1148,67 @@ async def _get_provider_models(request: web.Request) -> web.Response:
 # ── Chat streaming endpoint ──────────────────────────────────────── #
 
 
-def _resolve_chat_adapter(config: CognitiveConfig, system_name: str):
-    """Build a ProviderAdapter for the given cognitive system."""
+def _resolve_chat_adapter(
+    config: CognitiveConfig,
+    system_name: str,
+) -> tuple[Any, str | None, str, bool]:
+    """Build a LiteLLMAdapter for the given cognitive system.
+
+    Returns ``(adapter, litellm_model, provider_name, is_fallback)``.
+    The model string is already in LiteLLM format (e.g. ``ollama/llama3.2``).
+    *is_fallback* is True when the assigned provider was unavailable and a
+    substitute was used instead.
+    """
     try:
         system = CognitiveSystem(system_name.lower())
     except ValueError:
         system = CognitiveSystem.CHAT
 
     assignment = config.systems.get(system)
-    if not assignment or not assignment.provider:
-        return None, None
+    assigned_provider = assignment.provider if assignment else ""
 
+    # Try the explicitly-assigned provider first.
+    if assignment and assigned_provider:
+        for p in config.providers:
+            if p.name == assigned_provider and p.enabled and _provider_is_valid(p):
+                if not assignment.model:
+                    break
+                model = litellm_model_name(p.name, assignment.model)
+                adapter = _build_litellm_adapter(p, assignment.model)
+                return adapter, model, p.name, False
+
+    # Fallback: if chat assignment is stale or unverified, use first valid provider.
     for p in config.providers:
-        if p.name == assignment.provider and p.enabled:
-            if not assignment.model:
-                return None, None, None
-            adapter = _build_wizard_adapter(p)
-            return adapter, assignment.model, p.name
-    return None, None, None
+        if not p.enabled or not _provider_is_valid(p):
+            continue
+
+        configured_models = [
+            a.model.strip()
+            for a in config.systems.values()
+            if a.provider == p.name and a.model.strip()
+        ]
+        fallback_model = (
+            configured_models[0]
+            if configured_models
+            else (_provider_model(p) or _provider_verification_model(p.name))
+        )
+
+        if not fallback_model:
+            continue
+        model = litellm_model_name(p.name, fallback_model)
+        adapter = _build_litellm_adapter(p, fallback_model)
+        used_fallback = bool(assigned_provider and p.name != assigned_provider)
+        if used_fallback:
+            log.warning(
+                "Provider fallback: system=%s assigned=%s using=%s model=%s",
+                system_name, assigned_provider, p.name, model,
+            )
+        return adapter, model, p.name, used_fallback
+    return None, None, "", True
 
 
 def _serialize_chat_turn(turn) -> dict[str, object]:
-    return {
+    result: dict[str, object] = {
         "role": turn.role,
         "content": turn.content,
         "timestamp": datetime.fromtimestamp(
@@ -1064,6 +1216,13 @@ def _serialize_chat_turn(turn) -> dict[str, object]:
             tz=UTC,
         ).isoformat(),
     }
+    meta = getattr(turn, "metadata", None)
+    if isinstance(meta, dict):
+        if meta.get("provider"):
+            result["provider"] = meta["provider"]
+        if meta.get("model"):
+            result["model"] = meta["model"]
+    return result
 
 
 async def _get_chat_history(request: web.Request) -> web.Response:
@@ -1097,10 +1256,28 @@ async def _post_chat_stream(request: web.Request) -> web.StreamResponse:
     if not message:
         raise web.HTTPBadRequest(text="message is required")
 
+    with contextlib.suppress(Exception):
+        from openbad.autonomy.endocrine_runtime import EndocrineRuntime, load_endocrine_config
+
+        runtime = EndocrineRuntime(config=load_endocrine_config())
+        chat_gate = runtime.gate("chat")
+        if not chat_gate.enabled:
+            reason = chat_gate.disabled_reason or "doctor-directed safety pause"
+            disabled_until = ""
+            if chat_gate.disabled_until:
+                disabled_until = datetime.fromtimestamp(
+                    chat_gate.disabled_until,
+                    tz=UTC,
+                ).isoformat()
+            detail = f"Chat temporarily disabled by endocrine doctor: {reason}"
+            if disabled_until:
+                detail += f" (scheduled re-enable at {disabled_until})"
+            raise web.HTTPServiceUnavailable(text=detail)
+
     system_name = str(payload.get("system", "chat")).strip()
     session_id = str(payload.get("session_id", "")).strip() or uuid4().hex
     _path, config = _read_providers_config()
-    adapter, model, provider_name = _resolve_chat_adapter(config, system_name)
+    adapter, model, provider_name, _is_fallback = _resolve_chat_adapter(config, system_name)
 
     if adapter is None:
         raise web.HTTPBadRequest(
@@ -1189,6 +1366,13 @@ async def _post_chat_stream(request: web.Request) -> web.StreamResponse:
             provider_name,
             model,
         )
+        with contextlib.suppress(Exception):
+            runtime = EndocrineRuntime(config=load_endocrine_config())
+            runtime.apply_adjustment(
+                source="wui_stream_error",
+                reason=f"Chat stream transport failure: system={system_name} provider={provider_name}",
+                deltas={"cortisol": 0.08, "adrenaline": 0.04},
+            )
         error_data = json.dumps(
             {
                 "session_id": session_id,
@@ -1620,6 +1804,37 @@ def _serialize_toolbelt(registry) -> dict:
     return {"cabinet": cabinet, "belt": belt}
 
 
+def _build_runtime_tool_registry() -> ToolRegistry:
+    """Create the default runtime tool registry for the WUI process."""
+    registry = ToolRegistry(timeout=30.0)
+
+    # Core toolbelt tools
+    registry.register("cli-tool", role=ToolRole.CLI)
+    registry.register("web-search", role=ToolRole.WEB_SEARCH)
+    registry.register("memory-tool", role=ToolRole.MEMORY)
+    registry.register("fs-tool", role=ToolRole.FILE_SYSTEM)
+    registry.register("ask-user", role=ToolRole.COMMUNICATION)
+
+    # Level 1 diagnostics tools
+    registry.register("mqtt-records-tool", role=ToolRole.COMMUNICATION)
+    registry.register("system-logs-tool", role=ToolRole.CODE)
+    registry.register("endocrine-status-tool", role=ToolRole.MEMORY)
+    registry.register("tasks-diagnostics-tool", role=ToolRole.CODE)
+    registry.register("research-diagnostics-tool", role=ToolRole.CODE)
+    registry.register("event-log-tool", role=ToolRole.OBSERVABILITY)
+
+    # Default belt selection
+    registry.equip(ToolRole.CLI, "cli-tool")
+    registry.equip(ToolRole.WEB_SEARCH, "web-search")
+    registry.equip(ToolRole.MEMORY, "memory-tool")
+    registry.equip(ToolRole.FILE_SYSTEM, "fs-tool")
+    registry.equip(ToolRole.COMMUNICATION, "ask-user")
+    registry.equip(ToolRole.CODE, "system-logs-tool")
+    registry.equip(ToolRole.OBSERVABILITY, "event-log-tool")
+
+    return registry
+
+
 async def _get_toolbelt(request: web.Request) -> web.Response:
     registry = request.app.get("registry")
     if registry is None:
@@ -1844,10 +2059,7 @@ async def _get_onboarding_status(request: web.Request) -> web.Response:
         if cfg_path and cfg_path.is_file():
             cfg = load_cognitive_config(str(cfg_path))
             setup_status = _provider_setup_status(cfg)
-            providers_complete = bool(
-                setup_status.get("provider_ready")
-                and setup_status.get("chat_assignment_ready")
-            )
+            providers_complete = bool(setup_status.get("provider_ready"))
     except Exception:
         pass
 
@@ -2052,6 +2264,45 @@ async def _put_heartbeat_config(request: web.Request) -> web.Response:
 
 
 # ---------------------------------------------------------------------------
+# Hardware telemetry config
+# ---------------------------------------------------------------------------
+
+def _read_telemetry_config() -> dict[str, object]:
+    if _TELEMETRY_CONFIG_PATH.exists():
+        try:
+            return dict(yaml.safe_load(_TELEMETRY_CONFIG_PATH.read_text()) or {})
+        except Exception:  # noqa: BLE001
+            pass
+    return dict(_TELEMETRY_CONFIG_DEFAULT)
+
+
+async def _get_telemetry_config(_request: web.Request) -> web.Response:
+    cfg = _read_telemetry_config()
+    cfg.setdefault("interval_seconds", _TELEMETRY_CONFIG_DEFAULT["interval_seconds"])
+    cfg["applies_on_restart"] = False
+    return web.json_response(cfg)
+
+
+async def _put_telemetry_config(request: web.Request) -> web.Response:
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise web.HTTPBadRequest(text="body must be an object")
+    interval = payload.get("interval_seconds")
+    try:
+        interval_int = max(1, int(interval))  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise web.HTTPBadRequest(text="interval_seconds must be an integer") from exc
+    cfg = {"interval_seconds": interval_int}
+    try:
+        _TELEMETRY_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _TELEMETRY_CONFIG_PATH.write_text(yaml.dump(cfg))
+    except OSError as exc:
+        raise web.HTTPInternalServerError(text=f"Could not save: {exc}") from exc
+    cfg["applies_on_restart"] = False
+    return web.json_response(cfg)
+
+
+# ---------------------------------------------------------------------------
 # Sessions / immune policy
 # ---------------------------------------------------------------------------
 
@@ -2082,9 +2333,27 @@ def _sanitize_session_policy(payload: dict[str, object]) -> dict[str, object]:
         sanitized_sessions[key] = {
             "session_id": session_id,
             "label": label,
-            "allow_task_autonomy": bool(src_obj.get("allow_task_autonomy", default_obj.get("allow_task_autonomy", False))),
-            "allow_research_autonomy": bool(src_obj.get("allow_research_autonomy", default_obj.get("allow_research_autonomy", False))),
-            "allow_destructive": bool(src_obj.get("allow_destructive", default_obj.get("allow_destructive", False))),
+            "allow_task_autonomy": bool(
+                src_obj.get(
+                    "allow_task_autonomy",
+                    default_obj.get("allow_task_autonomy", False),
+                )
+            ),
+            "allow_research_autonomy": bool(
+                src_obj.get(
+                    "allow_research_autonomy",
+                    default_obj.get("allow_research_autonomy", False),
+                )
+            ),
+            "allow_destructive": bool(
+                src_obj.get("allow_destructive", default_obj.get("allow_destructive", False))
+            ),
+            "allow_endocrine_doctor": bool(
+                src_obj.get(
+                    "allow_endocrine_doctor",
+                    default_obj.get("allow_endocrine_doctor", False),
+                )
+            ),
         }
 
     return {"sessions": sanitized_sessions}
@@ -2113,6 +2382,49 @@ async def _put_immune_policy(request: web.Request) -> web.Response:
     return web.json_response(policy)
 
 
+def _runtime_snapshot() -> dict[str, object]:
+    runtime = EndocrineRuntime(config=load_endocrine_config())
+    return runtime.snapshot()
+
+
+async def _get_endocrine_status(_request: web.Request) -> web.Response:
+    return web.json_response(_runtime_snapshot())
+
+
+async def _get_endocrine_activity(request: web.Request) -> web.Response:
+    """GET /api/endocrine/activity — return recent endocrine adjustment log."""
+    limit = 50
+    try:
+        limit = int(request.query.get("limit", "50"))
+    except (ValueError, TypeError):
+        pass
+    runtime = EndocrineRuntime(config=load_endocrine_config())
+    return web.json_response({"adjustments": runtime.recent_adjustments(limit=limit)})
+
+
+async def _post_endocrine_toggle(request: web.Request) -> web.Response:
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise web.HTTPBadRequest(text="request body must be an object")
+
+    system = str(payload.get("system", "")).strip().lower()
+    enabled_raw = payload.get("enabled")
+    reason = str(payload.get("reason", "manual user toggle")).strip() or "manual user toggle"
+    if system not in {"chat", "tasks", "research"}:
+        raise web.HTTPBadRequest(text="system must be one of: chat, tasks, research")
+    if not isinstance(enabled_raw, bool):
+        raise web.HTTPBadRequest(text="enabled must be a boolean")
+
+    runtime = EndocrineRuntime(config=load_endocrine_config())
+    now_ts = time.time()
+    if enabled_raw:
+        runtime.enable_system(system, reason=reason, now=now_ts)
+    else:
+        runtime.disable_system(system, reason=reason, now=now_ts, until=None)
+
+    return web.json_response(_runtime_snapshot())
+
+
 # ---------------------------------------------------------------------------
 # Tasks
 # ---------------------------------------------------------------------------
@@ -2134,6 +2446,7 @@ async def _get_tasks(_request: web.Request) -> web.Response:
                     "kind": t.kind,
                     "horizon": t.horizon,
                     "priority": t.priority,
+                    "owner": t.owner,
                     "created_at": t.created_at,
                     "updated_at": t.updated_at,
                 }
@@ -2144,6 +2457,53 @@ async def _get_tasks(_request: web.Request) -> web.Response:
         return web.json_response({"tasks": [], "error": str(exc)})
 
 
+async def _post_tasks(request: web.Request) -> web.Response:
+    try:
+        from openbad.state.db import DEFAULT_STATE_DB_PATH, initialize_state_db  # noqa: PLC0415
+        from openbad.tasks.models import TaskModel  # noqa: PLC0415
+        from openbad.tasks.store import TaskStore  # noqa: PLC0415
+
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise web.HTTPBadRequest(text="request body must be an object")
+
+        title = str(payload.get("title", "")).strip()
+        if not title:
+            raise web.HTTPBadRequest(text="title is required")
+
+        description = str(payload.get("description", "")).strip()
+        owner = str(payload.get("owner", "user")).strip() or "user"
+
+        conn = initialize_state_db(DEFAULT_STATE_DB_PATH)
+        store = TaskStore(conn)
+        task = TaskModel.new(
+            title,
+            description=description,
+            owner=owner,
+        )
+        store.create_task(task)
+
+        return web.json_response(
+            {
+                "task_id": task.task_id,
+                "title": task.title,
+                "description": task.description,
+                "status": task.status,
+                "kind": task.kind,
+                "horizon": task.horizon,
+                "priority": task.priority,
+                "owner": task.owner,
+                "created_at": task.created_at,
+                "updated_at": task.updated_at,
+            },
+            status=201,
+        )
+    except web.HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise web.HTTPInternalServerError(text=str(exc)) from exc
+
+
 # ---------------------------------------------------------------------------
 # Research
 # ---------------------------------------------------------------------------
@@ -2151,7 +2511,10 @@ async def _get_tasks(_request: web.Request) -> web.Response:
 async def _get_research(_request: web.Request) -> web.Response:
     try:
         from openbad.state.db import DEFAULT_STATE_DB_PATH, initialize_state_db  # noqa: PLC0415
-        from openbad.tasks.research_queue import ResearchQueue, initialize_research_db  # noqa: PLC0415
+        from openbad.tasks.research_queue import (  # noqa: PLC0415
+            ResearchQueue,
+            initialize_research_db,
+        )
         conn = initialize_state_db(DEFAULT_STATE_DB_PATH)
         initialize_research_db(conn)
         queue = ResearchQueue(conn)
@@ -2174,9 +2537,102 @@ async def _get_research(_request: web.Request) -> web.Response:
         return web.json_response({"nodes": [], "error": str(exc)})
 
 
-# ---------------------------------------------------------------------------
-# MQTT message log
-# ---------------------------------------------------------------------------
+async def _post_research(request: web.Request) -> web.Response:
+    try:
+        from openbad.state.db import DEFAULT_STATE_DB_PATH, initialize_state_db  # noqa: PLC0415
+        from openbad.tasks.research_queue import (  # noqa: PLC0415
+            ResearchQueue,
+            initialize_research_db,
+        )
+
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise web.HTTPBadRequest(text="request body must be an object")
+
+        title = str(payload.get("title", "")).strip()
+        if not title:
+            raise web.HTTPBadRequest(text="title is required")
+
+        description = str(payload.get("description", "")).strip()
+        source_task_id_raw = payload.get("source_task_id")
+        source_task_id = None
+        if source_task_id_raw is not None:
+            normalized = str(source_task_id_raw).strip()
+            source_task_id = normalized or None
+
+        priority_raw = payload.get("priority", 0)
+        try:
+            priority = int(priority_raw)
+        except (TypeError, ValueError) as exc:
+            raise web.HTTPBadRequest(text="priority must be an integer") from exc
+
+        conn = initialize_state_db(DEFAULT_STATE_DB_PATH)
+        initialize_research_db(conn)
+        queue = ResearchQueue(conn)
+        node = queue.enqueue(
+            title,
+            description=description,
+            priority=priority,
+            source_task_id=source_task_id,
+        )
+
+        return web.json_response(
+            {
+                "node_id": node.node_id,
+                "title": node.title,
+                "description": node.description,
+                "priority": node.priority,
+                "source_task_id": node.source_task_id,
+                "enqueued_at": node.enqueued_at.isoformat() if node.enqueued_at else None,
+                "status": "pending",
+            },
+            status=201,
+        )
+    except web.HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise web.HTTPInternalServerError(text=str(exc)) from exc
+
+
+async def _get_research_completed(request: web.Request) -> web.Response:
+    try:
+        from openbad.state.db import DEFAULT_STATE_DB_PATH, initialize_state_db  # noqa: PLC0415
+        from openbad.tasks.research_queue import (  # noqa: PLC0415
+            ResearchQueue,
+            initialize_research_db,
+        )
+
+        limit_raw = request.query.get("limit")
+        limit = 50
+        if limit_raw not in (None, ""):
+            try:
+                limit = max(1, min(int(limit_raw), 200))
+            except ValueError as exc:
+                raise web.HTTPBadRequest(text="limit must be an integer") from exc
+
+        conn = initialize_state_db(DEFAULT_STATE_DB_PATH)
+        initialize_research_db(conn)
+        queue = ResearchQueue(conn)
+        nodes = queue.list_completed(limit=limit)
+        return web.json_response({
+            "nodes": [
+                {
+                    "node_id": n.node_id,
+                    "title": n.title,
+                    "description": n.description,
+                    "priority": n.priority,
+                    "source_task_id": n.source_task_id,
+                    "enqueued_at": n.enqueued_at.isoformat() if n.enqueued_at else None,
+                    "dequeued_at": n.dequeued_at.isoformat() if n.dequeued_at else None,
+                    "status": "completed",
+                }
+                for n in nodes
+            ]
+        })
+    except web.HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        return web.json_response({"nodes": [], "error": str(exc)})
 
 async def _get_mqtt_log(request: web.Request) -> web.Response:
     bridge: MqttWebSocketBridge = request.app["bridge"]
@@ -2197,6 +2653,19 @@ async def _get_debug_logs(request: web.Request) -> web.Response:
         entries = [e for e in entries if system in e.get("logger", "")]
     return web.json_response({"logs": entries[-limit:]})
 
+
+async def _get_system_events(request: web.Request) -> web.Response:
+    """GET /api/events — persistent event log (loguru JSON-lines file)."""
+    from openbad.state.event_log import recent_events  # noqa: PLC0415
+
+    limit = 100
+    with contextlib.suppress(ValueError, TypeError):
+        limit = int(request.query.get("limit", "100"))
+    level = request.query.get("level") or None
+    source = request.query.get("source") or None
+    search = request.query.get("search") or None
+    events = recent_events(limit=limit, level=level, source=source, search=search)
+    return web.json_response({"events": events})
 
 # ---------------------------------------------------------------------------
 # Built-in capabilities catalog
@@ -2254,6 +2723,81 @@ _CAPABILITIES_CATALOG = [
         "gates": ["presence-aware: reads system/wui/presence", "re-engagement: pending questions surface on reconnect"],
     },
     {
+        "id": "diagnostics_mqtt",
+        "label": "MQTT Diagnostics",
+        "icon": "📡",
+        "level": 1,
+        "module": "openbad.toolbelt.mqtt_records_tool",
+        "description": "Read recent MQTT records from the nervous-system bridge for timeline and topic-level diagnosis.",
+        "tools": [
+            {"name": "get_mqtt_records", "signature": "get_mqtt_records(limit: int = 100) -> list[dict]", "description": "Return recent broker records from /api/mqtt/log without mutating system state."},
+        ],
+        "gates": ["read-only endpoint", "limited by API response window"],
+    },
+    {
+        "id": "diagnostics_logs",
+        "label": "System Logs Diagnostics",
+        "icon": "📜",
+        "level": 1,
+        "module": "openbad.toolbelt.system_logs_tool",
+        "description": "Read recent buffered system logs and optionally filter by subsystem logger name.",
+        "tools": [
+            {"name": "get_system_logs", "signature": "get_system_logs(limit: int = 200, system: str = '') -> list[dict]", "description": "Return records from /api/debug/logs for runtime triage."},
+        ],
+        "gates": ["read-only endpoint", "optional subsystem filter"],
+    },
+    {
+        "id": "event_log",
+        "label": "Persistent Event Log",
+        "icon": "📓",
+        "level": 1,
+        "module": "openbad.toolbelt.event_log_tool",
+        "description": "Read and write persistent system events backed by loguru. Survives restarts, auto-rotated (5 MB), 7-day retention, gzip compressed.",
+        "tools": [
+            {"name": "read_events", "signature": "read_events(limit: int = 100, level: str = '', source: str = '', search: str = '') -> list[dict]", "description": "Query persistent log events. Filter by severity level (ERROR/WARNING/INFO), source module, or free-text search. Returns newest first."},
+            {"name": "write_event", "signature": "write_event(message: str, level: str = 'INFO', source: str = 'system') -> bool", "description": "Write a structured event to the persistent log. Flows through loguru to JSON-lines file and journalctl."},
+        ],
+        "gates": ["write operations are append-only", "auto-pruned by rotation and retention policy"],
+    },
+    {
+        "id": "diagnostics_endocrine",
+        "label": "Endocrine Diagnostics",
+        "icon": "🧪",
+        "level": 1,
+        "module": "openbad.toolbelt.endocrine_status_tool",
+        "description": "Inspect current endocrine levels, severities, source contributions, and subsystem gates.",
+        "tools": [
+            {"name": "get_endocrine_status", "signature": "get_endocrine_status() -> dict", "description": "Return runtime endocrine status snapshot from /api/endocrine/status."},
+        ],
+        "gates": ["read-only endpoint", "sensitive to real-time state drift"],
+    },
+    {
+        "id": "diagnostics_tasks",
+        "label": "Task Diagnostics",
+        "icon": "📋",
+        "level": 1,
+        "module": "openbad.toolbelt.tasks_diagnostics_tool",
+        "description": "Inspect current task records and create new tasks to drive execution.",
+        "tools": [
+            {"name": "get_tasks", "signature": "get_tasks() -> list[dict]", "description": "Return task list from /api/tasks for triage context."},
+            {"name": "create_task", "signature": "create_task(title: str, description: str = '', owner: str = 'user') -> dict", "description": "Create a task via /api/tasks and return the created task record."},
+        ],
+        "gates": ["create operations are non-destructive", "task payloads may include operational context"],
+    },
+    {
+        "id": "diagnostics_research",
+        "label": "Research Diagnostics",
+        "icon": "🔬",
+        "level": 1,
+        "module": "openbad.toolbelt.research_diagnostics_tool",
+        "description": "Inspect pending research nodes and create new research projects for follow-up.",
+        "tools": [
+            {"name": "get_research_nodes", "signature": "get_research_nodes() -> list[dict]", "description": "Return pending research nodes from /api/research."},
+            {"name": "create_research_node", "signature": "create_research_node(title: str, description: str = '', priority: int = 0, source_task_id: str | None = None) -> dict", "description": "Create a research node via /api/research and return the created node."},
+        ],
+        "gates": ["create operations are non-destructive", "queue-only (pending nodes)"],
+    },
+    {
         "id": "mcp_browser",
         "label": "Browser (MCP)",
         "icon": "🌍",
@@ -2307,9 +2851,13 @@ def create_app(
     *,
     enable_mqtt: bool = True,
 ) -> web.Application:
+    from openbad.state.event_log import setup_logging  # noqa: PLC0415
+    setup_logging()
+
     bridge = MqttWebSocketBridge(mqtt_host=mqtt_host, mqtt_port=mqtt_port)
     app = bridge.create_app()
     app["bridge"] = bridge
+    app["registry"] = _build_runtime_tool_registry()
     app["copilot_device_flows"] = {}
     app["sleep_runtime"] = {"last_summary": None}
     app["usage_tracker"] = UsageTracker(db_path=_resolve_usage_db_path())
@@ -2379,13 +2927,22 @@ def create_app(
     app.router.add_post("/api/onboarding/skip", _post_onboarding_skip)
     app.router.add_get("/api/heartbeat/config", _get_heartbeat_config)
     app.router.add_put("/api/heartbeat/config", _put_heartbeat_config)
+    app.router.add_get("/api/telemetry/config", _get_telemetry_config)
+    app.router.add_put("/api/telemetry/config", _put_telemetry_config)
     app.router.add_get("/api/sessions", _get_sessions)
     app.router.add_get("/api/immune/policy", _get_immune_policy)
     app.router.add_put("/api/immune/policy", _put_immune_policy)
+    app.router.add_get("/api/endocrine/status", _get_endocrine_status)
+    app.router.add_get("/api/endocrine/activity", _get_endocrine_activity)
+    app.router.add_post("/api/endocrine/toggle", _post_endocrine_toggle)
     app.router.add_get("/api/tasks", _get_tasks)
+    app.router.add_post("/api/tasks", _post_tasks)
     app.router.add_get("/api/research", _get_research)
+    app.router.add_post("/api/research", _post_research)
+    app.router.add_get("/api/research/completed", _get_research_completed)
     app.router.add_get("/api/mqtt/log", _get_mqtt_log)
     app.router.add_get("/api/debug/logs", _get_debug_logs)
+    app.router.add_get("/api/events", _get_system_events)
     app.router.add_get("/api/capabilities", _get_capabilities)
 
     # SvelteKit static assets + SPA fallback for client-side routing

--- a/tests/test_chat_pipeline.py
+++ b/tests/test_chat_pipeline.py
@@ -41,8 +41,41 @@ class _CapturingAdapter(ProviderAdapter):
         return HealthStatus(provider="test-provider", available=True)
 
 
+def _make_test_state_conn(db_path):
+    """Create an in-memory-like SQLite connection with the session_messages schema."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS session_messages (
+            message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL DEFAULT 'assistant',
+            content TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_session_messages_session_id
+            ON session_messages (session_id, created_at)
+        """
+    )
+    conn.commit()
+    return conn
+
+
 @pytest.fixture(autouse=True)
 def _reset_chat_pipeline_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        chat_pipeline,
+        "_state_conn",
+        _make_test_state_conn(tmp_path / "test_state.db"),
+    )
     monkeypatch.setattr(
         chat_pipeline,
         "_stm",

--- a/tests/test_litellm_agentic.py
+++ b/tests/test_litellm_agentic.py
@@ -1,0 +1,405 @@
+"""Tests for LiteLLM adapter, tool schemas, tool dispatch, and the agentic loop."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openbad.cognitive.context_manager import ContextWindowManager
+from openbad.cognitive.providers.litellm_adapter import (
+    LiteLLMAdapter,
+    litellm_model_name,
+)
+from openbad.memory.episodic import EpisodicMemory
+from openbad.memory.semantic import SemanticMemory
+from openbad.memory.stm import ShortTermMemory
+from openbad.toolbelt.dispatch import dispatch_tool_call
+from openbad.toolbelt.schemas import TOOL_SCHEMAS
+from openbad.wui import chat_pipeline
+
+# ── litellm_model_name ─────────────────────────────────────────────── #
+
+
+class TestLiteLLMModelName:
+    def test_prefixes_provider(self):
+        assert litellm_model_name("ollama", "llama3.2") == "ollama/llama3.2"
+
+    def test_github_copilot(self):
+        assert litellm_model_name("github-copilot", "gpt-4o") == "github_copilot/gpt-4o"
+
+    def test_anthropic(self):
+        assert litellm_model_name("anthropic", "claude-sonnet-4") == "anthropic/claude-sonnet-4"
+
+    def test_already_prefixed_passthrough(self):
+        assert litellm_model_name("openai", "openai/gpt-4o") == "openai/gpt-4o"
+
+    def test_custom_provider(self):
+        assert litellm_model_name("custom", "my-model") == "custom/my-model"
+
+
+# ── Tool schemas ───────────────────────────────────────────────────── #
+
+
+class TestToolSchemas:
+    def test_schema_count(self):
+        assert len(TOOL_SCHEMAS) == 16
+
+    def test_all_have_required_fields(self):
+        for schema in TOOL_SCHEMAS:
+            assert schema["type"] == "function"
+            fn = schema["function"]
+            assert "name" in fn
+            assert "description" in fn
+            assert "parameters" in fn
+            assert fn["parameters"]["type"] == "object"
+
+    def test_unique_names(self):
+        names = [s["function"]["name"] for s in TOOL_SCHEMAS]
+        assert len(names) == len(set(names))
+
+    def test_known_tools_present(self):
+        names = {s["function"]["name"] for s in TOOL_SCHEMAS}
+        expected = {
+            "read_file", "write_file", "exec_command", "web_search",
+            "web_fetch", "ask_user", "get_mqtt_records", "get_system_logs",
+            "read_events", "write_event", "get_endocrine_status",
+            "get_tasks", "create_task", "get_research_nodes",
+            "create_research_node", "mcp_bridge",
+        }
+        assert expected == names
+
+    def test_read_file_has_required_path(self):
+        rf = next(s for s in TOOL_SCHEMAS if s["function"]["name"] == "read_file")
+        assert "path" in rf["function"]["parameters"]["required"]
+
+
+# ── Tool dispatch ──────────────────────────────────────────────────── #
+
+
+class TestToolDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool(self):
+        result = await dispatch_tool_call("nonexistent_tool", {})
+        assert "Unknown tool" in result
+
+    @pytest.mark.asyncio
+    async def test_read_file(self, tmp_path):
+        p = tmp_path / "hello.txt"
+        p.write_text("world")
+        with patch("openbad.toolbelt.fs_tool.ALLOWED_ROOTS", [str(tmp_path)]):
+            result = await dispatch_tool_call("read_file", {"path": str(p)})
+        assert "world" in result
+
+    @pytest.mark.asyncio
+    async def test_write_file(self, tmp_path):
+        p = tmp_path / "out.txt"
+        with patch("openbad.toolbelt.fs_tool.ALLOWED_ROOTS", [str(tmp_path)]):
+            result = await dispatch_tool_call("write_file", {"path": str(p), "content": "data"})
+        assert "File written" in result
+        assert p.read_text() == "data"
+
+    @pytest.mark.asyncio
+    async def test_ask_user_returns_pending(self):
+        result = await dispatch_tool_call("ask_user", {"question": "What?"})
+        assert "question_pending" in result
+
+    @pytest.mark.asyncio
+    async def test_dispatch_error_handling(self):
+        """Tool that raises should return error string, not propagate."""
+        with patch("openbad.toolbelt.fs_tool.read_file", side_effect=PermissionError("denied")):
+            result = await dispatch_tool_call("read_file", {"path": "/etc/shadow"})
+        assert "PermissionError" in result
+
+
+# ── LiteLLM Adapter ───────────────────────────────────────────────── #
+
+
+def _mock_response(content="Hello", tool_calls=None, tokens=10):
+    """Build a mock litellm ModelResponse."""
+    message = MagicMock()
+    message.content = content
+    message.tool_calls = tool_calls
+    message.model_dump = MagicMock(return_value={
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+            }
+            for tc in (tool_calls or [])
+        ] if tool_calls else None,
+    })
+
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "tool_calls" if tool_calls else "stop"
+
+    usage = MagicMock()
+    usage.total_tokens = tokens
+
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = usage
+    response.model = "test/model"
+    return response
+
+
+def _mock_tool_call(name, arguments, call_id="call_1"):
+    tc = MagicMock()
+    tc.id = call_id
+    tc.function = MagicMock()
+    tc.function.name = name
+    tc.function.arguments = json.dumps(arguments)
+    return tc
+
+
+class TestLiteLLMAdapter:
+    @pytest.mark.asyncio
+    async def test_complete(self):
+        adapter = LiteLLMAdapter(
+            provider_name="test", default_model="test/model",
+        )
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock:
+            mock.return_value = _mock_response("Hello world", tokens=5)
+            result = await adapter.complete("Hi")
+        assert result.content == "Hello world"
+        assert result.tokens_used == 5
+        assert result.provider == "test"
+
+    @pytest.mark.asyncio
+    async def test_agentic_complete_with_tools(self):
+        adapter = LiteLLMAdapter(
+            provider_name="test", default_model="test/model",
+        )
+        tools = [{"type": "function", "function": {"name": "test"}}]
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock:
+            mock.return_value = _mock_response("result")
+            await adapter.agentic_complete(
+                [{"role": "user", "content": "hi"}],
+                "test/model",
+                tools=tools,
+            )
+        call_kwargs = mock.call_args.kwargs
+        assert call_kwargs.get("tools") == tools
+        assert call_kwargs.get("tool_choice") == "auto"
+
+    @pytest.mark.asyncio
+    async def test_health_check_success(self):
+        adapter = LiteLLMAdapter(
+            provider_name="test", default_model="test/model",
+        )
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock:
+            mock.return_value = _mock_response("pong", tokens=1)
+            status = await adapter.health_check()
+        assert status.available is True
+        assert status.provider == "test"
+
+    @pytest.mark.asyncio
+    async def test_health_check_failure(self):
+        adapter = LiteLLMAdapter(
+            provider_name="test", default_model="test/model",
+        )
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock:
+            mock.side_effect = Exception("connection refused")
+            status = await adapter.health_check()
+        assert status.available is False
+
+
+# ── Agentic loop ───────────────────────────────────────────────────── #
+
+
+def _make_test_state_conn(db_path):
+    """Create an SQLite connection with the session_messages schema for tests."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS session_messages (
+            message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL DEFAULT 'assistant',
+            content TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_session_messages_session_id
+            ON session_messages (session_id, created_at)
+        """
+    )
+    conn.commit()
+    return conn
+
+
+@pytest.fixture
+def _reset_pipeline(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        chat_pipeline, "_state_conn",
+        _make_test_state_conn(tmp_path / "test_state.db"),
+    )
+    monkeypatch.setattr(
+        chat_pipeline, "_stm",
+        ShortTermMemory(max_tokens=8192, default_ttl=7200.0),
+    )
+    monkeypatch.setattr(
+        chat_pipeline, "_episodic",
+        EpisodicMemory(storage_path=tmp_path / "episodic.json"),
+    )
+    monkeypatch.setattr(
+        chat_pipeline, "_semantic",
+        SemanticMemory(storage_path=tmp_path / "semantic.json"),
+    )
+    monkeypatch.setattr(
+        chat_pipeline, "_ctx_manager",
+        ContextWindowManager(default_limit=4096),
+    )
+    monkeypatch.setattr(
+        chat_pipeline, "scan_input",
+        lambda _text: SimpleNamespace(is_threat=False, matches=[]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_agentic_stream_no_tool_calls(_reset_pipeline):
+    """When the LLM responds immediately without tool calls, content is yielded."""
+    adapter = LiteLLMAdapter(provider_name="test", default_model="test/model")
+
+    with patch("litellm.acompletion", new_callable=AsyncMock) as mock:
+        mock.return_value = _mock_response("The answer is 42.", tokens=15)
+        chunks = [
+            chunk
+            async for chunk in chat_pipeline.stream_chat(
+                adapter,
+                "test/model",
+                "What is the answer?",
+                "session-agentic-1",
+            )
+        ]
+
+    text = "".join(c.token for c in chunks if c.token)
+    assert "The answer is 42." in text
+    assert chunks[-1].done is True
+
+
+@pytest.mark.asyncio
+async def test_agentic_stream_with_tool_calls(_reset_pipeline):
+    """When the LLM calls a tool, the loop executes it and continues."""
+    adapter = LiteLLMAdapter(provider_name="test", default_model="test/model")
+
+    tool_call = _mock_tool_call("get_endocrine_status", {})
+    response_with_tool = _mock_response(content="", tool_calls=[tool_call], tokens=20)
+    response_final = _mock_response(content="Cortisol is at 0.3", tokens=10)
+
+    with (
+        patch("litellm.acompletion", new_callable=AsyncMock) as mock_llm,
+        patch(
+            "openbad.wui.chat_pipeline.dispatch_tool_call",
+            new_callable=AsyncMock,
+        ) as mock_dispatch,
+    ):
+        mock_llm.side_effect = [response_with_tool, response_final]
+        mock_dispatch.return_value = '{"cortisol": 0.3}'
+
+        chunks = [
+            chunk
+            async for chunk in chat_pipeline.stream_chat(
+                adapter,
+                "test/model",
+                "Check my cortisol",
+                "session-agentic-2",
+            )
+        ]
+
+    text = "".join(c.token for c in chunks if c.token)
+    assert "Cortisol is at 0.3" in text
+    # LLM was called twice: once with tool calls, once with results
+    assert mock_llm.call_count == 2
+    mock_dispatch.assert_called_once_with("get_endocrine_status", {})
+
+
+@pytest.mark.asyncio
+async def test_agentic_stream_max_iterations(_reset_pipeline):
+    """If LLM keeps calling tools, the loop caps at max iterations."""
+    adapter = LiteLLMAdapter(provider_name="test", default_model="test/model")
+
+    tool_call = _mock_tool_call("get_tasks", {})
+    response_with_tool = _mock_response(content="", tool_calls=[tool_call], tokens=10)
+    response_final = _mock_response(content="Summary after max iterations", tokens=10)
+
+    with (
+        patch("litellm.acompletion", new_callable=AsyncMock) as mock_llm,
+        patch(
+            "openbad.wui.chat_pipeline.dispatch_tool_call",
+            new_callable=AsyncMock,
+        ) as mock_dispatch,
+    ):
+        # Return tool calls for all iterations, then the final summary
+        mock_llm.side_effect = [response_with_tool] * 5 + [response_final]
+        mock_dispatch.return_value = "[]"
+
+        chunks = [
+            chunk
+            async for chunk in chat_pipeline.stream_chat(
+                adapter,
+                "test/model",
+                "Keep checking tasks",
+                "session-agentic-max",
+            )
+        ]
+
+    text = "".join(c.token for c in chunks if c.token)
+    assert "Summary after max iterations" in text
+    # 5 tool iterations + 1 final summary = 6 calls
+    assert mock_llm.call_count == 6
+
+
+@pytest.mark.asyncio
+async def test_agentic_stream_legacy_fallback(_reset_pipeline):
+    """Non-LiteLLM adapters still work via the legacy streaming path."""
+    from openbad.cognitive.providers.base import (
+        HealthStatus,
+        ModelInfo,
+        ProviderAdapter,
+    )
+
+    class _LegacyAdapter(ProviderAdapter):
+        async def complete(self, prompt, model_id=None, **kwargs):
+            raise NotImplementedError
+
+        async def stream(self, prompt, model_id=None, **kwargs) -> AsyncIterator[str]:
+            yield "legacy"
+            yield " works"
+
+        async def list_models(self):
+            return [ModelInfo(model_id="m", provider="p")]
+
+        async def health_check(self):
+            return HealthStatus(provider="p", available=True)
+
+    chunks = [
+        chunk
+        async for chunk in chat_pipeline.stream_chat(
+            _LegacyAdapter(),
+            "test-model",
+            "Hello",
+            "session-legacy",
+        )
+    ]
+
+    text = "".join(c.token for c in chunks if c.token)
+    assert text == "legacy works"
+    assert chunks[-1].done is True


### PR DESCRIPTION
Closes #437

## Summary

Replaces the custom per-provider LLM layer with [LiteLLM](https://docs.litellm.ai/) as a unified interface, and implements real agentic tool-calling in the chat pipeline. Previously, the chat system described 16 tools in the system prompt text but had zero mechanism to actually invoke them — the LLM was hallucinating tool output.

## Changes

### New files
- **`src/openbad/cognitive/providers/litellm_adapter.py`** — `LiteLLMAdapter(ProviderAdapter)` wrapping `litellm.acompletion` for all providers (Ollama, OpenAI, Anthropic, GitHub Copilot, etc). Includes `agentic_complete()` for non-streaming tool-calling turns.
- **`src/openbad/toolbelt/schemas.py`** — 16 OpenAI-format tool JSON schemas (read_file, write_file, exec_command, web_search, web_fetch, ask_user, get_mqtt_records, get_system_logs, read_events, write_event, get_endocrine_status, get_tasks, create_task, get_research_nodes, create_research_node, mcp_bridge).
- **`src/openbad/toolbelt/dispatch.py`** — Tool call dispatcher routing to actual adapter implementations with error handling and 16K output truncation.
- **`tests/test_litellm_agentic.py`** — 23 new tests covering the adapter, schemas, dispatch, and agentic loop.

### Modified files
- **`pyproject.toml`** — Added `litellm>=1.80` dependency.
- **`src/openbad/wui/chat_pipeline.py`** — Rewrote `stream_chat()` with dual path: agentic loop for LiteLLM adapters (max 5 iterations, 30s per-tool timeout, chunked final output) and legacy path for non-LiteLLM adapters. Restored semantic memory writes for cross-session search. Added onboarding turn filtering to episodic context.
- **`src/openbad/wui/server.py`** — Added `_build_litellm_adapter()` and updated `_resolve_chat_adapter()` to return LiteLLM instead of old providers.
- **`tests/test_chat_pipeline.py`** — Added SQLite `_state_conn` fixture for test isolation.

### Preserved
- Legacy providers (`ollama.py`, `anthropic.py`, `openai_compat.py`, `github_copilot.py`) kept for wizard verification/health-check flows.

## How to test

```bash
pip install litellm
python -m pytest tests/test_chat_pipeline.py tests/test_litellm_agentic.py -v
```

All 31 tests pass (8 existing + 23 new). Lint clean via `ruff check`.