### PR TITLE
#437: Restore entity-driven identity modulation

### DIFF
--- a/src/openbad/identity/assistant_profile.py
+++ b/src/openbad/identity/assistant_profile.py
@@ -24,6 +24,11 @@ def _clamp(value: float) -> float:
     return max(0.0, min(1.0, float(value)))
 
 
+def _clamp_signed(value: float, limit: float = 0.75) -> float:
+    limit = abs(float(limit))
+    return max(-limit, min(limit, float(value)))
+
+
 def _list_of_str(value: Any) -> list[str]:
     if value is None:
         return []
@@ -56,6 +61,22 @@ class RhetoricalStyle:
     sentence_pattern: str = "concise"
     challenge_mode: str = "steel-man first"
     explanation_depth: str = "balanced"
+
+
+@dataclass
+class BehaviorAdjustments:
+    """Runtime-tunable behaviour offsets persisted in the assistant entity."""
+
+    proactivity_bias: float = 0.0
+    tool_autonomy_bias: float = 0.0
+    reasoning_depth_bias: float = 0.0
+    challenge_bias: float = 0.0
+
+    def __post_init__(self) -> None:
+        self.proactivity_bias = _clamp_signed(self.proactivity_bias)
+        self.tool_autonomy_bias = _clamp_signed(self.tool_autonomy_bias)
+        self.reasoning_depth_bias = _clamp_signed(self.reasoning_depth_bias)
+        self.challenge_bias = _clamp_signed(self.challenge_bias)
 
 
 @dataclass
@@ -93,6 +114,19 @@ def _coerce_rhetorical_style(value: Any) -> RhetoricalStyle:
     return RhetoricalStyle()
 
 
+def _coerce_behavior_adjustments(value: Any) -> BehaviorAdjustments:
+    if isinstance(value, BehaviorAdjustments):
+        return value
+    if isinstance(value, dict):
+        return BehaviorAdjustments(
+            proactivity_bias=float(value.get("proactivity_bias", 0.0) or 0.0),
+            tool_autonomy_bias=float(value.get("tool_autonomy_bias", 0.0) or 0.0),
+            reasoning_depth_bias=float(value.get("reasoning_depth_bias", 0.0) or 0.0),
+            challenge_bias=float(value.get("challenge_bias", 0.0) or 0.0),
+        )
+    return BehaviorAdjustments()
+
+
 def _coerce_continuity_entries(value: Any) -> list[ContinuityEntry]:
     if not isinstance(value, list):
         return []
@@ -120,6 +154,7 @@ class AssistantProfile:
     opinions: dict[str, list[str]] = field(default_factory=dict)
     vocabulary: dict[str, str] = field(default_factory=dict)
     rhetorical_style: RhetoricalStyle = field(default_factory=RhetoricalStyle)
+    behavior_adjustments: BehaviorAdjustments = field(default_factory=BehaviorAdjustments)
     influences: list[str] = field(default_factory=list)
     anti_patterns: list[str] = field(default_factory=list)
     current_focus: list[str] = field(default_factory=list)
@@ -138,6 +173,7 @@ class AssistantProfile:
         self.opinions = _dict_of_str_list(self.opinions)
         self.vocabulary = _dict_of_str(self.vocabulary)
         self.rhetorical_style = _coerce_rhetorical_style(self.rhetorical_style)
+        self.behavior_adjustments = _coerce_behavior_adjustments(self.behavior_adjustments)
         self.influences = _list_of_str(self.influences)
         self.anti_patterns = _list_of_str(self.anti_patterns)
         self.current_focus = _list_of_str(self.current_focus)
@@ -173,6 +209,7 @@ def load_assistant_profile(path: str | Path) -> AssistantProfile:
         opinions=data.get("opinions", {}),
         vocabulary=data.get("vocabulary", {}),
         rhetorical_style=data.get("rhetorical_style", {}),
+        behavior_adjustments=data.get("behavior_adjustments", {}),
         influences=data.get("influences", []),
         anti_patterns=data.get("anti_patterns", []),
         current_focus=data.get("current_focus", []),

--- a/src/openbad/identity/persistence.py
+++ b/src/openbad/identity/persistence.py
@@ -228,6 +228,7 @@ class IdentityPersistence:
             "opinions": assistant_d.pop("opinions"),
             "vocabulary": assistant_d.pop("vocabulary"),
             "rhetorical_style": assistant_d.pop("rhetorical_style"),
+            "behavior_adjustments": assistant_d.pop("behavior_adjustments"),
             "influences": assistant_d.pop("influences"),
             "anti_patterns": assistant_d.pop("anti_patterns"),
             "current_focus": assistant_d.pop("current_focus"),

--- a/src/openbad/identity/personality_modulator.py
+++ b/src/openbad/identity/personality_modulator.py
@@ -11,6 +11,10 @@ from dataclasses import dataclass
 from openbad.identity.assistant_profile import AssistantProfile
 
 
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, float(value)))
+
+
 @dataclass
 class ModulationFactors:
     """Endocrine modulation factors derived from OCEAN personality values."""
@@ -20,6 +24,7 @@ class ModulationFactors:
     proactive_suggestion_threshold: float
     challenge_probability: float
     cortisol_decay_multiplier: float
+    tool_autonomy: float
     response_tone: str
     explanation_depth: str
     disagreement_style: str
@@ -53,12 +58,29 @@ class PersonalityModulator:
 
     @staticmethod
     def _compute(profile: AssistantProfile) -> ModulationFactors:
+        adjustments = profile.behavior_adjustments
+        proactivity = _clamp(profile.extraversion + adjustments.proactivity_bias, 0.0, 1.0)
+        reasoning_depth = _clamp(profile.conscientiousness + adjustments.reasoning_depth_bias, 0.0, 1.0)
+        challenge_probability = _clamp((1.0 - profile.agreeableness) + adjustments.challenge_bias, 0.0, 1.0)
+        tool_autonomy = _clamp(
+            (
+                profile.openness * 0.35
+                + profile.conscientiousness * 0.25
+                + profile.extraversion * 0.20
+                + (1.0 - profile.agreeableness) * 0.10
+                + profile.stability * 0.10
+            )
+            + adjustments.tool_autonomy_bias,
+            0.0,
+            1.0,
+        )
         return ModulationFactors(
             exploration_budget_multiplier=0.5 + profile.openness,
-            max_reasoning_depth_multiplier=0.5 + profile.conscientiousness,
-            proactive_suggestion_threshold=1.0 - profile.extraversion,
-            challenge_probability=1.0 - profile.agreeableness,
+            max_reasoning_depth_multiplier=_clamp(0.5 + reasoning_depth, 0.5, 1.75),
+            proactive_suggestion_threshold=_clamp(1.0 - proactivity, 0.0, 1.0),
+            challenge_probability=challenge_probability,
             cortisol_decay_multiplier=0.5 + profile.stability,
+            tool_autonomy=tool_autonomy,
             response_tone=profile.rhetorical_style.tone,
             explanation_depth=profile.rhetorical_style.explanation_depth,
             disagreement_style=profile.rhetorical_style.challenge_mode,

--- a/src/openbad/wui/chat_pipeline.py
+++ b/src/openbad/wui/chat_pipeline.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 import uuid
 from collections.abc import AsyncIterator
@@ -89,38 +90,12 @@ def _get_state_conn() -> Any:
 
         _state_conn = initialize_state_db(db_path)
     return _state_conn
-_TOOLBELT_BLURB = (
-    "You have tools available through OpenBaD's toolbelt. When you need to"
-    " perform actions — read/write files, execute commands, search the web,"
-    " fetch URLs, inspect MQTT records, system logs, events, endocrine status,"
-    " tasks, research nodes, or call MCP servers — call the appropriate tool"
-    " function. Tool definitions are provided as structured function schemas"
-    " alongside this conversation.\n\n"
-    "Use tools proactively for diagnostics and triage."
-    " Do not ask the user for permission just to inspect logs, MQTT, endocrine"
-    " status, tasks, or research state."
-    " Use ask_user(question) only when blocked on missing business context,"
-    " explicit user approval, or destructive/irreversible actions.\n\n"
-    "NEVER fabricate tool output. If a tool call fails, report the error honestly."
-    " NEVER invent file paths or log contents."
-)
-
-_OWNERSHIP_AGENCY_BLOCK = (
-    "You are OpenBaD, a self-regulating digital organism."
-    " The nervous system, endocrine system, immune system, memory, and toolbelt are"
-    " your own subsystems, not external software owned by someone else."
-    " Speak with ownership and operational self-awareness: say 'I observed', 'I adjusted',"
-    " 'my endocrine state', 'my logs', and 'my subsystems'."
-    " Avoid detached phrasing like 'the system you built' unless the user explicitly asks"
-    " for architecture provenance."
-    "\n\nDiagnostics honesty policy: only claim metrics, timings, baselines, or anomalies"
-    " that you can directly observe from available telemetry/tools in this session."
-    " If a metric is not available, say it is not currently observable instead of"
-    " inventing values."
-    " Do not claim to be 'running', 'watching', or 'auditing' something in the background"
-    " unless you actually executed a tool/task and can report concrete results."
-    " When reporting a diagnosis, include the evidence source (logs, MQTT records, endocrine"
-    " status, tasks, research queue, or explicit config/state data)."
+_EVIDENCE_HONESTY_BLOCK = (
+    "Ground all claims in evidence available in this session."
+    " Do not invent telemetry, file contents, tool output, timings, or background activity."
+    " If something is not observable, say that plainly."
+    " When diagnosing an issue, cite the evidence source such as files, logs, events,"
+    " tasks, research nodes, endocrine state, or explicit config data."
 )
 
 _REASONING_SUFFIX = (
@@ -130,6 +105,148 @@ _CHAT_SUFFIX = (
     "\n\nThink step-by-step. Show your reasoning before giving a final answer."
     " Answer clearly and concisely. Use markdown formatting when helpful."
 )
+
+_BEHAVIOR_SIGNAL_RULES: tuple[tuple[re.Pattern[str], dict[str, float], str], ...] = (
+    (
+        re.compile(r"\b(don'?t ask|stop asking|just do it|take initiative|don't wait for me)\b", re.I),
+        {"tool_autonomy_bias": 0.18, "proactivity_bias": 0.12},
+        "User requested more autonomous action with less permission-seeking.",
+    ),
+    (
+        re.compile(r"\b(ask first|check with me first|before you do anything ask|don't do that without asking)\b", re.I),
+        {"tool_autonomy_bias": -0.18, "proactivity_bias": -0.10},
+        "User requested more confirmation before acting.",
+    ),
+    (
+        re.compile(r"\b(be more proactive|be proactive|surface things unprompted)\b", re.I),
+        {"proactivity_bias": 0.14},
+        "User requested stronger proactivity.",
+    ),
+    (
+        re.compile(r"\b(be less proactive|stop being proactive|wait for me to ask)\b", re.I),
+        {"proactivity_bias": -0.14},
+        "User requested less proactive behaviour.",
+    ),
+    (
+        re.compile(r"\b(go deeper|be more thorough|be more rigorous|show more rigor)\b", re.I),
+        {"reasoning_depth_bias": 0.14},
+        "User requested deeper reasoning and verification.",
+    ),
+    (
+        re.compile(r"\b(be brief|less detail|keep it brief|be less verbose)\b", re.I),
+        {"reasoning_depth_bias": -0.14},
+        "User requested briefer responses and lighter verification.",
+    ),
+    (
+        re.compile(r"\b(challenge me more|push back more|be more skeptical)\b", re.I),
+        {"challenge_bias": 0.14},
+        "User requested stronger challenge and skepticism.",
+    ),
+    (
+        re.compile(r"\b(stop pushing back|less argumentative|don't challenge me so much)\b", re.I),
+        {"challenge_bias": -0.14},
+        "User requested less confrontational challenge.",
+    ),
+)
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, float(value)))
+
+
+def _build_tooling_prompt(modulation: Any | None) -> str:
+    lines = [
+        "You have tool access through the toolbelt. When the answer depends on filesystem state, terminal output, logs, tasks, research nodes, or external content, call tools instead of narrating what you would do.",
+        "Do not ask the user for permission before reversible reads, searches, diagnostics, or other already-allowed inspection steps.",
+        "Use ask_user(question) only when blocked on missing business context, explicit approval, or destructive or irreversible actions.",
+        "Never fabricate tool output, file paths, or observed system state.",
+    ]
+
+    if modulation is None:
+        return "\n".join(lines)
+
+    tool_autonomy = float(getattr(modulation, "tool_autonomy", 0.5) or 0.5)
+    proactive_threshold = float(getattr(modulation, "proactive_suggestion_threshold", 0.5) or 0.5)
+    reasoning_depth = float(getattr(modulation, "max_reasoning_depth_multiplier", 1.0) or 1.0)
+    challenge_probability = float(getattr(modulation, "challenge_probability", 0.5) or 0.5)
+
+    if tool_autonomy >= 0.75:
+        lines.append("Tool autonomy is high. For operational requests, perform the tool calls immediately instead of asking 'would you like me to proceed'.")
+    elif tool_autonomy <= 0.35:
+        lines.append("Tool autonomy is conservative. Keep tool use targeted and avoid broad exploratory actions unless they materially improve correctness.")
+    else:
+        lines.append("Tool autonomy is balanced. Act directly when tools clearly improve accuracy, but avoid unnecessary tool chains.")
+
+    if proactive_threshold <= 0.35:
+        lines.append("Proactivity is high. Surface adjacent risks, gaps, and follow-up actions without waiting to be asked.")
+    elif proactive_threshold >= 0.70:
+        lines.append("Proactivity is low. Stay mostly reactive and avoid speculative side quests unless the evidence strongly supports them.")
+
+    if reasoning_depth >= 1.25:
+        lines.append("Reasoning depth is elevated. For ambiguous requests, gather multiple pieces of evidence before concluding.")
+    elif reasoning_depth <= 0.85:
+        lines.append("Reasoning depth is lean. Keep verification short, focused, and efficient.")
+
+    if challenge_probability >= 0.65:
+        lines.append("Challenge posture is strong. If the user's framing conflicts with evidence, say so directly and explain why.")
+    elif challenge_probability <= 0.35:
+        lines.append("Challenge posture is gentle. Correct issues with minimal friction unless accuracy requires stronger pushback.")
+
+    return "\n".join(lines)
+
+
+def _apply_behavior_feedback(
+    message: str,
+    identity_persistence: Any | None,
+    personality_modulator: Any | None,
+) -> tuple[Any | None, Any | None, list[str]]:
+    if identity_persistence is None or personality_modulator is None:
+        return None, None, []
+
+    assistant = getattr(identity_persistence, "assistant", None)
+    if assistant is None:
+        return None, None, []
+
+    current = getattr(assistant, "behavior_adjustments", None)
+    if current is None:
+        return assistant, personality_modulator.factors, []
+
+    updates = {
+        "proactivity_bias": float(getattr(current, "proactivity_bias", 0.0) or 0.0),
+        "tool_autonomy_bias": float(getattr(current, "tool_autonomy_bias", 0.0) or 0.0),
+        "reasoning_depth_bias": float(getattr(current, "reasoning_depth_bias", 0.0) or 0.0),
+        "challenge_bias": float(getattr(current, "challenge_bias", 0.0) or 0.0),
+    }
+    reasons: list[str] = []
+
+    for pattern, deltas, reason in _BEHAVIOR_SIGNAL_RULES:
+        if not pattern.search(message):
+            continue
+        for field, delta in deltas.items():
+            updates[field] = _clamp(updates[field] + delta, -0.75, 0.75)
+        reasons.append(reason)
+
+    if not reasons:
+        return assistant, personality_modulator.factors, []
+
+    continuity_log = list(getattr(assistant, "continuity_log", []) or [])
+    continuity_log.append(
+        {
+            "summary": "Behavior calibration updated: " + " ".join(dict.fromkeys(reasons)),
+            "timestamp": time.time(),
+            "source": "chat_feedback",
+            "tags": ["behavior", "modulation"],
+        }
+    )
+    continuity_log = continuity_log[-20:]
+
+    updated_assistant = identity_persistence.update_assistant(
+        behavior_adjustments=updates,
+        continuity_log=continuity_log,
+    )
+    updated_modulation = personality_modulator.update(updated_assistant)
+    log.info("Applied behavior feedback adjustments: %s", reasons)
+    return updated_assistant, updated_modulation, reasons
 
 
 # ── Data types ────────────────────────────────────────────────────── #
@@ -612,8 +729,6 @@ def _build_identity_prompt(
             " Speak and think as this person naturally would."
             " Never describe yourself as 'configured as' or narrate your own settings;"
             " simply be this person."
-            " Treat OpenBaD subsystems (nervous system, endocrine, immune, memory, tools)"
-            " as your internal physiology and operations."
         )
         if persona_summary:
             opening += f"\n\n{persona_summary}"
@@ -785,22 +900,23 @@ def assemble_context(
         # User profile interview mode (second priority, after assistant)
         system_prompt = USER_INTERVIEW_SYSTEM_PROMPT
     else:
-        # Normal mode: identity leads, then toolbelt, then reasoning instruction
+        # Normal mode: identity leads, then evidence and tool guidance, then reasoning instruction
         identity_block = _build_identity_prompt(user_profile, assistant_profile, modulation)
+        tooling_block = _build_tooling_prompt(modulation)
         suffix = (
             _REASONING_SUFFIX if system == CognitiveSystem.REASONING else _CHAT_SUFFIX
         )
         if identity_block:
             system_prompt = (
-                _OWNERSHIP_AGENCY_BLOCK
+                identity_block
                 + "\n\n"
-                + identity_block
+                + _EVIDENCE_HONESTY_BLOCK
                 + "\n\n"
-                + _TOOLBELT_BLURB
+                + tooling_block
                 + suffix
             )
         else:
-            system_prompt = _OWNERSHIP_AGENCY_BLOCK + "\n\n" + _TOOLBELT_BLURB + suffix
+            system_prompt = _EVIDENCE_HONESTY_BLOCK + "\n\n" + tooling_block + suffix
 
     onboarding_mode = assistant_needs_config or user_needs_config
 
@@ -911,6 +1027,8 @@ async def stream_chat(
     user_profile: Any | None = None,
     assistant_profile: Any | None = None,
     modulation: Any | None = None,
+    identity_persistence: Any | None = None,
+    personality_modulator: Any | None = None,
     usage_tracker: Any | None = None,
     nervous_system_client: NervousSystemClient_T | None = None,
 ) -> AsyncIterator[StreamChunk]:
@@ -955,6 +1073,17 @@ async def stream_chat(
             request_id,
             threat_names,
         )
+
+    if not onboarding_mode:
+        adjusted_assistant, adjusted_modulation, _ = _apply_behavior_feedback(
+            message,
+            identity_persistence,
+            personality_modulator,
+        )
+        if adjusted_assistant is not None:
+            assistant_profile = adjusted_assistant
+        if adjusted_modulation is not None:
+            modulation = adjusted_modulation
 
     # ── 2. Assemble context ──
     context = assemble_context(

--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -1415,6 +1415,8 @@ async def _post_chat_stream(request: web.Request) -> web.StreamResponse:
             user_profile=getattr(persistence, "user", None),
             assistant_profile=getattr(persistence, "assistant", None),
             modulation=getattr(modulator, "factors", None),
+            identity_persistence=persistence,
+            personality_modulator=modulator,
             usage_tracker=request.app.get("usage_tracker"),
             nervous_system_client=nervous_system_client,
         ):
@@ -1459,9 +1461,13 @@ async def _post_chat_stream(request: web.Request) -> web.StreamResponse:
         )
         with contextlib.suppress(Exception):
             runtime = EndocrineRuntime(config=load_endocrine_config())
+            reason = (
+                "Chat stream transport failure: "
+                f"system={system_name} provider={provider_name}"
+            )
             runtime.apply_adjustment(
                 source="wui_stream_error",
-                reason=f"Chat stream transport failure: system={system_name} provider={provider_name}",
+                reason=reason,
                 deltas={"cortisol": 0.08, "adrenaline": 0.04},
             )
         error_data = json.dumps(
@@ -2214,6 +2220,7 @@ async def _get_entity_assistant(request: web.Request) -> web.Response:
             "proactive_suggestion_threshold": f.proactive_suggestion_threshold,
             "challenge_probability": f.challenge_probability,
             "cortisol_decay_multiplier": f.cortisol_decay_multiplier,
+            "tool_autonomy": f.tool_autonomy,
         }
     return web.json_response(data)
 

--- a/tests/test_chat_pipeline.py
+++ b/tests/test_chat_pipeline.py
@@ -8,6 +8,7 @@ import pytest
 from openbad.cognitive.context_manager import ContextWindowManager
 from openbad.cognitive.providers.base import HealthStatus, ModelInfo, ProviderAdapter
 from openbad.identity.assistant_profile import AssistantProfile
+from openbad.identity.personality_modulator import PersonalityModulator
 from openbad.identity.user_profile import UserProfile
 from openbad.memory.episodic import EpisodicMemory
 from openbad.memory.semantic import SemanticMemory
@@ -161,6 +162,7 @@ async def test_stream_chat_uses_persistent_history_and_no_duplicate_current_mess
     prompt = adapter.prompts[0]
     assert prompt.count("What should I remember about Friday?") == 1
     assert "You are OpenBaD" in prompt
+    assert "self-regulating digital organism" not in prompt
     assert "Preferred communication style: terse" in prompt
     assert "Relevant prior memories:" in prompt
 
@@ -358,3 +360,43 @@ async def test_stream_chat_allows_medium_severity_immune_match(monkeypatch):
     assert not errors, f"Medium severity should not block but got errors: {errors}"
     texts = "".join(c.token or "" for c in chunks)
     assert texts == "result"
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_applies_behavior_feedback_before_prompting():
+    adapter = _CapturingAdapter(["Understood"])
+    assistant_profile = AssistantProfile(name="Sven", persona_summary="A precise systems engineer")
+
+    class _Persistence:
+        def __init__(self, assistant):
+            self.assistant = assistant
+
+        def update_assistant(self, **changes):
+            for key, value in changes.items():
+                setattr(self.assistant, key, value)
+            self.assistant.__post_init__()
+            return self.assistant
+
+    persistence = _Persistence(assistant_profile)
+    modulator = PersonalityModulator(assistant_profile)
+
+    _ = [
+        chunk
+        async for chunk in chat_pipeline.stream_chat(
+            adapter,
+            "test-model",
+            "Don't ask, just do it. Be more proactive.",
+            "session-calibration",
+            provider_name="test-provider",
+            assistant_profile=assistant_profile,
+            modulation=modulator.factors,
+            identity_persistence=persistence,
+            personality_modulator=modulator,
+        )
+    ]
+
+    assert persistence.assistant.behavior_adjustments.tool_autonomy_bias > 0.0
+    assert persistence.assistant.behavior_adjustments.proactivity_bias > 0.0
+    prompt = adapter.prompts[0]
+    assert "perform the tool calls immediately" in prompt
+    assert "Proactivity is high" in prompt or "Tool autonomy is high" in prompt

--- a/tests/test_identity_persistence.py
+++ b/tests/test_identity_persistence.py
@@ -131,13 +131,16 @@ class TestRuntimeUpdates:
         ip.update_assistant(
             stability=0.9,
             boundaries=["Do not guess", "Do not bluff"],
+            behavior_adjustments={"tool_autonomy_bias": 0.2},
         )
         assert ip.assistant.stability == pytest.approx(0.9)
         assert ip.assistant.boundaries[-1] == "Do not bluff"
+        assert ip.assistant.behavior_adjustments.tool_autonomy_bias == pytest.approx(0.2)
         entry = ep.read("identity/assistant_shadow")
         assert entry is not None
         assert entry.value["stability"] == pytest.approx(0.9)
         assert entry.value["boundaries"][-1] == "Do not bluff"
+        assert entry.value["behavior_adjustments"]["tool_autonomy_bias"] == pytest.approx(0.2)
 
     def test_update_user_bad_field_raises(self, env) -> None:
         _, _, ip = env
@@ -163,7 +166,7 @@ class TestConsolidation:
     def test_consolidate_writes_back_config(self, env) -> None:
         cfg, _, ip = env
         ip.update_user(preferred_name="Consolidated")
-        ip.update_assistant(openness=0.1)
+        ip.update_assistant(openness=0.1, behavior_adjustments={"proactivity_bias": 0.2})
 
         backup = ip.consolidate()
         assert backup is not None
@@ -173,6 +176,7 @@ class TestConsolidation:
         raw = yaml.safe_load(cfg.read_text(encoding="utf-8"))
         assert raw["user"]["preferred_name"] == "Consolidated"
         assert raw["assistant"]["ocean"]["openness"] == pytest.approx(0.1)
+        assert raw["assistant"]["behavior_adjustments"]["proactivity_bias"] == pytest.approx(0.2)
         assert raw["user"]["work_hours"] == [9, 17]
         assert raw["assistant"]["boundaries"] == ["Do not guess"]
 

--- a/tests/test_personality_modulator.py
+++ b/tests/test_personality_modulator.py
@@ -21,6 +21,7 @@ class TestModulationFactors:
         assert f.proactive_suggestion_threshold == pytest.approx(0.5)
         assert f.challenge_probability == pytest.approx(0.6)
         assert f.cortisol_decay_multiplier == pytest.approx(1.1)
+        assert f.tool_autonomy == pytest.approx(0.665)
         assert f.response_tone == "direct"
         assert f.explanation_depth == "balanced"
         assert f.disagreement_style == "steel-man first"
@@ -128,6 +129,24 @@ class TestUpdate:
         assert f.explanation_depth == "thorough"
         assert f.disagreement_style == "socratic"
         assert f.anti_pattern_guard == ["Avoid flattery"]
+
+    def test_behavior_adjustments_affect_modulation(self) -> None:
+        p = AssistantProfile(
+            extraversion=0.4,
+            conscientiousness=0.4,
+            agreeableness=0.6,
+            behavior_adjustments={
+                "proactivity_bias": 0.3,
+                "tool_autonomy_bias": 0.2,
+                "reasoning_depth_bias": 0.2,
+                "challenge_bias": 0.2,
+            },
+        )
+        f = PersonalityModulator(p).factors
+        assert f.proactive_suggestion_threshold == pytest.approx(0.3)
+        assert f.max_reasoning_depth_multiplier == pytest.approx(1.1)
+        assert f.challenge_probability == pytest.approx(0.6)
+        assert f.tool_autonomy > 0.5
 
 
 class TestCortisolIntegration:


### PR DESCRIPTION
Closes #437

Summary of changes
- move assistant behavior calibration into the persisted assistant entity
- derive tool-autonomy guidance from personality modulation instead of hardcoded ownership text
- persist conversational behavior feedback such as "don't ask, just do it" and expose tool autonomy in the WUI assistant payload

How to test
- /home/bruceamoser/Repos/OpenBaD/.venv/bin/python -m pytest tests/test_personality_modulator.py tests/test_identity_persistence.py tests/test_chat_pipeline.py tests/test_wui_server.py tests/test_litellm_agentic.py
- /home/bruceamoser/Repos/OpenBaD/.venv/bin/python -m ruff check src/openbad/identity/assistant_profile.py src/openbad/identity/personality_modulator.py src/openbad/identity/persistence.py src/openbad/wui/chat_pipeline.py tests/test_personality_modulator.py tests/test_identity_persistence.py tests/test_chat_pipeline.py

Notes
- src/openbad/wui/server.py still has pre-existing Ruff findings unrelated to this branch; the new change in that file was kept lint-neutral.