### PR TITLE
Add embedded skills MCP server, separate from toolbelt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "click>=8.1",
     "loguru>=0.7",
     "litellm>=1.80",
+    "mcp>=1.20",
 ]
 
 [project.scripts]

--- a/src/openbad/autonomy/tool_agent.py
+++ b/src/openbad/autonomy/tool_agent.py
@@ -5,7 +5,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from openbad.toolbelt.schemas import TOOL_SCHEMAS
+from openbad.skills import call_skill
+from openbad.skills.server import async_get_openai_tools
 
 log = logging.getLogger(__name__)
 
@@ -17,6 +18,10 @@ _TOOLING_BASE_PROMPT = (
     " the quality of the work. You may inspect files, events, MQTT records, endocrine"
     " state, tasks, and research nodes, and you may create or update task/research"
     " entries when follow-up work is warranted. Never fabricate tool results."
+    " If the user refers to a file but you have not verified its exact path yet, call"
+    " find_files before read_file. Search the current workspace first, and do not"
+    " supply a guessed absolute cwd such as another user's home directory unless the"
+    " user or a prior tool result explicitly provided that directory."
     " If a tool result starts with [access_request], do not claim the file or directory"
     " is missing. The access request has already been created. Tell the user to approve"
     " it in Toolbelt -> Path Access Requests, then retry after approval. Do not call"
@@ -118,8 +123,9 @@ async def run_tool_agent(
         {"role": "user", "content": user_prompt},
     ]
 
+    skill_schemas = await async_get_openai_tools()
     for iteration in range(_MAX_TOOL_ITERATIONS):
-        response = await agentic_complete(working_messages, model_id, tools=TOOL_SCHEMAS)
+        response = await agentic_complete(working_messages, model_id, tools=skill_schemas)
         usage = getattr(response, "usage", None)
         total_tokens += int(getattr(usage, "total_tokens", 0) or 0)
 
@@ -188,10 +194,10 @@ async def run_tool_agent(
                 )
             else:
                 try:
-                    from openbad.toolbelt.dispatch import dispatch_tool_call
+                    import asyncio as _aio
 
-                    result = await __import__("asyncio").wait_for(
-                        dispatch_tool_call(fn_name, fn_args),
+                    result = await _aio.wait_for(
+                        call_skill(fn_name, fn_args),
                         timeout=_TOOL_CALL_TIMEOUT_S,
                     )
                 except TimeoutError:

--- a/src/openbad/skills/__init__.py
+++ b/src/openbad/skills/__init__.py
@@ -1,0 +1,17 @@
+"""OpenBaD embedded skills — native MCP server for built-in capabilities.
+
+Embedded skills are the tools that ship with OpenBaD and work out of the box:
+file I/O, command execution, web search, diagnostics, task/research management,
+etc.  They are distinct from the *toolbelt*, which is a plugin system for
+user-built extensions (not yet implemented).
+
+The skills are defined using the MCP Python SDK's FastMCP decorator API so that:
+  - Schemas are auto-generated from type hints (no hand-written JSON).
+  - Any MCP client (Claude Code, VS Code, etc.) can connect and use them.
+  - The internal agentic loop also consumes them via ``get_openai_tools()``
+    and ``call_skill()``.
+"""
+
+from openbad.skills.server import get_openai_tools, call_skill, skill_server
+
+__all__ = ["get_openai_tools", "call_skill", "skill_server"]

--- a/src/openbad/skills/server.py
+++ b/src/openbad/skills/server.py
@@ -1,0 +1,800 @@
+"""OpenBaD embedded-skills MCP server.
+
+Uses FastMCP to define every built-in skill with ``@mcp.tool()`` decorators.
+Schemas are derived automatically from function signatures, type hints, and
+docstrings — no hand-maintained JSON.
+
+Public helpers consumed by the agentic loop:
+    ``get_openai_tools()``  – returns OpenAI-format tool schemas for LiteLLM.
+    ``call_skill(name, args)``  – dispatches a tool call and returns a string.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+log = logging.getLogger(__name__)
+
+# ── FastMCP instance ──────────────────────────────────────────────────── #
+
+skill_server = FastMCP(
+    "OpenBaD Skills",
+    instructions=(
+        "Embedded skills for OpenBaD — a self-improving, curiosity-driven, "
+        "research-first Linux assistant."
+    ),
+)
+
+# Maximum output length per skill result to avoid ballooning LLM context.
+_MAX_RESULT_CHARS = 16_000
+_ACCESS_REQUEST_PREFIX = "[access_request]"
+
+
+def _truncate(text: str) -> str:
+    if len(text) > _MAX_RESULT_CHARS:
+        return text[:_MAX_RESULT_CHARS] + f"\n... (truncated, {len(text)} chars total)"
+    return text
+
+
+def _fmt_access_request(target: str, detail: str) -> str:
+    return (
+        f"{_ACCESS_REQUEST_PREFIX} Access to {target} is not currently permitted. {detail}\n"
+        "A path access request must be approved in the Toolbelt UI under "
+        "Path Access Requests before retrying."
+    )
+
+
+def _fmt_access_with_record(target: str, detail: str, record: dict[str, Any] | None) -> str:
+    if not record:
+        return _fmt_access_request(target, detail)
+    request = record.get("request") if isinstance(record.get("request"), dict) else {}
+    if request:
+        request_id = str(request.get("request_id", "")).strip()
+        root = str(request.get("normalized_root", "")).strip()
+        return (
+            f"{_ACCESS_REQUEST_PREFIX} Access to {target} is not currently permitted. {detail}\n"
+            f"Pending request: {request_id or 'unknown'} for root {root or 'unknown'}.\n"
+            "That request is already created. Tell the user to approve it in "
+            "Toolbelt -> Path Access Requests, then retry."
+        )
+    grant = record.get("grant") if isinstance(record.get("grant"), dict) else {}
+    if grant:
+        return (
+            f"{_ACCESS_REQUEST_PREFIX} Access to {target} was previously blocked, "
+            "but the root is now granted. Retry the operation."
+        )
+    return _fmt_access_request(target, detail)
+
+
+# ── File System ───────────────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+def find_files(
+    pattern: str,
+    cwd: str = ".",
+    limit: int = 50,
+) -> str:
+    """Find files under a directory using a glob or substring pattern.
+
+    Args:
+        pattern: Glob-like pattern or plain substring to search for.
+        cwd: Directory to search within.  Defaults to the current working
+             directory.  Omit unless the directory was explicitly provided
+             by the user or a prior tool result.
+        limit: Maximum number of matches to return (default 50).
+    """
+    from openbad.toolbelt.fs_tool import find_files as _find
+    from openbad.toolbelt.access_control import create_access_request
+
+    try:
+        return _find(pattern, cwd=cwd, limit=limit)
+    except PermissionError as exc:
+        detail = str(exc)
+        if "outside allowed roots" in detail:
+            record = create_access_request(
+                cwd, requester="skill:find_files",
+                reason=f"find_files requested cwd access for pattern {pattern}",
+                prefer_parent=False,
+            )
+            return _fmt_access_with_record(f"search root {cwd!r}", detail, record)
+        return f"Error: PermissionError: {detail}"
+
+
+@skill_server.tool()
+def read_file(path: str) -> str:
+    """Read the contents of a file and return the text content.
+
+    Args:
+        path: Absolute or relative path to the file.
+    """
+    from openbad.toolbelt.fs_tool import read_file as _read
+    from openbad.toolbelt.access_control import create_access_request
+
+    try:
+        return _read(path)
+    except PermissionError as exc:
+        detail = str(exc)
+        if "outside allowed roots" in detail:
+            record = create_access_request(
+                path, requester="skill:read_file",
+                reason="read_file requested access outside allowed roots",
+                prefer_parent=True,
+            )
+            return _fmt_access_with_record(f"path {path!r}", detail, record)
+        return f"Error: PermissionError: {detail}"
+
+
+@skill_server.tool()
+def write_file(path: str, content: str) -> str:
+    """Write content to a file (creates or overwrites).
+
+    Args:
+        path: Absolute or relative path to the file.
+        content: Content to write to the file.
+    """
+    from openbad.toolbelt.fs_tool import write_file as _write
+    from openbad.toolbelt.access_control import create_access_request
+
+    try:
+        _write(path, content)
+    except PermissionError as exc:
+        detail = str(exc)
+        if "outside allowed roots" in detail:
+            record = create_access_request(
+                path, requester="skill:write_file",
+                reason="write_file requested access outside allowed roots",
+                prefer_parent=True,
+            )
+            return _fmt_access_with_record(f"path {path!r}", detail, record)
+        return f"Error: PermissionError: {detail}"
+    return f"File written: {path}"
+
+
+# ── Command Execution ─────────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+async def exec_command(
+    command: str,
+    args: list[str] | None = None,
+    cwd: str | None = None,
+) -> str:
+    """Execute a shell command and return stdout/stderr.  Runs in a sandboxed environment.
+
+    Args:
+        command: The shell command to execute.
+        args: Optional list of arguments.
+        cwd: Optional working directory.
+    """
+    from openbad.toolbelt.access_control import create_access_request
+    from openbad.toolbelt.cli_tool import CliToolAdapter
+
+    cli = CliToolAdapter()
+    result = await cli.async_execute(command, args=args, cwd=cwd)
+    parts: list[str] = []
+    if result.stdout:
+        parts.append(result.stdout)
+    if result.returncode == -1 and "allowed roots" in (result.stderr or ""):
+        requested_cwd = str(cwd or cli.config.working_directory)
+        record = create_access_request(
+            requested_cwd, requester="skill:exec_command",
+            reason=f"exec_command requested cwd access for command {command}",
+            prefer_parent=False,
+        )
+        return _fmt_access_with_record(
+            f"working directory {requested_cwd!r}", result.stderr, record,
+        )
+    if result.stderr:
+        parts.append(f"STDERR: {result.stderr}")
+    parts.append(f"(exit code {result.returncode})")
+    return "\n".join(parts)
+
+
+# ── Access Control ────────────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+def get_path_access_status() -> str:
+    """Return current approved path roots and pending access requests for tool usage."""
+    from openbad.toolbelt.access_control import list_access_grants, list_access_requests
+
+    return json.dumps(
+        {"pending_requests": list_access_requests(status="pending"),
+         "grants": list_access_grants()},
+        indent=2, default=str,
+    )
+
+
+# ── Terminal Sessions ─────────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+def list_terminal_sessions() -> str:
+    """List currently active PTY-backed terminal sessions."""
+    from openbad.toolbelt.terminal_sessions import get_terminal_session_manager
+
+    return json.dumps(get_terminal_session_manager().list_sessions(), indent=2, default=str)
+
+
+@skill_server.tool()
+def create_terminal_session(
+    cwd: str,
+    shell: str = "/bin/bash",
+    requester: str = "session",
+) -> str:
+    """Create a PTY-backed interactive terminal session in an approved working directory.
+
+    Args:
+        cwd: Working directory for the shell session.
+        shell: Shell executable to launch (default /bin/bash).
+        requester: Requester identity, such as session or subsystem name.
+    """
+    from openbad.toolbelt.access_control import create_access_request
+    from openbad.toolbelt.terminal_sessions import get_terminal_session_manager
+
+    try:
+        session = get_terminal_session_manager().create_session(
+            cwd=cwd, requester=requester, shell=shell,
+        )
+    except PermissionError as exc:
+        record = create_access_request(
+            cwd, requester="skill:create_terminal_session",
+            reason="terminal session requested cwd access outside allowed roots",
+            prefer_parent=False,
+        )
+        return _fmt_access_with_record(f"working directory {cwd!r}", str(exc), record)
+    return json.dumps(session, indent=2, default=str)
+
+
+@skill_server.tool()
+def send_terminal_input(
+    session_id: str,
+    input: str,
+    append_newline: bool = True,
+) -> str:
+    """Send text input to an active PTY terminal session.
+
+    Args:
+        session_id: Terminal session identifier.
+        input: Text to send to the terminal.
+        append_newline: Whether to append a newline after the input (default true).
+    """
+    from openbad.toolbelt.terminal_sessions import get_terminal_session_manager
+
+    result = get_terminal_session_manager().send_input(
+        session_id, input, append_newline=append_newline,
+    )
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+def read_terminal_output(
+    session_id: str,
+    max_bytes: int = 8192,
+) -> str:
+    """Read the latest available output from an active PTY terminal session.
+
+    Args:
+        session_id: Terminal session identifier.
+        max_bytes: Maximum bytes of terminal output to return (default 8192).
+    """
+    from openbad.toolbelt.terminal_sessions import get_terminal_session_manager
+
+    result = get_terminal_session_manager().read_output(session_id, max_bytes=max_bytes)
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+def close_terminal_session(
+    session_id: str,
+    reason: str = "session-request",
+) -> str:
+    """Close an active PTY terminal session and release resources.
+
+    Args:
+        session_id: Terminal session identifier.
+        reason: Reason for closing the session.
+    """
+    from openbad.toolbelt.terminal_sessions import get_terminal_session_manager
+
+    result = get_terminal_session_manager().close_session(session_id, reason=reason)
+    return json.dumps(result, indent=2, default=str)
+
+
+# ── Web ───────────────────────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+def web_search(query: str) -> str:
+    """Search the web using the configured search engine.  Returns results with title, URL, and snippet.
+
+    Args:
+        query: The search query.
+    """
+    from openbad.toolbelt.web_search import WebSearchToolAdapter
+
+    adapter = WebSearchToolAdapter()
+    results = adapter.search(query)
+    return json.dumps(
+        [{"title": r.title, "url": r.url, "snippet": r.snippet} for r in results],
+        indent=2,
+    )
+
+
+@skill_server.tool()
+def web_fetch(url: str) -> str:
+    """Fetch the text content of a web page given its URL.
+
+    Args:
+        url: The URL to fetch.
+    """
+    from openbad.toolbelt.web_search import web_fetch as _fetch
+
+    return _fetch(url)
+
+
+# ── User Interaction ──────────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+def ask_user(question: str) -> str:
+    """Ask the user a question and wait for their response.  Use when you need clarification or confirmation.
+
+    Args:
+        question: The question to ask the user.
+    """
+    return (
+        f"[question_pending] The agent wants to ask: {question}\n"
+        "(Waiting for user response via the WUI.)"
+    )
+
+
+# ── System Diagnostics ────────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+async def get_mqtt_records(limit: int = 100) -> str:
+    """Retrieve recent MQTT messages from the nervous system bus.
+
+    Args:
+        limit: Maximum number of records to return (default 100).
+    """
+    from openbad.toolbelt.mqtt_records_tool import MqttRecordsToolAdapter
+
+    adapter = MqttRecordsToolAdapter()
+    records = await asyncio.to_thread(adapter.get_mqtt_records, limit=limit)
+    return json.dumps(records, indent=2, default=str)
+
+
+@skill_server.tool()
+async def get_system_logs(limit: int = 200, system: str = "") -> str:
+    """Retrieve recent persistent system log events.  Optionally filter by source subsystem.
+
+    Args:
+        limit: Maximum number of log lines (default 200).
+        system: Optional source module filter (e.g. 'wui', 'endocrine').
+    """
+    from openbad.toolbelt.event_log_tool import EventLogToolAdapter
+
+    adapter = EventLogToolAdapter()
+    events = await asyncio.to_thread(adapter.read_events, limit=limit, source=system)
+    return json.dumps(events, indent=2, default=str)
+
+
+@skill_server.tool()
+async def read_events(
+    limit: int = 100,
+    level: str = "",
+    source: str = "",
+    search: str = "",
+) -> str:
+    """Read entries from the persistent event log.  Supports filtering by level, source, and text search.
+
+    Args:
+        limit: Maximum number of events (default 100).
+        level: Filter by level (e.g. 'INFO', 'WARNING', 'ERROR').
+        source: Filter by event source.
+        search: Text search within event messages.
+    """
+    from openbad.toolbelt.event_log_tool import EventLogToolAdapter
+
+    adapter = EventLogToolAdapter()
+    events = await asyncio.to_thread(
+        adapter.read_events, limit=limit, level=level, source=source, search=search,
+    )
+    return json.dumps(events, indent=2, default=str)
+
+
+@skill_server.tool()
+async def write_event(
+    message: str,
+    level: str = "INFO",
+    source: str = "system",
+) -> str:
+    """Write a new entry to the persistent event log.
+
+    Args:
+        message: The event message.
+        level: Log level (default 'INFO').  One of DEBUG, INFO, WARNING, ERROR, CRITICAL.
+        source: Event source identifier (default 'system').
+    """
+    from openbad.toolbelt.event_log_tool import EventLogToolAdapter
+
+    adapter = EventLogToolAdapter()
+    ok = await asyncio.to_thread(adapter.write_event, message=message, level=level, source=source)
+    return "Event logged." if ok else "Failed to log event."
+
+
+@skill_server.tool()
+async def get_endocrine_status() -> str:
+    """Get the current endocrine system hormone levels (cortisol, dopamine, serotonin, etc.)."""
+    from openbad.toolbelt.endocrine_status_tool import EndocrineStatusToolAdapter
+
+    adapter = EndocrineStatusToolAdapter()
+    status = await asyncio.to_thread(adapter.get_endocrine_status)
+    return json.dumps(status, indent=2, default=str)
+
+
+@skill_server.tool()
+async def call_doctor(
+    reason: str,
+    source: str = "session",
+    context: dict[str, Any] | None = None,
+) -> str:
+    """Request a doctor visit over the embedded MQTT bus with a reason and optional context.
+
+    Args:
+        reason: Why the doctor should be called.
+        source: Requester identity, such as session or subsystem name.
+        context: Optional structured context payload for the doctor.
+    """
+    from openbad.toolbelt.doctor_tool import DoctorToolAdapter
+
+    adapter = DoctorToolAdapter()
+    result = await asyncio.to_thread(adapter.call_doctor, reason, source=source, context=context)
+    return json.dumps(result, indent=2, default=str)
+
+
+# ── Task Management ───────────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+async def get_tasks() -> str:
+    """Retrieve the current task list from the task manager."""
+    from openbad.toolbelt.tasks_diagnostics_tool import TasksDiagnosticsToolAdapter
+
+    adapter = TasksDiagnosticsToolAdapter()
+    tasks = await asyncio.to_thread(adapter.get_tasks)
+    return json.dumps(tasks, indent=2, default=str)
+
+
+@skill_server.tool()
+async def create_task(
+    title: str,
+    description: str = "",
+    owner: str = "user",
+) -> str:
+    """Create a new task in the task manager.
+
+    Args:
+        title: The task title.
+        description: Optional task description.
+        owner: Task owner ('user' or 'agent', default 'user').
+    """
+    from openbad.toolbelt.tasks_diagnostics_tool import TasksDiagnosticsToolAdapter
+
+    adapter = TasksDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(adapter.create_task, title=title, description=description, owner=owner)
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+async def update_task(
+    task_id: str,
+    title: str | None = None,
+    description: str | None = None,
+    owner: str | None = None,
+) -> str:
+    """Update mutable fields on an existing task.
+
+    Args:
+        task_id: The task ID to update.
+        title: Optional updated title.
+        description: Optional updated description.
+        owner: Optional updated owner.
+    """
+    from openbad.toolbelt.tasks_diagnostics_tool import TasksDiagnosticsToolAdapter
+
+    adapter = TasksDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(
+        adapter.update_task, task_id, title=title, description=description, owner=owner,
+    )
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+async def complete_task(task_id: str) -> str:
+    """Mark an existing task complete.
+
+    Args:
+        task_id: The task ID to complete.
+    """
+    from openbad.toolbelt.tasks_diagnostics_tool import TasksDiagnosticsToolAdapter
+
+    adapter = TasksDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(adapter.complete_task, task_id)
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+async def work_on_next_task(
+    source: str = "session",
+    reason: str = "next task requested",
+) -> str:
+    """Queue an event requesting work on the next eligible task.
+
+    Args:
+        source: Requester identity, such as session or subsystem name.
+        reason: Why the next task should be processed now.
+    """
+    from openbad.toolbelt.tasks_diagnostics_tool import TasksDiagnosticsToolAdapter
+
+    adapter = TasksDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(adapter.work_on_next_task, source=source, reason=reason)
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+async def work_on_task(
+    task_id: str,
+    source: str = "session",
+    reason: str = "specific task requested",
+) -> str:
+    """Queue an event requesting work on a specific task by ID.
+
+    Args:
+        task_id: The task ID to work on.
+        source: Requester identity, such as session or subsystem name.
+        reason: Why this specific task should be processed now.
+    """
+    from openbad.toolbelt.tasks_diagnostics_tool import TasksDiagnosticsToolAdapter
+
+    adapter = TasksDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(adapter.work_on_task, task_id, source=source, reason=reason)
+    return json.dumps(result, indent=2, default=str)
+
+
+# ── Research Management ───────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+async def get_research_nodes() -> str:
+    """List current research queue nodes."""
+    from openbad.toolbelt.research_diagnostics_tool import ResearchDiagnosticsToolAdapter
+
+    adapter = ResearchDiagnosticsToolAdapter()
+    nodes = await asyncio.to_thread(adapter.get_research_nodes)
+    return json.dumps(nodes, indent=2, default=str)
+
+
+@skill_server.tool()
+async def create_research_node(
+    title: str,
+    description: str = "",
+    priority: int = 0,
+) -> str:
+    """Create a new research node for exploration.
+
+    Args:
+        title: Research topic title.
+        description: Optional description of the research question.
+        priority: Priority (0 is normal, higher is more urgent).
+    """
+    from openbad.toolbelt.research_diagnostics_tool import ResearchDiagnosticsToolAdapter
+
+    adapter = ResearchDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(
+        adapter.create_research_node, title=title, description=description, priority=priority,
+    )
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+async def update_research_node(
+    node_id: str,
+    title: str | None = None,
+    description: str | None = None,
+    priority: int | None = None,
+    source_task_id: str | None = None,
+) -> str:
+    """Update a pending research node.
+
+    Args:
+        node_id: The research node ID to update.
+        title: Optional updated title.
+        description: Optional updated description.
+        priority: Optional updated priority.
+        source_task_id: Optional related task ID.
+    """
+    from openbad.toolbelt.research_diagnostics_tool import ResearchDiagnosticsToolAdapter
+
+    adapter = ResearchDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(
+        adapter.update_research_node, node_id,
+        title=title, description=description,
+        priority=priority, source_task_id=source_task_id,
+    )
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+async def complete_research_node(node_id: str) -> str:
+    """Mark a research node complete.
+
+    Args:
+        node_id: The research node ID to complete.
+    """
+    from openbad.toolbelt.research_diagnostics_tool import ResearchDiagnosticsToolAdapter
+
+    adapter = ResearchDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(adapter.complete_research_node, node_id)
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+async def work_on_next_research(
+    source: str = "session",
+    reason: str = "next research requested",
+) -> str:
+    """Queue an event requesting work on the next eligible research item.
+
+    Args:
+        source: Requester identity, such as session or subsystem name.
+        reason: Why the next research item should be processed now.
+    """
+    from openbad.toolbelt.research_diagnostics_tool import ResearchDiagnosticsToolAdapter
+
+    adapter = ResearchDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(adapter.work_on_next_research, source=source, reason=reason)
+    return json.dumps(result, indent=2, default=str)
+
+
+@skill_server.tool()
+async def work_on_research(
+    node_id: str,
+    source: str = "session",
+    reason: str = "specific research requested",
+) -> str:
+    """Queue an event requesting work on a specific research item by ID.
+
+    Args:
+        node_id: The research node ID to work on.
+        source: Requester identity, such as session or subsystem name.
+        reason: Why this specific research item should be processed now.
+    """
+    from openbad.toolbelt.research_diagnostics_tool import ResearchDiagnosticsToolAdapter
+
+    adapter = ResearchDiagnosticsToolAdapter()
+    result = await asyncio.to_thread(adapter.work_on_research, node_id, source=source, reason=reason)
+    return json.dumps(result, indent=2, default=str)
+
+
+# ── MCP Bridge (meta-tool for external MCP servers) ──────────────────── #
+
+
+@skill_server.tool()
+async def mcp_bridge(
+    server: str,
+    tool_name: str,
+    arguments: dict[str, Any] | None = None,
+) -> str:
+    """Call a tool on a connected MCP (Model Context Protocol) server.
+
+    Args:
+        server: Name of the MCP server to call.
+        tool_name: Name of the tool on the MCP server.
+        arguments: Arguments to pass to the MCP tool.
+    """
+    from openbad.toolbelt.mcp_bridge import MCPRunner
+
+    runner = MCPRunner.stdio([server])
+    async with runner:
+        result = await runner.call_tool(tool_name, arguments or {})
+    return json.dumps(result, indent=2, default=str) if not isinstance(result, str) else result
+
+
+# ── Public API for the agentic loop ──────────────────────────────────── #
+
+
+def _mcp_tool_to_openai(tool: Any) -> dict[str, Any]:
+    """Convert a single MCP Tool object to OpenAI function-calling format."""
+    schema = tool.inputSchema or {}
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description or "",
+            "parameters": {
+                "type": schema.get("type", "object"),
+                "properties": schema.get("properties", {}),
+                "required": schema.get("required", []),
+            },
+        },
+    }
+
+
+async def _async_get_openai_tools() -> list[dict[str, Any]]:
+    """Async helper — query the MCP server for tools and convert schemas."""
+    mcp_tools = await skill_server.list_tools()
+    return [_mcp_tool_to_openai(t) for t in mcp_tools]
+
+
+def get_openai_tools() -> list[dict[str, Any]]:
+    """Return OpenAI-format tool schemas for all embedded skills.
+
+    Designed to be called from both sync and async contexts.  If an event loop
+    is already running (e.g. inside aiohttp), this uses eager evaluation via
+    a cached result so it doesn't block.
+    """
+    # Cache to avoid repeated MCP queries during a single server lifetime.
+    if not hasattr(get_openai_tools, "_cache"):
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            # Create a future and schedule the coroutine
+            import concurrent.futures
+            future: concurrent.futures.Future[list[dict[str, Any]]] = concurrent.futures.Future()
+
+            async def _populate() -> None:
+                try:
+                    result = await _async_get_openai_tools()
+                    future.set_result(result)
+                except Exception as exc:
+                    future.set_exception(exc)
+
+            loop.create_task(_populate())
+            # We can't block here, so return empty on first call and rely
+            # on the cache being populated for subsequent calls.
+            # Better approach: eagerly populate at startup.
+            return []
+        else:
+            get_openai_tools._cache = asyncio.run(_async_get_openai_tools())  # type: ignore[attr-defined]
+    return get_openai_tools._cache  # type: ignore[attr-defined]
+
+
+async def async_get_openai_tools() -> list[dict[str, Any]]:
+    """Async version — always preferred when an event loop is available."""
+    if not hasattr(get_openai_tools, "_cache"):
+        get_openai_tools._cache = await _async_get_openai_tools()  # type: ignore[attr-defined]
+    return get_openai_tools._cache  # type: ignore[attr-defined]
+
+
+async def call_skill(name: str, arguments: dict[str, Any]) -> str:
+    """Dispatch a skill call by name and return a plain-text result string.
+
+    This replaces the old ``dispatch_tool_call()`` for embedded skills.
+    """
+    try:
+        result = await skill_server.call_tool(name, arguments)
+        # result is (content_list, structured_content | None)
+        content_list, _structured = result
+        parts: list[str] = []
+        for item in content_list:
+            if hasattr(item, "text"):
+                parts.append(item.text)
+            else:
+                parts.append(str(item))
+        text = "\n".join(parts) if parts else ""
+        return _truncate(text)
+    except Exception as exc:
+        log.warning("Skill %s raised: %s", name, exc, exc_info=True)
+        return f"Error executing {name}: {type(exc).__name__}: {exc}"

--- a/src/openbad/toolbelt/dispatch.py
+++ b/src/openbad/toolbelt/dispatch.py
@@ -69,6 +69,33 @@ async def dispatch_tool_call(name: str, arguments: dict[str, Any]) -> str:
 async def _dispatch(name: str, args: dict[str, Any]) -> str:
     """Route to the correct adapter."""
 
+    if name == "find_files":
+        from openbad.toolbelt.fs_tool import find_files
+        from openbad.toolbelt.access_control import create_access_request
+
+        try:
+            return find_files(
+                str(args.get("pattern") or ""),
+                cwd=str(args.get("cwd") or "."),
+                limit=int(args.get("limit", 50)),
+            )
+        except PermissionError as exc:
+            requested_cwd = str(args.get("cwd") or ".")
+            detail = str(exc)
+            if "outside allowed roots" in detail:
+                record = create_access_request(
+                    requested_cwd,
+                    requester="tool:find_files",
+                    reason=f"find_files requested cwd access for pattern {args.get('pattern', '')}",
+                    prefer_parent=False,
+                )
+                return _format_access_request_with_record(
+                    f"search root {requested_cwd!r}",
+                    detail,
+                    record,
+                )
+            return f"Error executing find_files: PermissionError: {detail}"
+
     if name == "read_file":
         from openbad.toolbelt.fs_tool import read_file
         from openbad.toolbelt.access_control import create_access_request

--- a/src/openbad/toolbelt/fs_tool.py
+++ b/src/openbad/toolbelt/fs_tool.py
@@ -23,8 +23,11 @@ import logging
 import os
 import tempfile
 import uuid
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import json
 
 from openbad.immune_system.rules_engine import FileOperationRule
 from openbad.toolbelt.access_control import effective_allowed_roots
@@ -187,6 +190,54 @@ def read_file(
             f"read_file deferred: disk saturated (path={resolved!r})"
         )
     return Path(resolved).read_text(encoding=encoding)
+
+
+def find_files(
+    pattern: str,
+    *,
+    cwd: str = ".",
+    limit: int = 50,
+) -> str:
+    """Find files under *cwd* matching *pattern* and return JSON paths.
+
+    Parameters
+    ----------
+    pattern:
+        Glob-like pattern or plain substring to search for.
+    cwd:
+        Root directory to search within. Must be inside allowed roots.
+    limit:
+        Maximum number of matches to return.
+    """
+    resolved_root = _validate(cwd)
+    root = Path(resolved_root)
+    needle = pattern.strip()
+    max_results = max(1, min(int(limit), 200))
+
+    results: list[str] = []
+    if any(char in needle for char in "*?[]"):
+        glob_pattern = needle if "/" in needle or needle.startswith("**") else f"**/{needle}"
+        iterator = root.glob(glob_pattern)
+        for candidate in iterator:
+            if not candidate.is_file():
+                continue
+            results.append(str(candidate.resolve(strict=False)))
+            if len(results) >= max_results:
+                break
+    else:
+        lowered = needle.lower()
+        for candidate in root.rglob("*"):
+            if not candidate.is_file():
+                continue
+            resolved_candidate = str(candidate.resolve(strict=False))
+            if lowered and lowered not in candidate.name.lower() and lowered not in resolved_candidate.lower():
+                continue
+            results.append(resolved_candidate)
+            if len(results) >= max_results:
+                break
+
+    results = sorted(dict.fromkeys(results))
+    return json.dumps(results, indent=2)
 
 
 def write_file(

--- a/src/openbad/toolbelt/schemas.py
+++ b/src/openbad/toolbelt/schemas.py
@@ -46,6 +46,25 @@ def _tool(
 
 TOOL_SCHEMAS: list[dict[str, Any]] = [
     _tool(
+        "find_files",
+        "Find files under a directory using a glob or substring pattern.",
+        {
+            "pattern": {
+                "type": "string",
+                "description": "Glob-like pattern or plain substring to search for.",
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Directory to search within. Defaults to the current working directory. Omit this unless the directory was explicitly provided by the user or a prior tool result.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of matches to return (default: 50).",
+            },
+        },
+        ["pattern"],
+    ),
+    _tool(
         "read_file",
         "Read the contents of a file. Return the text content.",
         {

--- a/src/openbad/wui/chat_pipeline.py
+++ b/src/openbad/wui/chat_pipeline.py
@@ -33,8 +33,8 @@ from openbad.cognitive.context_manager import (
 from openbad.cognitive.providers.base import ProviderAdapter
 from openbad.cognitive.providers.github_copilot import GitHubCopilotProvider
 from openbad.cognitive.providers.litellm_adapter import LiteLLMAdapter
-from openbad.toolbelt.dispatch import dispatch_tool_call
-from openbad.toolbelt.schemas import TOOL_SCHEMAS
+from openbad.skills import call_skill
+from openbad.skills.server import async_get_openai_tools
 from openbad.identity.onboarding import (
     INTERVIEW_SYSTEM_PROMPT,
     USER_INTERVIEW_SYSTEM_PROMPT,
@@ -159,6 +159,7 @@ def _build_tooling_prompt(modulation: Any | None) -> str:
         "You have tool access through the toolbelt. When the answer depends on filesystem state, terminal output, logs, tasks, research nodes, or external content, call tools instead of narrating what you would do.",
         "Do not ask the user for permission before reversible reads, searches, diagnostics, or other already-allowed inspection steps.",
         "Use ask_user(question) only when blocked on missing business context, explicit approval, or destructive or irreversible actions.",
+        "If the user mentions a filename or spec and the exact path is not verified, use find_files before read_file. Search the current workspace first, and never invent directories, absolute paths, or a guessed cwd.",
         "If a tool returns [access_request], the system already created the path access request automatically. Tell the user to approve it in Toolbelt -> Path Access Requests, then continue with any non-blocked next steps.",
         "Never fabricate tool output, file paths, or observed system state.",
     ]
@@ -1254,7 +1255,7 @@ async def _agentic_stream(
     """
     import asyncio as _asyncio
 
-    tools = TOOL_SCHEMAS
+    tools = await async_get_openai_tools()
     total_tokens = 0
     access_notices: list[str] = []
     # Work on a mutable copy so tool messages accumulate across iterations.
@@ -1323,7 +1324,7 @@ async def _agentic_stream(
 
             try:
                 result = await _asyncio.wait_for(
-                    dispatch_tool_call(fn_name, fn_args),
+                    call_skill(fn_name, fn_args),
                     timeout=_TOOL_CALL_TIMEOUT_S,
                 )
             except TimeoutError:

--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -1904,7 +1904,7 @@ async def _put_senses(request: web.Request) -> web.Response:
 
 def _serialize_toolbelt(registry) -> dict:
     """Serialize ToolRegistry state for JSON response."""
-    from openbad.toolbelt.schemas import TOOL_SCHEMAS  # noqa: PLC0415
+    from openbad.skills.server import get_openai_tools  # noqa: PLC0415
 
     belt_names: dict[str, str | None] = {}
     for role, tool in registry.get_belt().items():
@@ -1938,7 +1938,7 @@ def _serialize_toolbelt(registry) -> dict:
             "name": schema["function"]["name"],
             "description": schema["function"]["description"],
         }
-        for schema in TOOL_SCHEMAS
+        for schema in get_openai_tools()
     ]
 
     return {
@@ -3137,6 +3137,7 @@ _CAPABILITIES_CATALOG = [
         "module": "openbad.toolbelt.fs_tool",
         "description": "Read and write files within permitted paths, governed by immune-system path rules and disk I/O interoception.",
         "tools": [
+            {"name": "find_files", "signature": "find_files(pattern: str, cwd: str | None = None, limit: int = 50) -> list[str]", "description": "Locate files under a permitted directory using a glob or substring pattern before reading them."},
             {"name": "read_file", "signature": "read_file(path: str) -> str", "description": "Read a file and return its contents as text."},
             {"name": "write_file", "signature": "write_file(path: str, content: str) -> None", "description": "Write content to a file. Blocked for restricted paths (/etc/, ~/.ssh/, system binaries)."},
         ],

--- a/tests/test_chat_pipeline.py
+++ b/tests/test_chat_pipeline.py
@@ -208,6 +208,8 @@ def test_assemble_context_includes_access_approval_guidance():
 
     assert "Toolbelt -> Path Access Requests" in context.system_prompt
     assert "already created the path access request automatically" in context.system_prompt
+    assert "use find_files before read_file" in context.system_prompt
+    assert "Search the current workspace first" in context.system_prompt
 
 
 @pytest.mark.asyncio
@@ -454,7 +456,7 @@ async def test_agentic_stream_surfaces_access_request_notice(monkeypatch):
             "That request is already created. Tell the user to approve it in Toolbelt -> Path Access Requests, then retry."
         )
 
-    monkeypatch.setattr(chat_pipeline, "dispatch_tool_call", _fake_dispatch)
+    monkeypatch.setattr(chat_pipeline, "call_skill", _fake_dispatch)
 
     chunks = [
         chunk

--- a/tests/test_litellm_agentic.py
+++ b/tests/test_litellm_agentic.py
@@ -47,7 +47,7 @@ class TestLiteLLMModelName:
 
 class TestToolSchemas:
     def test_schema_count(self):
-        assert len(TOOL_SCHEMAS) == 31
+        assert len(TOOL_SCHEMAS) == 32
 
     def test_all_have_required_fields(self):
         for schema in TOOL_SCHEMAS:
@@ -65,7 +65,7 @@ class TestToolSchemas:
     def test_known_tools_present(self):
         names = {s["function"]["name"] for s in TOOL_SCHEMAS}
         expected = {
-            "read_file", "write_file", "exec_command", "get_path_access_status",
+            "find_files", "read_file", "write_file", "exec_command", "get_path_access_status",
             "list_terminal_sessions", "create_terminal_session", "send_terminal_input",
             "read_terminal_output", "close_terminal_session", "web_search",
             "web_fetch", "ask_user", "get_mqtt_records", "get_system_logs",
@@ -99,6 +99,19 @@ class TestToolDispatch:
         with patch("openbad.toolbelt.fs_tool.ALLOWED_ROOTS", [str(tmp_path)]):
             result = await dispatch_tool_call("read_file", {"path": str(p)})
         assert "world" in result
+
+    @pytest.mark.asyncio
+    async def test_find_files(self, tmp_path):
+        nested = tmp_path / "docs"
+        nested.mkdir()
+        target = nested / "11-OpenBaD Library System Upgrade Spec.md"
+        target.write_text("spec")
+        with patch("openbad.toolbelt.fs_tool.ALLOWED_ROOTS", [str(tmp_path)]):
+            result = await dispatch_tool_call(
+                "find_files",
+                {"pattern": "*Library System Upgrade Spec.md", "cwd": str(tmp_path)},
+            )
+        assert str(target) in result
 
     @pytest.mark.asyncio
     async def test_write_file(self, tmp_path):
@@ -322,7 +335,7 @@ async def test_agentic_stream_with_tool_calls(_reset_pipeline):
     with (
         patch("litellm.acompletion", new_callable=AsyncMock) as mock_llm,
         patch(
-            "openbad.wui.chat_pipeline.dispatch_tool_call",
+            "openbad.wui.chat_pipeline.call_skill",
             new_callable=AsyncMock,
         ) as mock_dispatch,
     ):
@@ -361,7 +374,7 @@ async def test_agentic_stream_with_usage_tracking_wrapper(_reset_pipeline):
     with (
         patch("litellm.acompletion", new_callable=AsyncMock) as mock_llm,
         patch(
-            "openbad.wui.chat_pipeline.dispatch_tool_call",
+            "openbad.wui.chat_pipeline.call_skill",
             new_callable=AsyncMock,
         ) as mock_dispatch,
     ):
@@ -403,7 +416,7 @@ async def test_agentic_stream_does_not_double_count_tokens(_reset_pipeline):
     with (
         patch("litellm.acompletion", new_callable=AsyncMock) as mock_llm,
         patch(
-            "openbad.wui.chat_pipeline.dispatch_tool_call",
+            "openbad.wui.chat_pipeline.call_skill",
             new_callable=AsyncMock,
         ) as mock_dispatch,
     ):
@@ -436,7 +449,7 @@ async def test_agentic_stream_max_iterations(_reset_pipeline):
     with (
         patch("litellm.acompletion", new_callable=AsyncMock) as mock_llm,
         patch(
-            "openbad.wui.chat_pipeline.dispatch_tool_call",
+            "openbad.wui.chat_pipeline.call_skill",
             new_callable=AsyncMock,
         ) as mock_dispatch,
     ):

--- a/tests/test_tool_agent.py
+++ b/tests/test_tool_agent.py
@@ -56,7 +56,7 @@ async def test_run_tool_agent_uses_agentic_tools() -> None:
         ]
     )
 
-    with patch("openbad.toolbelt.dispatch.dispatch_tool_call", new_callable=AsyncMock) as dispatch:
+    with patch("openbad.autonomy.tool_agent.call_skill", new_callable=AsyncMock) as dispatch:
         dispatch.return_value = '{"task_id": "task-123"}'
         result = await run_tool_agent(
             adapter,
@@ -93,7 +93,7 @@ async def test_run_tool_agent_marks_missing_creation_as_unverified() -> None:
         ]
     )
 
-    with patch("openbad.toolbelt.dispatch.dispatch_tool_call", new_callable=AsyncMock) as dispatch:
+    with patch("openbad.autonomy.tool_agent.call_skill", new_callable=AsyncMock) as dispatch:
         dispatch.return_value = "{}"
         result = await run_tool_agent(
             adapter,
@@ -125,7 +125,7 @@ async def test_run_tool_agent_blocks_tool_call_via_validator() -> None:
         ]
     )
 
-    with patch("openbad.toolbelt.dispatch.dispatch_tool_call", new_callable=AsyncMock) as dispatch:
+    with patch("openbad.autonomy.tool_agent.call_skill", new_callable=AsyncMock) as dispatch:
         result = await run_tool_agent(
             adapter,
             "test-model",


### PR DESCRIPTION
## Summary

Create a native FastMCP server for embedded skills (`openbad.skills`), cleanly separated from the toolbelt plugin system (`openbad.toolbelt`).

### Changes
- **New** `src/openbad/skills/` package with FastMCP server exposing all 32 built-in tools via `@skill_server.tool()` decorators
- Schemas auto-derived from Python type hints instead of hand-maintained JSON
- Add `find_files` tool to toolbelt (fs_tool, dispatch, schemas)
- Wire `tool_agent.py`, `chat_pipeline.py`, `server.py` to use `openbad.skills` (`call_skill`, `async_get_openai_tools`) instead of toolbelt dispatch/schemas
- Add `mcp>=1.20` dependency to pyproject.toml
- Update test patch targets to match new import paths

### Architecture
- **Embedded skills** (`openbad.skills`): Built-in tools that ship with OpenBaD, work out of the box
- **Toolbelt** (`openbad.toolbelt`): Plugin system for user-built extensions (unchanged, separate concern)

### Testing
42 tests in affected files pass. Full suite: 3502 passed, 32 pre-existing failures.