### PR TITLE
Fix: clarify embedded skills vs mcp_bridge in system prompts

### DIFF
--- a/src/openbad/autonomy/tool_agent.py
+++ b/src/openbad/autonomy/tool_agent.py
@@ -14,10 +14,13 @@ _MAX_TOOL_ITERATIONS = 6
 _TOOL_CALL_TIMEOUT_S = 20
 
 _TOOLING_BASE_PROMPT = (
-    "You have access to OpenBaD's embedded tools. Use them proactively when they improve"
-    " the quality of the work. You may inspect files, events, MQTT records, endocrine"
-    " state, tasks, and research nodes, and you may create or update task/research"
-    " entries when follow-up work is warranted. Never fabricate tool results."
+    "You have access to OpenBaD's embedded skills. These are built-in tools provided"
+    " directly to you — they are NOT on an external server. Use them proactively when"
+    " they improve the quality of the work. You may inspect files, events, MQTT records,"
+    " endocrine state, tasks, and research nodes, and you may create or update"
+    " task/research entries when follow-up work is warranted. Never fabricate tool results."
+    " The mcp_bridge tool is ONLY for connecting to external third-party MCP servers."
+    " Do not use mcp_bridge to access your own embedded skills — just call them directly."
     " If the user refers to a file but you have not verified its exact path yet, call"
     " find_files before read_file. Search the current workspace first, and do not"
     " supply a guessed absolute cwd such as another user's home directory unless the"

--- a/src/openbad/wui/chat_pipeline.py
+++ b/src/openbad/wui/chat_pipeline.py
@@ -156,7 +156,8 @@ def _clamp(value: float, low: float, high: float) -> float:
 
 def _build_tooling_prompt(modulation: Any | None) -> str:
     lines = [
-        "You have tool access through the toolbelt. When the answer depends on filesystem state, terminal output, logs, tasks, research nodes, or external content, call tools instead of narrating what you would do.",
+        "You have access to OpenBaD's embedded skills. These are built-in tools provided directly to you — they are NOT on an external server. When the answer depends on filesystem state, terminal output, logs, tasks, research nodes, or external content, call your tools instead of narrating what you would do.",
+        "The mcp_bridge tool is ONLY for connecting to external third-party MCP servers. Do not use mcp_bridge to access your own embedded skills — just call them directly by name.",
         "Do not ask the user for permission before reversible reads, searches, diagnostics, or other already-allowed inspection steps.",
         "Use ask_user(question) only when blocked on missing business context, explicit approval, or destructive or irreversible actions.",
         "If the user mentions a filename or spec and the exact path is not verified, use find_files before read_file. Search the current workspace first, and never invent directories, absolute paths, or a guessed cwd.",


### PR DESCRIPTION
## Problem

When asked about the skills MCP server, Bonsai-8B used `mcp_bridge` to try to reach it — treating its own embedded tools as an external MCP server.

## Root Cause

System prompts said "tool access through the toolbelt" without clarifying that the LLM's tools ARE the embedded skills provided directly, and that `mcp_bridge` is only for external third-party servers.

## Fix

- Both system prompts (chat_pipeline + tool_agent) now explicitly state:
  - Tools are embedded skills provided directly — not on an external server
  - `mcp_bridge` is ONLY for connecting to external third-party MCP servers
  - Call embedded skills directly by name

## Testing
42/42 affected tests pass.