### PR TITLE
Add list_embedded_skills self-introspection tool

### DIFF
--- a/src/openbad/skills/server.py
+++ b/src/openbad/skills/server.py
@@ -709,6 +709,23 @@ async def mcp_bridge(
     return json.dumps(result, indent=2, default=str) if not isinstance(result, str) else result
 
 
+# ── Self-introspection ───────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+async def list_embedded_skills() -> str:
+    """List all embedded skills available to you in this session.
+
+    Call this when asked about your tools, capabilities, or embedded skills.
+    These are YOUR tools — you call them directly by name.
+    """
+    tools = await skill_server.list_tools()
+    lines = [f"You have {len(tools)} embedded skills:\n"]
+    for t in tools:
+        lines.append(f"- **{t.name}**: {t.description.splitlines()[0]}")
+    return "\n".join(lines)
+
+
 # ── Public API for the agentic loop ──────────────────────────────────── #
 
 

--- a/src/openbad/wui/chat_pipeline.py
+++ b/src/openbad/wui/chat_pipeline.py
@@ -158,6 +158,7 @@ def _build_tooling_prompt(modulation: Any | None) -> str:
     lines = [
         "You have access to OpenBaD's embedded skills. These are built-in tools provided directly to you — they are NOT on an external server. When the answer depends on filesystem state, terminal output, logs, tasks, research nodes, or external content, call your tools instead of narrating what you would do.",
         "The mcp_bridge tool is ONLY for connecting to external third-party MCP servers. Do not use mcp_bridge to access your own embedded skills — just call them directly by name.",
+        "If asked about your tools or capabilities, call list_embedded_skills to see everything available to you.",
         "Do not ask the user for permission before reversible reads, searches, diagnostics, or other already-allowed inspection steps.",
         "Use ask_user(question) only when blocked on missing business context, explicit approval, or destructive or irreversible actions.",
         "If the user mentions a filename or spec and the exact path is not verified, use find_files before read_file. Search the current workspace first, and never invent directories, absolute paths, or a guessed cwd.",


### PR DESCRIPTION
## Problem

Small models (Bonsai-8B) say "I cannot check the embedded skills" when asked about their tools — they can't introspect on their own tool list.

## Fix

- Add `list_embedded_skills` tool (tool #33) that enumerates all embedded skills
- System prompt tells the LLM: "If asked about your tools or capabilities, call list_embedded_skills"

## Testing
42/42 tests pass. Tool verified: 33 tools registered.