### PR TITLE
Register Bonsai-8B as function-call-capable with LiteLLM

### DIFF
--- a/src/openbad/cognitive/providers/litellm_adapter.py
+++ b/src/openbad/cognitive/providers/litellm_adapter.py
@@ -30,6 +30,17 @@ from openbad.cognitive.providers.base import (
 
 log = logging.getLogger(__name__)
 
+# Register local models that LiteLLM doesn't know about as supporting
+# function calling.  Without this, LiteLLM may silently drop tool
+# definitions when formatting requests to these models.
+litellm.register_model(
+    {
+        "ollama/bonsai-8b": {"supports_function_calling": True},
+        "ollama_chat/bonsai-8b": {"supports_function_calling": True},
+        "openai/Bonsai-8B.gguf": {"supports_function_calling": True},
+    }
+)
+
 
 # Map internal provider names → LiteLLM model prefix.
 # NOTE: ``github-copilot`` is deliberately mapped to ``openai`` so that


### PR DESCRIPTION
## Problem
LiteLLM doesn't recognize Bonsai-8B (Qwen3-based, trained for tool calling) in its model registry. `supports_function_calling()` returned `False`, potentially causing tools to be dropped.

## Fix
Register all three model name variants at module import:
- `ollama/bonsai-8b`
- `ollama_chat/bonsai-8b`
- `openai/Bonsai-8B.gguf`

Combined with `--jinja` flag on llama-server, this enables the full native tool calling pipeline.

## Testing
42/42 tests pass. All variants confirmed `supports_function_calling=True`.