### PR TITLE
#512: Create LangChain model wrapper around ModelRouter

### DIFF
--- a/src/openbad/frameworks/langchain_model.py
+++ b/src/openbad/frameworks/langchain_model.py
@@ -1,0 +1,262 @@
+"""LangChain ``BaseChatModel`` wrapper around OpenBaD's ``ModelRouter``.
+
+``OpenBaDChatModel`` presents a standard LangChain chat model interface
+while delegating provider selection, cortisol-based downgrade, and fallback
+chains to the existing :class:`~openbad.cognitive.model_router.ModelRouter`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+
+from openbad.cognitive.model_router import ModelRouter, Priority
+from openbad.cognitive.providers.base import ProviderAdapter
+from openbad.usage_recorder import record_usage_event
+
+log = logging.getLogger(__name__)
+
+
+def _messages_to_prompt(messages: list[BaseMessage]) -> str:
+    """Flatten LangChain messages into a single prompt string.
+
+    This is used when the underlying ``ProviderAdapter`` only exposes a
+    plain-text ``complete()`` / ``stream()`` interface.
+    """
+    parts: list[str] = []
+    for msg in messages:
+        content = msg.content if isinstance(msg.content, str) else str(msg.content)
+        if isinstance(msg, SystemMessage):
+            parts.append(f"[system] {content}")
+        elif isinstance(msg, HumanMessage):
+            parts.append(f"[user] {content}")
+        elif isinstance(msg, AIMessage):
+            parts.append(f"[assistant] {content}")
+        else:
+            parts.append(content)
+    return "\n\n".join(parts)
+
+
+def _extract_system_and_user(messages: list[BaseMessage]) -> tuple[str, str]:
+    """Split messages into a system prompt and the remaining user prompt."""
+    system_parts: list[str] = []
+    user_parts: list[str] = []
+    for msg in messages:
+        content = msg.content if isinstance(msg.content, str) else str(msg.content)
+        if isinstance(msg, SystemMessage):
+            system_parts.append(content)
+        else:
+            role = "user" if isinstance(msg, HumanMessage) else "assistant"
+            user_parts.append(f"[{role}] {content}")
+    return "\n\n".join(system_parts), "\n\n".join(user_parts)
+
+
+class OpenBaDChatModel(BaseChatModel):
+    """LangChain chat model backed by OpenBaD's ``ModelRouter``.
+
+    Parameters
+    ----------
+    router:
+        The :class:`~openbad.cognitive.model_router.ModelRouter` that
+        selects provider/model based on priority, cortisol, and budget.
+    priority:
+        Default routing priority.  Can be overridden per-call via
+        ``model_kwargs={"priority": Priority.CRITICAL}``.
+    cortisol:
+        Current cortisol level (0.0–1.0).  When above the router's
+        threshold the model is downgraded to cheaper alternatives.
+    system_name:
+        Identifier used for usage-recording attribution.
+    """
+
+    # Pydantic v2 fields — LangChain requires these to be class-level.
+    router: Any  # ModelRouter (Any to avoid pydantic issues with complex types)
+    priority: int = Priority.MEDIUM
+    cortisol: float = 0.0
+    system_name: str = "chat"
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    # ------------------------------------------------------------------
+    # Required BaseChatModel overrides
+    # ------------------------------------------------------------------
+
+    @property
+    def _llm_type(self) -> str:
+        return "openbad"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {
+            "priority": self.priority,
+            "cortisol": self.cortisol,
+            "system_name": self.system_name,
+        }
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Synchronous generation — delegates to async via event loop."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(asyncio.run, self._agenerate(messages, stop=stop, **kwargs))
+                return future.result()
+        return asyncio.run(self._agenerate(messages, stop=stop, **kwargs))
+
+    async def _agenerate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: Any | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Async generation using the model router."""
+        priority = Priority(kwargs.pop("priority", self.priority))
+        cortisol = kwargs.pop("cortisol", self.cortisol)
+
+        adapter, model_id, decision = await self._route(priority, cortisol)
+        prompt = _messages_to_prompt(messages)
+
+        result = await adapter.complete(prompt, model_id, **kwargs)
+
+        self._record_usage(
+            provider=decision.provider,
+            model=model_id,
+            tokens=result.tokens_used,
+        )
+
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(content=result.content),
+                    generation_info={
+                        "provider": decision.provider,
+                        "model_id": model_id,
+                        "tokens_used": result.tokens_used,
+                        "latency_ms": result.latency_ms,
+                        "cortisol_downgrade": decision.cortisol_downgrade,
+                        "fallback_index": decision.fallback_index,
+                    },
+                )
+            ],
+            llm_output={
+                "provider": decision.provider,
+                "model_id": model_id,
+                "tokens_used": result.tokens_used,
+            },
+        )
+
+    async def _astream(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: Any | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        """Async streaming using the model router."""
+        priority = Priority(kwargs.pop("priority", self.priority))
+        cortisol = kwargs.pop("cortisol", self.cortisol)
+
+        adapter, model_id, decision = await self._route(priority, cortisol)
+        prompt = _messages_to_prompt(messages)
+
+        total_tokens = 0
+        async for token in adapter.stream(prompt, model_id, **kwargs):
+            total_tokens += 1
+            chunk = ChatGenerationChunk(
+                message=AIMessageChunk(content=token),
+                generation_info={"provider": decision.provider, "model_id": model_id},
+            )
+            if run_manager:
+                await run_manager.on_llm_new_token(token)
+            yield chunk
+
+        self._record_usage(
+            provider=decision.provider,
+            model=model_id,
+            tokens=total_tokens,
+        )
+
+    def _stream(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        """Synchronous streaming — wraps async stream."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        async def _collect() -> list[ChatGenerationChunk]:
+            chunks: list[ChatGenerationChunk] = []
+            async for chunk in self._astream(messages, stop=stop, **kwargs):
+                chunks.append(chunk)
+            return chunks
+
+        if loop and loop.is_running():
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(asyncio.run, _collect())
+                yield from future.result()
+        else:
+            yield from asyncio.run(_collect())
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _route(
+        self,
+        priority: Priority,
+        cortisol: float,
+    ) -> tuple[ProviderAdapter, str, Any]:
+        """Delegate to the model router."""
+        router: ModelRouter = self.router
+        return await router.route(priority, cortisol=cortisol)
+
+    def _record_usage(
+        self,
+        *,
+        provider: str,
+        model: str,
+        tokens: int,
+    ) -> None:
+        """Record token usage for observability."""
+        if tokens > 0:
+            try:
+                record_usage_event(
+                    provider=provider,
+                    model=model,
+                    system=self.system_name,
+                    tokens=tokens,
+                )
+            except Exception:
+                log.debug("Failed to record usage", exc_info=True)

--- a/tests/test_langchain_model.py
+++ b/tests/test_langchain_model.py
@@ -1,0 +1,287 @@
+"""Tests for the OpenBaDChatModel LangChain wrapper."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from openbad.cognitive.model_router import (
+    FallbackChain,
+    ModelRouter,
+    Priority,
+    RouteStep,
+)
+from openbad.cognitive.providers.base import (
+    CompletionResult,
+    HealthStatus,
+    ProviderAdapter,
+)
+from openbad.cognitive.providers.registry import ProviderRegistry
+from openbad.frameworks.langchain_model import OpenBaDChatModel, _messages_to_prompt
+
+# ── Helpers ───────────────────────────────────────────────────────────── #
+
+
+class FakeAdapter(ProviderAdapter):
+    """Minimal provider adapter for testing."""
+
+    def __init__(self, content: str = "Hello!", tokens: int = 10) -> None:
+        self._content = content
+        self._tokens = tokens
+
+    async def complete(
+        self, prompt: str, model_id: str | None = None, **kw: Any,
+    ) -> CompletionResult:
+        return CompletionResult(
+            content=self._content,
+            model_id=model_id or "test-model",
+            provider="fake",
+            tokens_used=self._tokens,
+            latency_ms=42.0,
+        )
+
+    async def stream(
+        self, prompt: str, model_id: str | None = None, **kw: Any,
+    ) -> AsyncIterator[str]:
+        for token in self._content.split():
+            yield token
+
+    async def list_models(self) -> list:
+        return []
+
+    async def health_check(self) -> HealthStatus:
+        return HealthStatus(provider="fake", available=True)
+
+
+class UnhealthyAdapter(FakeAdapter):
+    """Adapter that reports unhealthy."""
+
+    async def health_check(self) -> HealthStatus:
+        return HealthStatus(provider="unhealthy", available=False)
+
+
+def _make_registry(*adapters: tuple[str, ProviderAdapter]) -> ProviderRegistry:
+    """Build a ProviderRegistry with pre-registered adapters."""
+    registry = ProviderRegistry()
+    for name, adapter in adapters:
+        registry.register(name, adapter)
+    return registry
+
+
+def _make_router(
+    registry: ProviderRegistry,
+    chains: dict[Priority, FallbackChain] | None = None,
+    cortisol_threshold: float = 0.8,
+) -> ModelRouter:
+    return ModelRouter(
+        registry=registry,
+        chains=chains,
+        cortisol_threshold=cortisol_threshold,
+    )
+
+
+def _make_model(
+    router: ModelRouter,
+    priority: int = Priority.MEDIUM,
+    cortisol: float = 0.0,
+    system_name: str = "test",
+) -> OpenBaDChatModel:
+    return OpenBaDChatModel(
+        router=router,
+        priority=priority,
+        cortisol=cortisol,
+        system_name=system_name,
+    )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────── #
+
+
+class TestMessageConversion:
+    def test_flatten_messages(self) -> None:
+        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+        msgs = [
+            SystemMessage(content="Be helpful."),
+            HumanMessage(content="Hi"),
+            AIMessage(content="Hello!"),
+        ]
+        prompt = _messages_to_prompt(msgs)
+        assert "[system] Be helpful." in prompt
+        assert "[user] Hi" in prompt
+        assert "[assistant] Hello!" in prompt
+
+
+class TestLLMType:
+    def test_llm_type(self) -> None:
+        registry = _make_registry(("fake", FakeAdapter()))
+        router = _make_router(registry, chains={
+            Priority.MEDIUM: FallbackChain(steps=(RouteStep("fake", "m1"),)),
+        })
+        model = _make_model(router)
+        assert model._llm_type == "openbad"
+
+
+class TestRoutingDelegation:
+    @pytest.mark.asyncio
+    async def test_routes_to_provider(self) -> None:
+        adapter = FakeAdapter(content="Routed response", tokens=15)
+        registry = _make_registry(("primary", adapter))
+        router = _make_router(registry, chains={
+            Priority.HIGH: FallbackChain(steps=(RouteStep("primary", "gpt-4"),)),
+        })
+        model = _make_model(router, priority=Priority.HIGH)
+
+        from langchain_core.messages import HumanMessage
+
+        result = await model.ainvoke([HumanMessage(content="test")])
+        assert result.content == "Routed response"
+
+    @pytest.mark.asyncio
+    async def test_priority_override_via_kwargs(self) -> None:
+        """Priority can be overridden per-call via model kwargs."""
+        fast_adapter = FakeAdapter(content="fast", tokens=5)
+        slow_adapter = FakeAdapter(content="slow", tokens=50)
+        registry = _make_registry(("fast", fast_adapter), ("slow", slow_adapter))
+        router = _make_router(registry, chains={
+            Priority.LOW: FallbackChain(steps=(RouteStep("fast", "small"),)),
+            Priority.HIGH: FallbackChain(steps=(RouteStep("slow", "large"),)),
+        })
+        model = _make_model(router, priority=Priority.LOW)
+
+        from langchain_core.messages import HumanMessage
+
+        # Default priority is LOW → fast adapter
+        result = await model.ainvoke([HumanMessage(content="q")])
+        assert result.content == "fast"
+
+        # Override to HIGH → slow adapter
+        result = await model.ainvoke([HumanMessage(content="q")], priority=Priority.HIGH)
+        assert result.content == "slow"
+
+
+class TestCortisolDowngrade:
+    @pytest.mark.asyncio
+    async def test_cortisol_downgrades_priority(self) -> None:
+        """High cortisol should downgrade routing to cheaper models."""
+        cheap_adapter = FakeAdapter(content="cheap", tokens=3)
+        expensive_adapter = FakeAdapter(content="expensive", tokens=100)
+        registry = _make_registry(("cheap", cheap_adapter), ("expensive", expensive_adapter))
+        router = _make_router(
+            registry,
+            chains={
+                Priority.HIGH: FallbackChain(steps=(RouteStep("expensive", "big"),)),
+                Priority.MEDIUM: FallbackChain(steps=(RouteStep("cheap", "small"),)),
+            },
+            cortisol_threshold=0.5,
+        )
+
+        # No cortisol → HIGH priority → expensive
+        model = _make_model(router, priority=Priority.HIGH, cortisol=0.0)
+        from langchain_core.messages import HumanMessage
+
+        result = await model.ainvoke([HumanMessage(content="q")])
+        assert result.content == "expensive"
+
+        # High cortisol → downgraded to MEDIUM → cheap
+        model = _make_model(router, priority=Priority.HIGH, cortisol=0.9)
+        result = await model.ainvoke([HumanMessage(content="q")])
+        assert result.content == "cheap"
+
+
+class TestFallbackChain:
+    @pytest.mark.asyncio
+    async def test_falls_back_on_unhealthy(self) -> None:
+        """When primary is unhealthy, falls back to next in chain."""
+        unhealthy = UnhealthyAdapter(content="unreachable")
+        fallback = FakeAdapter(content="fallback", tokens=8)
+        registry = _make_registry(("primary", unhealthy), ("backup", fallback))
+        router = _make_router(registry, chains={
+            Priority.HIGH: FallbackChain(steps=(
+                RouteStep("primary", "m1"),
+                RouteStep("backup", "m2"),
+            )),
+        })
+        model = _make_model(router, priority=Priority.HIGH)
+
+        from langchain_core.messages import HumanMessage
+
+        result = await model.ainvoke([HumanMessage(content="test")])
+        assert result.content == "fallback"
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_astream_yields_chunks(self) -> None:
+        adapter = FakeAdapter(content="Hello world from OpenBaD", tokens=4)
+        registry = _make_registry(("streamer", adapter))
+        router = _make_router(registry, chains={
+            Priority.MEDIUM: FallbackChain(steps=(RouteStep("streamer", "m1"),)),
+        })
+        model = _make_model(router)
+
+        from langchain_core.messages import HumanMessage
+
+        chunks = []
+        async for chunk in model.astream([HumanMessage(content="test")]):
+            chunks.append(chunk.content)
+
+        assert len(chunks) == 4
+        assert "Hello" in chunks[0]
+        assert "OpenBaD" in chunks[3]
+
+
+class TestUsageRecording:
+    @pytest.mark.asyncio
+    async def test_records_usage(self) -> None:
+        adapter = FakeAdapter(content="tracked", tokens=25)
+        registry = _make_registry(("tracked", adapter))
+        router = _make_router(registry, chains={
+            Priority.MEDIUM: FallbackChain(steps=(RouteStep("tracked", "m1"),)),
+        })
+        model = _make_model(router, system_name="test-system")
+
+        from langchain_core.messages import HumanMessage
+
+        with patch("openbad.frameworks.langchain_model.record_usage_event") as mock_record:
+            await model.ainvoke([HumanMessage(content="test")])
+            mock_record.assert_called_once()
+            call_kwargs = mock_record.call_args.kwargs
+            assert call_kwargs["provider"] == "tracked"
+            assert call_kwargs["tokens"] == 25
+            assert call_kwargs["system"] == "test-system"
+
+
+class TestIdentifyingParams:
+    def test_identifying_params(self) -> None:
+        registry = _make_registry(("fake", FakeAdapter()))
+        router = _make_router(registry)
+        model = _make_model(router, priority=Priority.HIGH, cortisol=0.5, system_name="chat")
+        params = model._identifying_params
+        assert params["priority"] == Priority.HIGH
+        assert params["cortisol"] == 0.5
+        assert params["system_name"] == "chat"
+
+
+class TestGenerationInfo:
+    @pytest.mark.asyncio
+    async def test_generation_info_includes_routing(self) -> None:
+        adapter = FakeAdapter(content="info-test", tokens=12)
+        registry = _make_registry(("prov", adapter))
+        router = _make_router(registry, chains={
+            Priority.MEDIUM: FallbackChain(steps=(RouteStep("prov", "m1"),)),
+        })
+        model = _make_model(router)
+
+        from langchain_core.messages import HumanMessage
+
+        result = await model._agenerate([HumanMessage(content="test")])
+        gen_info = result.generations[0].generation_info
+        assert gen_info["provider"] == "prov"
+        assert gen_info["model_id"] == "m1"
+        assert gen_info["tokens_used"] == 12
+        assert gen_info["cortisol_downgrade"] is False
+        assert gen_info["fallback_index"] == 0


### PR DESCRIPTION
Closes #512

## Summary
Implements `OpenBaDChatModel(BaseChatModel)` — a LangChain chat model wrapper that delegates to OpenBaD's `ModelRouter` for provider selection, preserving cortisol-based downgrade, fallback chains, and budget tracking.

### Changes
- **src/openbad/frameworks/langchain_model.py**: `OpenBaDChatModel` with `_generate()`, `_agenerate()`, `_stream()`, `_astream()` methods
- **tests/test_langchain_model.py**: 10 tests covering routing delegation, cortisol downgrade, fallback chains, streaming, usage recording

### Key Features
- Wraps `ModelRouter.route()` for provider selection — all existing routing logic preserved
- Priority can be overridden per-call via `model_kwargs={"priority": Priority.CRITICAL}`
- Cortisol state modulates routing (high cortisol → cheaper models)
- Streaming via `_astream()` delegates to `ProviderAdapter.stream()`
- Token usage recorded via `record_usage_event()`
- Generation info includes routing metadata (provider, model, fallback index, cortisol downgrade)

### How to test
```bash
source .venv/bin/activate
python -m pytest tests/test_langchain_model.py -v
ruff check src/openbad/frameworks/langchain_model.py tests/test_langchain_model.py
```

## Depends on
- #511