### PR TITLE
#513: Convert toolbelt to LangChain Tools

### DIFF
--- a/src/openbad/frameworks/langchain_tools.py
+++ b/src/openbad/frameworks/langchain_tools.py
@@ -1,0 +1,261 @@
+"""Wrap OpenBaD's embedded skills as LangChain ``StructuredTool`` instances.
+
+Reads tool definitions from the FastMCP ``skill_server`` and produces
+LangChain-compatible tools that preserve immune gating, access control,
+and result truncation.
+
+Public API
+----------
+``get_openbad_tools()``
+    Returns all embedded skills as a ``list[BaseTool]``.
+``get_tools_for_role(role)``
+    Returns a role-filtered subset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from langchain_core.tools import BaseTool, StructuredTool
+
+from openbad.skills.server import call_skill, skill_server
+
+log = logging.getLogger(__name__)
+
+# ── Role → tool-name allow-lists ──────────────────────────────────────── #
+#
+# Each agent role gets a curated subset of tools.  Names must match the
+# function names registered on ``skill_server``.
+
+_ROLE_TOOLS: dict[str, set[str]] = {
+    "chat": {
+        "ask_user",
+        "web_search",
+        "web_fetch",
+        "read_file",
+        "find_files",
+        "get_endocrine_status",
+        "get_tasks",
+        "get_research_nodes",
+        "read_events",
+    },
+    "task": {
+        "read_file",
+        "write_file",
+        "find_files",
+        "exec_command",
+        "create_task",
+        "update_task",
+        "complete_task",
+        "work_on_task",
+        "work_on_next_task",
+        "list_terminal_sessions",
+        "create_terminal_session",
+        "send_terminal_input",
+        "read_terminal_output",
+        "close_terminal_session",
+        "web_search",
+        "web_fetch",
+        "ask_user",
+    },
+    "research": {
+        "web_search",
+        "web_fetch",
+        "read_file",
+        "find_files",
+        "create_research_node",
+        "update_research_node",
+        "complete_research_node",
+        "work_on_research",
+        "work_on_next_research",
+        "get_research_nodes",
+        "read_events",
+    },
+    "doctor": {
+        "call_doctor",
+        "get_endocrine_status",
+        "get_system_logs",
+        "get_mqtt_records",
+        "read_events",
+        "get_tasks",
+        "get_research_nodes",
+        "list_embedded_skills",
+    },
+    "sleep": {
+        "read_events",
+        "get_tasks",
+        "get_research_nodes",
+        "get_endocrine_status",
+    },
+    "immune": {
+        "get_mqtt_records",
+        "get_system_logs",
+        "read_events",
+        "get_endocrine_status",
+        "get_path_access_status",
+    },
+    "explorer": {
+        "web_search",
+        "web_fetch",
+        "read_file",
+        "find_files",
+        "create_research_node",
+        "read_events",
+        "get_endocrine_status",
+    },
+}
+
+
+# ── Internal helpers ──────────────────────────────────────────────────── #
+
+
+def _build_args_schema(
+    properties: dict[str, Any],
+    required: list[str],
+) -> type:
+    """Dynamically build a pydantic model from JSON Schema properties.
+
+    LangChain ``StructuredTool`` uses an ``args_schema`` pydantic model
+    for input validation.  We create one on-the-fly from the MCP tool's
+    ``inputSchema``.
+    """
+    from pydantic import create_model
+    from pydantic.fields import FieldInfo
+
+    field_definitions: dict[str, Any] = {}
+    for name, prop in properties.items():
+        json_type = prop.get("type", "string")
+        py_type = _json_type_to_python(json_type)
+        default = ... if name in required else prop.get("default")
+        description = prop.get("description", "")
+        field_definitions[name] = (
+            py_type,
+            FieldInfo(default=default, description=description),
+        )
+
+    if not field_definitions:
+        return create_model("ToolInput")
+
+    return create_model("ToolInput", **field_definitions)
+
+
+def _json_type_to_python(json_type: str) -> type:
+    """Map JSON Schema type strings to Python types."""
+    mapping: dict[str, type] = {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+    return mapping.get(json_type, str)
+
+
+def _make_tool_func(tool_name: str) -> Any:
+    """Create an async callable that dispatches to ``call_skill``."""
+
+    async def _invoke(**kwargs: Any) -> str:
+        return await call_skill(tool_name, kwargs)
+
+    _invoke.__name__ = tool_name
+    _invoke.__qualname__ = tool_name
+    return _invoke
+
+
+def _mcp_tool_to_langchain(mcp_tool: Any) -> StructuredTool:
+    """Convert a single MCP ``Tool`` object to a LangChain ``StructuredTool``."""
+    schema = mcp_tool.inputSchema or {}
+    properties = schema.get("properties", {})
+    required = schema.get("required", [])
+
+    args_schema = _build_args_schema(properties, required)
+    func = _make_tool_func(mcp_tool.name)
+
+    return StructuredTool(
+        name=mcp_tool.name,
+        description=mcp_tool.description or f"OpenBaD skill: {mcp_tool.name}",
+        coroutine=func,
+        args_schema=args_schema,
+    )
+
+
+# ── Public API ────────────────────────────────────────────────────────── #
+
+# Module-level cache so tools are built only once.
+_tools_cache: list[BaseTool] | None = None
+
+
+async def _async_build_tools() -> list[BaseTool]:
+    """Query the MCP server for tools and convert them all."""
+    mcp_tools = await skill_server.list_tools()
+    return [_mcp_tool_to_langchain(t) for t in mcp_tools]
+
+
+def get_openbad_tools() -> list[BaseTool]:
+    """Return all embedded OpenBaD skills as LangChain tools.
+
+    Caches the result on first call.  Safe to call from sync or async
+    contexts.
+    """
+    global _tools_cache  # noqa: PLW0603
+    if _tools_cache is not None:
+        return list(_tools_cache)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        log.warning(
+            "get_openbad_tools() called inside a running event loop; "
+            "returning empty list.  Use async_get_openbad_tools() instead."
+        )
+        return []
+
+    _tools_cache = asyncio.run(_async_build_tools())
+    return list(_tools_cache)
+
+
+async def async_get_openbad_tools() -> list[BaseTool]:
+    """Async version — preferred when an event loop is available."""
+    global _tools_cache  # noqa: PLW0603
+    if _tools_cache is not None:
+        return list(_tools_cache)
+    _tools_cache = await _async_build_tools()
+    return list(_tools_cache)
+
+
+def get_tools_for_role(role: str) -> list[BaseTool]:
+    """Return the subset of tools allowed for a given agent role.
+
+    Parameters
+    ----------
+    role:
+        One of: ``chat``, ``task``, ``research``, ``doctor``, ``sleep``,
+        ``immune``, ``explorer``.  Unknown roles get an empty list.
+    """
+    allowed = _ROLE_TOOLS.get(role.lower(), set())
+    if not allowed:
+        log.warning("No tool allowlist defined for role %r", role)
+        return []
+    return [t for t in get_openbad_tools() if t.name in allowed]
+
+
+async def async_get_tools_for_role(role: str) -> list[BaseTool]:
+    """Async variant of :func:`get_tools_for_role`."""
+    allowed = _ROLE_TOOLS.get(role.lower(), set())
+    if not allowed:
+        log.warning("No tool allowlist defined for role %r", role)
+        return []
+    all_tools = await async_get_openbad_tools()
+    return [t for t in all_tools if t.name in allowed]
+
+
+def clear_tools_cache() -> None:
+    """Reset the tool cache — useful in tests."""
+    global _tools_cache  # noqa: PLW0603
+    _tools_cache = None

--- a/tests/test_langchain_tools.py
+++ b/tests/test_langchain_tools.py
@@ -1,0 +1,202 @@
+"""Tests for the LangChain tool wrappers around OpenBaD skills."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openbad.frameworks.langchain_tools import (
+    _ROLE_TOOLS,
+    _build_args_schema,
+    _json_type_to_python,
+    _make_tool_func,
+    _mcp_tool_to_langchain,
+    async_get_openbad_tools,
+    async_get_tools_for_role,
+    clear_tools_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Ensure tool cache is reset between tests."""
+    clear_tools_cache()
+    yield
+    clear_tools_cache()
+
+
+# ── Fake MCP tool objects ─────────────────────────────────────────────── #
+
+
+def _fake_mcp_tool(
+    name: str = "test_tool",
+    description: str = "A test tool",
+    properties: dict[str, Any] | None = None,
+    required: list[str] | None = None,
+) -> MagicMock:
+    """Build a mock MCP Tool object."""
+    tool = MagicMock()
+    tool.name = name
+    tool.description = description
+    tool.inputSchema = {
+        "type": "object",
+        "properties": properties or {"query": {"type": "string", "description": "Search query"}},
+        "required": required or ["query"],
+    }
+    return tool
+
+
+# ── Unit tests ────────────────────────────────────────────────────────── #
+
+
+class TestJsonTypeToPython:
+    def test_string(self) -> None:
+        assert _json_type_to_python("string") is str
+
+    def test_integer(self) -> None:
+        assert _json_type_to_python("integer") is int
+
+    def test_number(self) -> None:
+        assert _json_type_to_python("number") is float
+
+    def test_boolean(self) -> None:
+        assert _json_type_to_python("boolean") is bool
+
+    def test_array(self) -> None:
+        assert _json_type_to_python("array") is list
+
+    def test_object(self) -> None:
+        assert _json_type_to_python("object") is dict
+
+    def test_unknown_defaults_to_str(self) -> None:
+        assert _json_type_to_python("foobar") is str
+
+
+class TestBuildArgsSchema:
+    def test_creates_pydantic_model(self) -> None:
+        props = {
+            "query": {"type": "string", "description": "Search query"},
+            "limit": {"type": "integer", "description": "Max results", "default": 10},
+        }
+        model = _build_args_schema(props, required=["query"])
+        instance = model(query="hello")
+        assert instance.query == "hello"
+        assert instance.limit == 10
+
+    def test_empty_properties(self) -> None:
+        model = _build_args_schema({}, required=[])
+        assert model is not None
+
+
+class TestMcpToolToLangchain:
+    def test_converts_name_and_description(self) -> None:
+        mcp_tool = _fake_mcp_tool(name="web_search", description="Search the web")
+        lc_tool = _mcp_tool_to_langchain(mcp_tool)
+        assert lc_tool.name == "web_search"
+        assert lc_tool.description == "Search the web"
+
+    def test_has_coroutine(self) -> None:
+        mcp_tool = _fake_mcp_tool()
+        lc_tool = _mcp_tool_to_langchain(mcp_tool)
+        assert lc_tool.coroutine is not None
+
+
+class TestMakeToolFunc:
+    @pytest.mark.asyncio
+    async def test_dispatches_to_call_skill(self) -> None:
+        func = _make_tool_func("web_search")
+        with patch(
+            "openbad.frameworks.langchain_tools.call_skill",
+            new_callable=AsyncMock,
+            return_value="result text",
+        ) as mock_call:
+            result = await func(query="test")
+            mock_call.assert_called_once_with("web_search", {"query": "test"})
+            assert result == "result text"
+
+
+class TestAsyncGetOpenbadTools:
+    @pytest.mark.asyncio
+    async def test_returns_langchain_tools(self) -> None:
+        fake_tools = [
+            _fake_mcp_tool("read_file", "Read a file", {"path": {"type": "string"}}, ["path"]),
+            _fake_mcp_tool("web_search", "Search", {"query": {"type": "string"}}, ["query"]),
+        ]
+        with patch("openbad.frameworks.langchain_tools.skill_server") as mock_server:
+            mock_server.list_tools = AsyncMock(return_value=fake_tools)
+            # Re-import to pick up the patched server
+            from openbad.frameworks import langchain_tools
+
+            langchain_tools._tools_cache = None
+            tools = await langchain_tools._async_build_tools()
+            assert len(tools) == 2
+            names = {t.name for t in tools}
+            assert "read_file" in names
+            assert "web_search" in names
+
+    @pytest.mark.asyncio
+    async def test_caches_result(self) -> None:
+        fake_tools = [_fake_mcp_tool("test", "Test")]
+        with patch("openbad.frameworks.langchain_tools.skill_server") as mock_server:
+            mock_server.list_tools = AsyncMock(return_value=fake_tools)
+            from openbad.frameworks import langchain_tools
+
+            langchain_tools._tools_cache = None
+            first = await langchain_tools._async_build_tools()
+            langchain_tools._tools_cache = first
+            second = await async_get_openbad_tools()
+            # Should return cached copy
+            assert len(second) == len(first)
+            # list_tools should only have been called once (during _async_build_tools)
+            assert mock_server.list_tools.await_count == 1
+
+
+class TestRoleFiltering:
+    def test_all_roles_defined(self) -> None:
+        expected_roles = {"chat", "task", "research", "doctor", "sleep", "immune", "explorer"}
+        assert expected_roles == set(_ROLE_TOOLS.keys())
+
+    @pytest.mark.asyncio
+    async def test_filters_by_role(self) -> None:
+        fake_tools = [
+            _fake_mcp_tool("web_search", "Search"),
+            _fake_mcp_tool("read_file", "Read file"),
+            _fake_mcp_tool("exec_command", "Execute command"),
+            _fake_mcp_tool("call_doctor", "Doctor"),
+        ]
+        with patch("openbad.frameworks.langchain_tools.skill_server") as mock_server:
+            mock_server.list_tools = AsyncMock(return_value=fake_tools)
+            from openbad.frameworks import langchain_tools
+
+            langchain_tools._tools_cache = None
+            langchain_tools._tools_cache = await langchain_tools._async_build_tools()
+
+            doctor_tools = await async_get_tools_for_role("doctor")
+            doctor_names = {t.name for t in doctor_tools}
+            assert "call_doctor" in doctor_names
+            # Doctor should NOT have exec_command
+            assert "exec_command" not in doctor_names
+
+    @pytest.mark.asyncio
+    async def test_unknown_role_returns_empty(self) -> None:
+        from openbad.frameworks import langchain_tools
+
+        langchain_tools._tools_cache = []
+        tools = await async_get_tools_for_role("nonexistent_role")
+        assert tools == []
+
+    def test_task_role_has_exec_command(self) -> None:
+        assert "exec_command" in _ROLE_TOOLS["task"]
+
+    def test_immune_role_has_no_write_tools(self) -> None:
+        immune_tools = _ROLE_TOOLS["immune"]
+        assert "write_file" not in immune_tools
+        assert "exec_command" not in immune_tools
+
+    def test_sleep_role_is_read_only(self) -> None:
+        sleep_tools = _ROLE_TOOLS["sleep"]
+        assert "write_file" not in sleep_tools
+        assert "exec_command" not in sleep_tools
+        assert "create_task" not in sleep_tools


### PR DESCRIPTION
Closes #513

## Summary
Wraps all ~33 embedded OpenBaD skills (FastMCP tools) as LangChain `StructuredTool` instances for use by LangChain agents and CrewAI crews.

### Changes
- **src/openbad/frameworks/langchain_tools.py**: Dynamic conversion of MCP tools to LangChain `StructuredTool`
- **tests/test_langchain_tools.py**: 20 tests covering type conversion, schema building, dispatch, caching, and role filtering

### Key Features
- **Dynamic conversion**: Reads tool definitions from FastMCP `skill_server` at runtime — no hand-maintained schemas
- **Pydantic args schemas**: Auto-generated from MCP `inputSchema` properties and types
- **Async dispatch**: Each tool delegates to `call_skill()` which preserves immune gating, access control, and result truncation
- **Role-based filtering**: `get_tools_for_role(role)` returns curated tool subsets for each agent role:
  - `chat` — ask_user, web_search, read_file, etc.
  - `task` — exec_command, write_file, terminals, task management
  - `research` — web_search, research nodes
  - `doctor` — call_doctor, system logs, endocrine status
  - `sleep` — read-only tools
  - `immune` — system logs, MQTT records (no write access)
  - `explorer` — web_search, research nodes (read-focused)
- **Caching**: Tools built once and cached for the process lifetime

### How to test
```bash
source .venv/bin/activate
python -m pytest tests/test_langchain_tools.py -v
ruff check src/openbad/frameworks/langchain_tools.py tests/test_langchain_tools.py
```

## Depends on
- #511