### PR TITLE
#515: LangGraph checkpoint saver backed by OpenBaD memory

### DIFF
--- a/src/openbad/frameworks/langgraph_checkpointer.py
+++ b/src/openbad/frameworks/langgraph_checkpointer.py
@@ -1,0 +1,346 @@
+"""LangGraph checkpoint saver backed by OpenBaD's memory hierarchy.
+
+Persists LangGraph workflow state in episodic memory (JSON append-only
+log) and mirrors active checkpoints in STM for fast access.  On
+workflow completion the final state is available for sleep consolidation.
+
+Public API
+----------
+``OpenBaDCheckpointSaver``
+    Drop-in replacement for ``InMemorySaver`` or ``SqliteSaver``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterator, Iterator, Sequence
+from typing import Any
+
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+)
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.episodic import EpisodicMemory
+from openbad.memory.stm import ShortTermMemory
+
+# Prefix used for all episodic and STM keys managed by this saver.
+_KEY_PREFIX = "langgraph:checkpoint"
+_WRITES_PREFIX = "langgraph:writes"
+
+
+def _checkpoint_key(thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> str:
+    ns = checkpoint_ns or ""
+    return f"{_KEY_PREFIX}:{thread_id}:{ns}:{checkpoint_id}"
+
+
+def _writes_key(
+    thread_id: str, checkpoint_ns: str, checkpoint_id: str, task_id: str, idx: int
+) -> str:
+    ns = checkpoint_ns or ""
+    return f"{_WRITES_PREFIX}:{thread_id}:{ns}:{checkpoint_id}:{task_id}:{idx}"
+
+
+def _thread_prefix(thread_id: str, checkpoint_ns: str = "") -> str:
+    ns = checkpoint_ns or ""
+    return f"{_KEY_PREFIX}:{thread_id}:{ns}:"
+
+
+def _writes_thread_prefix(thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> str:
+    ns = checkpoint_ns or ""
+    return f"{_WRITES_PREFIX}:{thread_id}:{ns}:{checkpoint_id}:"
+
+
+def _config_value(config: RunnableConfig, key: str, default: str = "") -> str:
+    return str(config.get("configurable", {}).get(key, default))
+
+
+def _serialize(obj: Any) -> str:
+    def _default(o: Any) -> Any:
+        if isinstance(o, set):
+            return list(o)
+        return str(o)
+
+    return json.dumps(obj, default=_default, sort_keys=True)
+
+
+def _deserialize(s: str) -> Any:
+    return json.loads(s)
+
+
+class OpenBaDCheckpointSaver(BaseCheckpointSaver[int]):
+    """Persist LangGraph checkpoints in OpenBaD episodic + STM memory.
+
+    Parameters
+    ----------
+    episodic:
+        Episodic memory store for durable checkpoint storage.
+    stm:
+        Short-term memory for fast access to active workflow state.
+        If ``None``, STM mirroring is skipped.
+    """
+
+    def __init__(
+        self,
+        episodic: EpisodicMemory,
+        stm: ShortTermMemory | None = None,
+    ) -> None:
+        super().__init__()
+        self._episodic = episodic
+        self._stm = stm
+
+    # ── Version management ────────────────────────────────────────── #
+
+    def get_next_version(self, current: int | None, channel: Any) -> int:
+        if current is None:
+            return 1
+        return current + 1
+
+    # ── put ────────────────────────────────────────────────────────── #
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        thread_id = _config_value(config, "thread_id")
+        checkpoint_ns = _config_value(config, "checkpoint_ns")
+        checkpoint_id = checkpoint["id"]
+
+        key = _checkpoint_key(thread_id, checkpoint_ns, checkpoint_id)
+        now = time.time()
+
+        payload = {
+            "checkpoint": checkpoint,
+            "metadata": metadata,
+            "parent_checkpoint_id": _config_value(config, "checkpoint_id"),
+        }
+
+        entry = MemoryEntry(
+            key=key,
+            value=_serialize(payload),
+            tier=MemoryTier.EPISODIC,
+            created_at=now,
+            metadata={
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+                "source": "langgraph",
+            },
+        )
+        self._episodic.write(entry)
+
+        # Mirror to STM for fast reads of active state.
+        if self._stm is not None:
+            stm_entry = MemoryEntry(
+                key=key,
+                value=_serialize(payload),
+                tier=MemoryTier.STM,
+                created_at=now,
+                metadata=entry.metadata.copy(),
+            )
+            self._stm.write(stm_entry)
+
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            },
+        }
+
+    # ── put_writes ────────────────────────────────────────────────── #
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        thread_id = _config_value(config, "thread_id")
+        checkpoint_ns = _config_value(config, "checkpoint_ns")
+        checkpoint_id = _config_value(config, "checkpoint_id")
+        now = time.time()
+
+        for idx, (channel, value) in enumerate(writes):
+            key = _writes_key(thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
+            payload = {
+                "channel": channel,
+                "value": value,
+                "task_id": task_id,
+                "task_path": task_path,
+            }
+            entry = MemoryEntry(
+                key=key,
+                value=_serialize(payload),
+                tier=MemoryTier.EPISODIC,
+                created_at=now,
+                metadata={
+                    "thread_id": thread_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "checkpoint_id": checkpoint_id,
+                    "task_id": task_id,
+                    "source": "langgraph_writes",
+                },
+            )
+            self._episodic.write(entry)
+
+    # ── get_tuple ─────────────────────────────────────────────────── #
+
+    def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        thread_id = _config_value(config, "thread_id")
+        checkpoint_ns = _config_value(config, "checkpoint_ns")
+        checkpoint_id = _config_value(config, "checkpoint_id")
+
+        if checkpoint_id:
+            # Retrieve specific checkpoint.
+            key = _checkpoint_key(thread_id, checkpoint_ns, checkpoint_id)
+            # Try STM first for fast access.
+            entry = (
+                self._stm.read(key) if self._stm is not None else None
+            ) or self._episodic.read(key)
+            if entry is None:
+                return None
+            return self._entry_to_tuple(entry, thread_id, checkpoint_ns)
+
+        # No checkpoint_id → return the latest for this thread.
+        prefix = _thread_prefix(thread_id, checkpoint_ns)
+        entries = self._episodic.query(prefix)
+        if not entries:
+            return None
+        # Entries are chronological; take the last one.
+        latest = entries[-1]
+        return self._entry_to_tuple(latest, thread_id, checkpoint_ns)
+
+    # ── list ──────────────────────────────────────────────────────── #
+
+    def list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> Iterator[CheckpointTuple]:
+        if config is None:
+            return
+
+        thread_id = _config_value(config, "thread_id")
+        checkpoint_ns = _config_value(config, "checkpoint_ns")
+        prefix = _thread_prefix(thread_id, checkpoint_ns)
+        entries = self._episodic.query(prefix)
+
+        # Reverse to get newest first.
+        entries = list(reversed(entries))
+
+        if before is not None:
+            before_id = _config_value(before, "checkpoint_id")
+            if before_id:
+                entries = [e for e in entries if e.metadata.get("checkpoint_id", "") < before_id]
+
+        if filter:
+            for k, v in filter.items():
+                entries = [e for e in entries if e.metadata.get(k) == v]
+
+        if limit is not None:
+            entries = entries[:limit]
+
+        for entry in entries:
+            tup = self._entry_to_tuple(entry, thread_id, checkpoint_ns)
+            if tup is not None:
+                yield tup
+
+    # ── Async wrappers ────────────────────────────────────────────── #
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        return self.put(config, checkpoint, metadata, new_versions)
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        self.put_writes(config, writes, task_id, task_path)
+
+    async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        return self.get_tuple(config)
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        for tup in self.list(config, filter=filter, before=before, limit=limit):
+            yield tup
+
+    # ── Helpers ───────────────────────────────────────────────────── #
+
+    def _entry_to_tuple(
+        self, entry: MemoryEntry, thread_id: str, checkpoint_ns: str
+    ) -> CheckpointTuple | None:
+        try:
+            payload = _deserialize(entry.value)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+        checkpoint: Checkpoint = payload["checkpoint"]
+        metadata: CheckpointMetadata = payload.get("metadata", {})
+        parent_id: str = payload.get("parent_checkpoint_id", "")
+        checkpoint_id = checkpoint["id"]
+
+        cfg: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            },
+        }
+
+        parent_cfg: RunnableConfig | None = None
+        if parent_id:
+            parent_cfg = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "checkpoint_id": parent_id,
+                },
+            }
+
+        # Collect pending writes.
+        writes_prefix = _writes_thread_prefix(thread_id, checkpoint_ns, checkpoint_id)
+        write_entries = self._episodic.query(writes_prefix)
+        pending_writes: list[tuple[str, str, Any]] = []
+        for we in write_entries:
+            try:
+                wp = _deserialize(we.value)
+                pending_writes.append((wp["task_id"], wp["channel"], wp["value"]))
+            except (json.JSONDecodeError, TypeError, KeyError):
+                continue
+
+        return CheckpointTuple(
+            config=cfg,
+            checkpoint=checkpoint,
+            metadata=metadata,
+            parent_config=parent_cfg,
+            pending_writes=pending_writes or None,
+        )

--- a/tests/test_langgraph_checkpointer.py
+++ b/tests/test_langgraph_checkpointer.py
@@ -1,0 +1,265 @@
+"""Tests for openbad.frameworks.langgraph_checkpointer."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from openbad.frameworks.langgraph_checkpointer import OpenBaDCheckpointSaver
+from openbad.memory.episodic import EpisodicMemory
+from openbad.memory.stm import ShortTermMemory
+
+# ── Fixtures ──────────────────────────────────────────────────────────── #
+
+
+@pytest.fixture()
+def episodic(tmp_path):
+    return EpisodicMemory(storage_path=tmp_path / "episodic.json")
+
+
+@pytest.fixture()
+def stm():
+    return ShortTermMemory()
+
+
+@pytest.fixture()
+def saver(episodic, stm):
+    return OpenBaDCheckpointSaver(episodic=episodic, stm=stm)
+
+
+@pytest.fixture()
+def saver_no_stm(episodic):
+    return OpenBaDCheckpointSaver(episodic=episodic, stm=None)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────── #
+
+
+def _make_config(thread_id="t1", checkpoint_ns="", checkpoint_id=""):
+    return {
+        "configurable": {
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+        },
+    }
+
+
+def _make_checkpoint(checkpoint_id=None, channel_values=None):
+    return {
+        "v": 1,
+        "ts": "2025-01-01T00:00:00Z",
+        "id": checkpoint_id or uuid.uuid4().hex[:8],
+        "channel_values": channel_values or {"messages": ["hello"]},
+        "channel_versions": {"messages": 1},
+        "versions_seen": {},
+        "pending_sends": [],
+    }
+
+
+# ── Round-trip: put → get_tuple ──────────────────────────────────────── #
+
+
+class TestPutAndGetTuple:
+    def test_round_trip(self, saver):
+        cp = _make_checkpoint("cp1")
+        config = _make_config(thread_id="t1")
+        metadata = {"source": "input", "step": 0}
+
+        result_config = saver.put(config, cp, metadata, {"messages": 1})
+        assert result_config["configurable"]["checkpoint_id"] == "cp1"
+
+        retrieved = saver.get_tuple(_make_config(thread_id="t1", checkpoint_id="cp1"))
+        assert retrieved is not None
+        assert retrieved.checkpoint["id"] == "cp1"
+        assert retrieved.checkpoint["channel_values"] == {"messages": ["hello"]}
+        assert retrieved.metadata["source"] == "input"
+
+    def test_get_latest_without_checkpoint_id(self, saver):
+        saver.put(_make_config("t1"), _make_checkpoint("cp1"), {"step": 0}, {})
+        cfg = _make_config("t1", checkpoint_id="cp1")
+        saver.put(cfg, _make_checkpoint("cp2"), {"step": 1}, {})
+
+        retrieved = saver.get_tuple(_make_config("t1"))
+        assert retrieved is not None
+        assert retrieved.checkpoint["id"] == "cp2"
+
+    def test_returns_none_for_missing(self, saver):
+        result = saver.get_tuple(_make_config("nonexistent", checkpoint_id="nope"))
+        assert result is None
+
+
+# ── STM sync ─────────────────────────────────────────────────────────── #
+
+
+class TestSTMSync:
+    def test_active_state_in_stm(self, saver, stm):
+        cp = _make_checkpoint("cp1")
+        saver.put(_make_config("t1"), cp, {}, {})
+        keys = stm.list_keys()
+        assert any("cp1" in k for k in keys)
+
+    def test_stm_used_for_fast_read(self, saver, stm):
+        cp = _make_checkpoint("cp1")
+        saver.put(_make_config("t1"), cp, {}, {})
+        # Reading with checkpoint_id should hit STM first.
+        retrieved = saver.get_tuple(_make_config("t1", checkpoint_id="cp1"))
+        assert retrieved is not None
+        assert retrieved.checkpoint["id"] == "cp1"
+
+    def test_no_stm_still_works(self, saver_no_stm):
+        cp = _make_checkpoint("cp1")
+        saver_no_stm.put(_make_config("t1"), cp, {"step": 0}, {})
+        retrieved = saver_no_stm.get_tuple(_make_config("t1", checkpoint_id="cp1"))
+        assert retrieved is not None
+        assert retrieved.checkpoint["id"] == "cp1"
+
+
+# ── Episodic persistence ─────────────────────────────────────────────── #
+
+
+class TestEpisodicPersistence:
+    def test_survives_reload(self, episodic, tmp_path):
+        saver = OpenBaDCheckpointSaver(episodic=episodic)
+        cp = _make_checkpoint("cp1", {"key": "value"})
+        saver.put(_make_config("t1"), cp, {"step": 0}, {})
+        episodic.save()
+
+        # Create a new episodic memory pointing at the same file.
+        episodic2 = EpisodicMemory(storage_path=tmp_path / "episodic.json")
+        saver2 = OpenBaDCheckpointSaver(episodic=episodic2)
+        retrieved = saver2.get_tuple(_make_config("t1", checkpoint_id="cp1"))
+        assert retrieved is not None
+        assert retrieved.checkpoint["channel_values"] == {"key": "value"}
+
+
+# ── Listing ──────────────────────────────────────────────────────────── #
+
+
+class TestListing:
+    def test_lists_all_checkpoints(self, saver):
+        saver.put(_make_config("t1"), _make_checkpoint("cp1"), {"step": 0}, {})
+        saver.put(
+            _make_config("t1", checkpoint_id="cp1"),
+            _make_checkpoint("cp2"),
+            {"step": 1},
+            {},
+        )
+        results = list(saver.list(_make_config("t1")))
+        assert len(results) == 2
+        # Newest first.
+        assert results[0].checkpoint["id"] == "cp2"
+        assert results[1].checkpoint["id"] == "cp1"
+
+    def test_list_with_limit(self, saver):
+        saver.put(_make_config("t1"), _make_checkpoint("cp1"), {}, {})
+        saver.put(_make_config("t1", checkpoint_id="cp1"), _make_checkpoint("cp2"), {}, {})
+        saver.put(_make_config("t1", checkpoint_id="cp2"), _make_checkpoint("cp3"), {}, {})
+        results = list(saver.list(_make_config("t1"), limit=2))
+        assert len(results) == 2
+
+    def test_list_with_before(self, saver):
+        saver.put(_make_config("t1"), _make_checkpoint("cp1"), {}, {})
+        saver.put(_make_config("t1", checkpoint_id="cp1"), _make_checkpoint("cp2"), {}, {})
+        saver.put(_make_config("t1", checkpoint_id="cp2"), _make_checkpoint("cp3"), {}, {})
+        results = list(
+            saver.list(_make_config("t1"), before=_make_config("t1", checkpoint_id="cp3"))
+        )
+        assert all(r.checkpoint["id"] < "cp3" for r in results)
+
+    def test_list_none_config(self, saver):
+        results = list(saver.list(None))
+        assert results == []
+
+
+# ── Parent config ────────────────────────────────────────────────────── #
+
+
+class TestParentConfig:
+    def test_parent_config_set(self, saver):
+        saver.put(_make_config("t1"), _make_checkpoint("cp1"), {}, {})
+        saver.put(
+            _make_config("t1", checkpoint_id="cp1"),
+            _make_checkpoint("cp2"),
+            {},
+            {},
+        )
+        retrieved = saver.get_tuple(_make_config("t1", checkpoint_id="cp2"))
+        assert retrieved is not None
+        assert retrieved.parent_config is not None
+        assert retrieved.parent_config["configurable"]["checkpoint_id"] == "cp1"
+
+    def test_first_checkpoint_no_parent(self, saver):
+        saver.put(_make_config("t1"), _make_checkpoint("cp1"), {}, {})
+        retrieved = saver.get_tuple(_make_config("t1", checkpoint_id="cp1"))
+        assert retrieved is not None
+        assert retrieved.parent_config is None
+
+
+# ── put_writes / pending_writes ──────────────────────────────────────── #
+
+
+class TestPutWrites:
+    def test_writes_stored_and_retrieved(self, saver):
+        cp = _make_checkpoint("cp1")
+        saver.put(_make_config("t1"), cp, {}, {})
+        saver.put_writes(
+            _make_config("t1", checkpoint_id="cp1"),
+            [("messages", "write1"), ("output", "write2")],
+            task_id="task-1",
+        )
+        retrieved = saver.get_tuple(_make_config("t1", checkpoint_id="cp1"))
+        assert retrieved is not None
+        assert retrieved.pending_writes is not None
+        assert len(retrieved.pending_writes) == 2
+
+
+# ── Async variants ───────────────────────────────────────────────────── #
+
+
+class TestAsyncVariants:
+    @pytest.mark.asyncio
+    async def test_aput_and_aget_tuple(self, saver):
+        cp = _make_checkpoint("cp1")
+        config = _make_config("t1")
+        await saver.aput(config, cp, {"step": 0}, {})
+        retrieved = await saver.aget_tuple(_make_config("t1", checkpoint_id="cp1"))
+        assert retrieved is not None
+        assert retrieved.checkpoint["id"] == "cp1"
+
+    @pytest.mark.asyncio
+    async def test_alist(self, saver):
+        await saver.aput(_make_config("t1"), _make_checkpoint("cp1"), {}, {})
+        await saver.aput(
+            _make_config("t1", checkpoint_id="cp1"),
+            _make_checkpoint("cp2"),
+            {},
+            {},
+        )
+        results = [r async for r in saver.alist(_make_config("t1"))]
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_aput_writes(self, saver):
+        cp = _make_checkpoint("cp1")
+        await saver.aput(_make_config("t1"), cp, {}, {})
+        await saver.aput_writes(
+            _make_config("t1", checkpoint_id="cp1"),
+            [("ch", "val")],
+            task_id="t-1",
+        )
+        retrieved = await saver.aget_tuple(_make_config("t1", checkpoint_id="cp1"))
+        assert retrieved is not None
+        assert retrieved.pending_writes is not None
+
+
+# ── Version management ───────────────────────────────────────────────── #
+
+
+class TestVersionManagement:
+    def test_get_next_version_from_none(self, saver):
+        assert saver.get_next_version(None, None) == 1
+
+    def test_get_next_version_increments(self, saver):
+        assert saver.get_next_version(3, None) == 4


### PR DESCRIPTION
Closes #515

## Summary
Implements a LangGraph `BaseCheckpointSaver` backed by OpenBaD's episodic memory (JSON append-only log) with optional STM mirroring for fast access to active workflow state.

### Changes
- **src/openbad/frameworks/langgraph_checkpointer.py**: `OpenBaDCheckpointSaver` implementation
- **tests/test_langgraph_checkpointer.py**: 19 tests

### Key Features
- **Episodic persistence**: Checkpoints stored as `MemoryEntry` in episodic memory with JSON serialization
- **STM mirroring**: Active checkpoints mirrored to STM for fast reads (optional)
- **Round-trip fidelity**: `put()` → `get_tuple()` preserves all checkpoint data, metadata, and parent config
- **Listing**: `list()` returns checkpoints newest-first with `before`, `filter`, and `limit` support
- **Pending writes**: `put_writes()` stores intermediate writes, retrieved as `pending_writes` on `get_tuple()`
- **Parent tracking**: Automatic parent config linking across checkpoint chain
- **Version management**: Integer versioning via `get_next_version()`
- **Async support**: `aput()`, `aget_tuple()`, `alist()`, `aput_writes()` wrappers
- **Sleep consolidation ready**: State persisted in episodic memory is available for memory consolidation during sleep cycles

### How to test
```bash
source .venv/bin/activate
python -m pytest tests/test_langgraph_checkpointer.py -v
ruff check src/openbad/frameworks/langgraph_checkpointer.py
```

## Depends on
- #511