### PR TITLE
#516: LangGraph workflow graphs for core task patterns

### DIFF
--- a/src/openbad/frameworks/workflows/__init__.py
+++ b/src/openbad/frameworks/workflows/__init__.py
@@ -1,0 +1,20 @@
+"""LangGraph workflow graphs for OpenBaD task patterns.
+
+Each workflow maps to a ``TaskKind`` and replaces the linear
+``NodeTemplate`` DAG chains with ``StateGraph`` definitions that
+support conditional retry edges and structured state transitions.
+
+Public API
+----------
+``get_workflow(kind)``
+    Return a compiled ``StateGraph`` for the given ``TaskKind``.
+``AgentState``
+    TypedDict flowing through all workflow nodes.
+"""
+
+from __future__ import annotations
+
+from openbad.frameworks.workflows.registry import get_workflow
+from openbad.frameworks.workflows.state import AgentState
+
+__all__ = ["AgentState", "get_workflow"]

--- a/src/openbad/frameworks/workflows/nodes.py
+++ b/src/openbad/frameworks/workflows/nodes.py
@@ -1,0 +1,67 @@
+"""Reusable node functions and retry-edge builder for workflows."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from openbad.frameworks.workflows.state import AgentState
+
+log = logging.getLogger(__name__)
+
+# Default max retries per node type — matches existing NodeTemplate defaults.
+DEFAULT_MAX_RETRIES: dict[str, int] = {
+    "clarify": 0,
+    "plan": 1,
+    "execute": 2,
+    "review": 0,
+    "gather": 2,
+    "analyse": 1,
+    "summarise": 0,
+}
+
+
+def _make_node(node_type: str):
+    """Return a node function that records its type in the result list.
+
+    Each node function:
+    1. Logs entry.
+    2. Appends a result dict with ``node_type`` and ``status``.
+    3. Returns updated ``AgentState``.
+
+    In a future iteration nodes will delegate to LangChain chains or
+    CrewAI agents.  For now they are stubs that ensure the graph
+    structure, retry logic, and state transitions are correct.
+    """
+
+    def _node(state: AgentState) -> dict[str, Any]:
+        task_id = state.get("task_metadata", {}).get("task_id", "?")
+        log.info("Workflow node '%s' running for task %s", node_type, task_id)
+
+        results = list(state.get("results", []))
+        results.append({"node": node_type, "status": "done"})
+        return {"results": results, "status": "running"}
+
+    _node.__name__ = node_type  # LangGraph uses __name__ as the node key
+    _node.__qualname__ = node_type
+    return _node
+
+
+def should_retry(node_type: str, max_retries: int | None = None):
+    """Return a conditional-edge function for retry logic.
+
+    The returned function checks ``state["retry_counts"][node_type]``
+    against *max_retries* and routes to either the node (retry) or
+    the next step.
+    """
+    limit = max_retries if max_retries is not None else DEFAULT_MAX_RETRIES.get(node_type, 0)
+
+    def _decide(state: AgentState) -> str:
+        counts = state.get("retry_counts", {})
+        current = counts.get(node_type, 0)
+        error = state.get("error", "")
+        if error and current < limit:
+            return "retry"
+        return "continue"
+
+    return _decide

--- a/src/openbad/frameworks/workflows/registry.py
+++ b/src/openbad/frameworks/workflows/registry.py
@@ -1,0 +1,44 @@
+"""Registry mapping TaskKind to compiled workflow graphs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.graph import StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from openbad.frameworks.workflows.research_workflow import build_research_graph
+from openbad.frameworks.workflows.scheduled_workflow import build_scheduled_graph
+from openbad.frameworks.workflows.system_workflow import build_system_graph
+from openbad.frameworks.workflows.user_request_workflow import (
+    build_user_request_graph,
+)
+
+# Maps TaskKind string values to graph builder functions.
+_BUILDERS: dict[str, Any] = {
+    "user_requested": build_user_request_graph,
+    "research": build_research_graph,
+    "system": build_system_graph,
+    "scheduled": build_scheduled_graph,
+}
+
+
+def get_workflow(
+    kind: str,
+    *,
+    checkpointer: Any | None = None,
+) -> CompiledStateGraph:
+    """Return a compiled workflow graph for the given task kind.
+
+    Parameters
+    ----------
+    kind:
+        A ``TaskKind`` value (e.g. ``"user_requested"``).
+    checkpointer:
+        Optional ``BaseCheckpointSaver`` for state persistence.
+    """
+    builder = _BUILDERS.get(kind)
+    if builder is None:
+        raise ValueError(f"Unknown task kind: {kind!r}")
+    graph: StateGraph = builder()
+    return graph.compile(checkpointer=checkpointer)

--- a/src/openbad/frameworks/workflows/research_workflow.py
+++ b/src/openbad/frameworks/workflows/research_workflow.py
@@ -1,0 +1,41 @@
+"""Research workflow: Gather → Analyse → Summarise.
+
+Maps to ``TaskKind.RESEARCH``.
+"""
+
+from __future__ import annotations
+
+from langgraph.graph import END, StateGraph
+
+from openbad.frameworks.workflows.nodes import _make_node, should_retry
+from openbad.frameworks.workflows.state import AgentState
+
+
+def build_research_graph() -> StateGraph:
+    """Return an uncompiled ``StateGraph`` for research tasks."""
+    graph = StateGraph(AgentState)
+
+    graph.add_node("gather", _make_node("gather"))
+    graph.add_node("analyse", _make_node("analyse"))
+    graph.add_node("summarise", _make_node("summarise"))
+
+    graph.set_entry_point("gather")
+
+    # gather: retry up to 2 times.
+    graph.add_conditional_edges(
+        "gather",
+        should_retry("gather"),
+        {"retry": "gather", "continue": "analyse"},
+    )
+
+    # analyse: retry up to 1 time.
+    graph.add_conditional_edges(
+        "analyse",
+        should_retry("analyse"),
+        {"retry": "analyse", "continue": "summarise"},
+    )
+
+    # summarise has 0 retries → always finishes.
+    graph.add_edge("summarise", END)
+
+    return graph

--- a/src/openbad/frameworks/workflows/scheduled_workflow.py
+++ b/src/openbad/frameworks/workflows/scheduled_workflow.py
@@ -1,0 +1,29 @@
+"""Scheduled workflow: single Execute node.
+
+Maps to ``TaskKind.SCHEDULED``.
+"""
+
+from __future__ import annotations
+
+from langgraph.graph import END, StateGraph
+
+from openbad.frameworks.workflows.nodes import _make_node, should_retry
+from openbad.frameworks.workflows.state import AgentState
+
+
+def build_scheduled_graph() -> StateGraph:
+    """Return an uncompiled ``StateGraph`` for scheduled tasks."""
+    graph = StateGraph(AgentState)
+
+    graph.add_node("execute", _make_node("execute"))
+
+    graph.set_entry_point("execute")
+
+    # execute: retry up to 1 time (matches existing SCHEDULED template).
+    graph.add_conditional_edges(
+        "execute",
+        should_retry("execute", max_retries=1),
+        {"retry": "execute", "continue": END},
+    )
+
+    return graph

--- a/src/openbad/frameworks/workflows/state.py
+++ b/src/openbad/frameworks/workflows/state.py
@@ -1,0 +1,38 @@
+"""Shared workflow state definition."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class AgentState(TypedDict, total=False):
+    """State flowing through every LangGraph workflow node.
+
+    Attributes
+    ----------
+    messages:
+        Accumulated conversation messages (user, assistant, system).
+    context:
+        Additional context gathered during clarification / research.
+    memory_refs:
+        Keys of relevant memory entries pulled from STM/episodic.
+    task_metadata:
+        Task model fields: task_id, kind, priority, owner, etc.
+    results:
+        Outputs collected from execution nodes.
+    retry_counts:
+        Per-node retry counters: ``{"clarify": 0, "execute": 1, …}``.
+    error:
+        Last error message (set by nodes on failure).
+    status:
+        Overall workflow status: ``"running"``, ``"done"``, ``"failed"``.
+    """
+
+    messages: list[dict[str, Any]]
+    context: str
+    memory_refs: list[str]
+    task_metadata: dict[str, Any]
+    results: list[dict[str, Any]]
+    retry_counts: dict[str, int]
+    error: str
+    status: str

--- a/src/openbad/frameworks/workflows/system_workflow.py
+++ b/src/openbad/frameworks/workflows/system_workflow.py
@@ -1,0 +1,29 @@
+"""System workflow: single Execute node.
+
+Maps to ``TaskKind.SYSTEM``.
+"""
+
+from __future__ import annotations
+
+from langgraph.graph import END, StateGraph
+
+from openbad.frameworks.workflows.nodes import _make_node, should_retry
+from openbad.frameworks.workflows.state import AgentState
+
+
+def build_system_graph() -> StateGraph:
+    """Return an uncompiled ``StateGraph`` for system tasks."""
+    graph = StateGraph(AgentState)
+
+    graph.add_node("execute", _make_node("execute"))
+
+    graph.set_entry_point("execute")
+
+    # execute: retry up to 1 time (matches existing SYSTEM template).
+    graph.add_conditional_edges(
+        "execute",
+        should_retry("execute", max_retries=1),
+        {"retry": "execute", "continue": END},
+    )
+
+    return graph

--- a/src/openbad/frameworks/workflows/user_request_workflow.py
+++ b/src/openbad/frameworks/workflows/user_request_workflow.py
@@ -1,0 +1,45 @@
+"""User-request workflow: Clarify → Plan → Execute → Review.
+
+Maps to ``TaskKind.USER_REQUESTED``.
+"""
+
+from __future__ import annotations
+
+from langgraph.graph import END, StateGraph
+
+from openbad.frameworks.workflows.nodes import _make_node, should_retry
+from openbad.frameworks.workflows.state import AgentState
+
+
+def build_user_request_graph() -> StateGraph:
+    """Return an uncompiled ``StateGraph`` for user-requested tasks."""
+    graph = StateGraph(AgentState)
+
+    graph.add_node("clarify", _make_node("clarify"))
+    graph.add_node("plan", _make_node("plan"))
+    graph.add_node("execute", _make_node("execute"))
+    graph.add_node("review", _make_node("review"))
+
+    graph.set_entry_point("clarify")
+
+    # clarify has 0 retries → always continues.
+    graph.add_edge("clarify", "plan")
+
+    # plan: retry up to 1 time.
+    graph.add_conditional_edges(
+        "plan",
+        should_retry("plan"),
+        {"retry": "plan", "continue": "execute"},
+    )
+
+    # execute: retry up to 2 times.
+    graph.add_conditional_edges(
+        "execute",
+        should_retry("execute"),
+        {"retry": "execute", "continue": "review"},
+    )
+
+    # review has 0 retries → always finishes.
+    graph.add_edge("review", END)
+
+    return graph

--- a/tests/test_workflow_graphs.py
+++ b/tests/test_workflow_graphs.py
@@ -1,0 +1,217 @@
+"""Tests for openbad.frameworks.workflows — task workflow graphs."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.frameworks.workflows.nodes import (
+    _make_node,
+    should_retry,
+)
+from openbad.frameworks.workflows.registry import get_workflow
+from openbad.frameworks.workflows.research_workflow import build_research_graph
+from openbad.frameworks.workflows.scheduled_workflow import build_scheduled_graph
+from openbad.frameworks.workflows.state import AgentState
+from openbad.frameworks.workflows.system_workflow import build_system_graph
+from openbad.frameworks.workflows.user_request_workflow import (
+    build_user_request_graph,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────── #
+
+
+def _initial_state(**overrides) -> AgentState:
+    base: AgentState = {
+        "messages": [],
+        "context": "",
+        "memory_refs": [],
+        "task_metadata": {"task_id": "test-1"},
+        "results": [],
+        "retry_counts": {},
+        "error": "",
+        "status": "running",
+    }
+    base.update(overrides)
+    return base
+
+
+# ── AgentState ────────────────────────────────────────────────────────── #
+
+
+class TestAgentState:
+    def test_all_fields_present(self) -> None:
+        state = _initial_state()
+        assert "messages" in state
+        assert "task_metadata" in state
+        assert "retry_counts" in state
+        assert "results" in state
+
+
+# ── Node functions ────────────────────────────────────────────────────── #
+
+
+class TestMakeNode:
+    def test_appends_result(self) -> None:
+        node = _make_node("execute")
+        out = node(_initial_state())
+        assert len(out["results"]) == 1
+        assert out["results"][0]["node"] == "execute"
+        assert out["results"][0]["status"] == "done"
+
+    def test_preserves_existing_results(self) -> None:
+        node = _make_node("plan")
+        state = _initial_state(
+            results=[{"node": "clarify", "status": "done"}],
+        )
+        out = node(state)
+        assert len(out["results"]) == 2
+
+
+# ── Retry logic ──────────────────────────────────────────────────────── #
+
+
+class TestShouldRetry:
+    def test_continue_when_no_error(self) -> None:
+        decide = should_retry("execute")
+        state = _initial_state()
+        assert decide(state) == "continue"
+
+    def test_retry_on_error_within_limit(self) -> None:
+        decide = should_retry("execute", max_retries=2)
+        state = _initial_state(error="something failed", retry_counts={"execute": 0})
+        assert decide(state) == "retry"
+
+    def test_continue_when_retries_exhausted(self) -> None:
+        decide = should_retry("execute", max_retries=2)
+        state = _initial_state(error="still failing", retry_counts={"execute": 2})
+        assert decide(state) == "continue"
+
+    def test_uses_default_max_retries(self) -> None:
+        decide = should_retry("gather")
+        state = _initial_state(error="net error", retry_counts={"gather": 1})
+        # DEFAULT_MAX_RETRIES["gather"] == 2, so retry should still be possible.
+        assert decide(state) == "retry"
+
+    def test_zero_max_retries_never_retries(self) -> None:
+        decide = should_retry("clarify")
+        state = _initial_state(error="bad input", retry_counts={"clarify": 0})
+        assert decide(state) == "continue"
+
+
+# ── Graph compilation ────────────────────────────────────────────────── #
+
+
+class TestUserRequestGraph:
+    def test_compiles(self) -> None:
+        graph = build_user_request_graph()
+        compiled = graph.compile()
+        assert compiled is not None
+
+    def test_has_expected_nodes(self) -> None:
+        graph = build_user_request_graph()
+        node_names = set(graph.nodes.keys())
+        assert {"clarify", "plan", "execute", "review"} <= node_names
+
+    def test_invoke_traverses_all_nodes(self) -> None:
+        compiled = build_user_request_graph().compile()
+        result = compiled.invoke(_initial_state())
+        node_names = [r["node"] for r in result["results"]]
+        assert node_names == ["clarify", "plan", "execute", "review"]
+
+
+class TestResearchGraph:
+    def test_compiles(self) -> None:
+        graph = build_research_graph()
+        compiled = graph.compile()
+        assert compiled is not None
+
+    def test_has_expected_nodes(self) -> None:
+        graph = build_research_graph()
+        node_names = set(graph.nodes.keys())
+        assert {"gather", "analyse", "summarise"} <= node_names
+
+    def test_invoke_traverses_all_nodes(self) -> None:
+        compiled = build_research_graph().compile()
+        result = compiled.invoke(_initial_state())
+        node_names = [r["node"] for r in result["results"]]
+        assert node_names == ["gather", "analyse", "summarise"]
+
+
+class TestSystemGraph:
+    def test_compiles(self) -> None:
+        graph = build_system_graph()
+        compiled = graph.compile()
+        assert compiled is not None
+
+    def test_invoke_single_execute(self) -> None:
+        compiled = build_system_graph().compile()
+        result = compiled.invoke(_initial_state())
+        node_names = [r["node"] for r in result["results"]]
+        assert node_names == ["execute"]
+
+
+class TestScheduledGraph:
+    def test_compiles(self) -> None:
+        graph = build_scheduled_graph()
+        compiled = graph.compile()
+        assert compiled is not None
+
+    def test_invoke_single_execute(self) -> None:
+        compiled = build_scheduled_graph().compile()
+        result = compiled.invoke(_initial_state())
+        node_names = [r["node"] for r in result["results"]]
+        assert node_names == ["execute"]
+
+
+# ── Registry ─────────────────────────────────────────────────────────── #
+
+
+class TestRegistry:
+    def test_get_user_requested(self) -> None:
+        wf = get_workflow("user_requested")
+        assert wf is not None
+
+    def test_get_research(self) -> None:
+        wf = get_workflow("research")
+        assert wf is not None
+
+    def test_get_system(self) -> None:
+        wf = get_workflow("system")
+        assert wf is not None
+
+    def test_get_scheduled(self) -> None:
+        wf = get_workflow("scheduled")
+        assert wf is not None
+
+    def test_unknown_kind_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown task kind"):
+            get_workflow("nonexistent")
+
+    def test_invoke_via_registry(self) -> None:
+        wf = get_workflow("research")
+        result = wf.invoke(_initial_state())
+        assert len(result["results"]) == 3
+
+
+# ── State transitions ────────────────────────────────────────────────── #
+
+
+class TestStateTransitions:
+    def test_results_accumulate(self) -> None:
+        wf = get_workflow("user_requested")
+        result = wf.invoke(_initial_state())
+        assert len(result["results"]) == 4
+
+    def test_task_metadata_preserved(self) -> None:
+        wf = get_workflow("user_requested")
+        state = _initial_state(
+            task_metadata={"task_id": "t-42", "kind": "user_requested"},
+        )
+        result = wf.invoke(state)
+        assert result["task_metadata"]["task_id"] == "t-42"
+
+    def test_context_preserved(self) -> None:
+        wf = get_workflow("research")
+        state = _initial_state(context="background info")
+        result = wf.invoke(state)
+        assert result["context"] == "background info"


### PR DESCRIPTION
Closes #516

## Summary
Replaces the linear `NodeTemplate` DAG chains with LangGraph `StateGraph` definitions for each `TaskKind`, enabling conditional retry edges and structured state transitions.

### Changes
- **src/openbad/frameworks/workflows/state.py**: `AgentState` TypedDict with messages, context, memory_refs, task_metadata, results, retry_counts, error, status
- **src/openbad/frameworks/workflows/nodes.py**: Reusable `_make_node()` factory and `should_retry()` conditional-edge builder with configurable max retries
- **src/openbad/frameworks/workflows/user_request_workflow.py**: Clarify → Plan → Execute → Review (plan retries 1x, execute retries 2x)
- **src/openbad/frameworks/workflows/research_workflow.py**: Gather → Analyse → Summarise (gather retries 2x, analyse retries 1x)
- **src/openbad/frameworks/workflows/system_workflow.py**: Single Execute node (retries 1x)
- **src/openbad/frameworks/workflows/scheduled_workflow.py**: Single Execute node (retries 1x)
- **src/openbad/frameworks/workflows/registry.py**: `get_workflow(kind)` maps `TaskKind` values to compiled graphs
- **tests/test_workflow_graphs.py**: 27 tests covering state, nodes, retry logic, graph compilation, traversal, and registry

### Retry defaults match existing `NodeTemplate` configuration
| Node | Max Retries |
|------|------------|
| clarify | 0 |
| plan | 1 |
| execute | 2 (user_requested), 1 (system/scheduled) |
| review | 0 |
| gather | 2 |
| analyse | 1 |
| summarise | 0 |

### How to test
```bash
source .venv/bin/activate
python -m pytest tests/test_workflow_graphs.py -v
ruff check src/openbad/frameworks/workflows/
```

## Depends on
- #515, #512, #513