### PR TITLE
#518: LangGraph reasoning strategies (CoT, ToT, MCTS)

### DIFF
--- a/src/openbad/frameworks/workflows/reasoning/__init__.py
+++ b/src/openbad/frameworks/workflows/reasoning/__init__.py
@@ -1,0 +1,33 @@
+"""LangGraph-based reasoning strategies.
+
+Replaces custom reasoning implementations with LangChain chains
+and LangGraph graphs:
+
+``ChainOfThoughtGraph``
+    LangChain prompt chain for step-by-step reasoning.
+``TreeOfThoughtsGraph``
+    LangGraph branching graph: generate → evaluate → select.
+``MCTSGraph``
+    LangGraph looping graph: select → expand → simulate → backpropagate.
+
+All implement the ``reason(state) → state`` interface and are
+selectable by priority level.
+"""
+
+from __future__ import annotations
+
+from openbad.frameworks.workflows.reasoning.chain_of_thought import (
+    ChainOfThoughtGraph,
+)
+from openbad.frameworks.workflows.reasoning.mcts import MCTSGraph
+from openbad.frameworks.workflows.reasoning.state import ReasoningState
+from openbad.frameworks.workflows.reasoning.tree_of_thoughts import (
+    TreeOfThoughtsGraph,
+)
+
+__all__ = [
+    "ChainOfThoughtGraph",
+    "MCTSGraph",
+    "ReasoningState",
+    "TreeOfThoughtsGraph",
+]

--- a/src/openbad/frameworks/workflows/reasoning/chain_of_thought.py
+++ b/src/openbad/frameworks/workflows/reasoning/chain_of_thought.py
@@ -1,0 +1,85 @@
+"""Chain-of-Thought reasoning as a LangChain prompt chain.
+
+Simple sequential strategy: decompose → step through → conclude.
+No graph needed — implemented as a linear chain of node functions.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from openbad.frameworks.workflows.reasoning.state import ReasoningState
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_MAX_STEPS = 10
+
+
+def decompose(state: ReasoningState) -> dict[str, Any]:
+    """Break the problem into sub-steps."""
+    prompt = state.get("prompt", "")
+    return {
+        "steps": [
+            {
+                "step": 1,
+                "thought": f"Decompose: {prompt}",
+                "conclusion": "Problem decomposed into sub-steps.",
+            },
+        ],
+    }
+
+
+def step_through(state: ReasoningState) -> dict[str, Any]:
+    """Execute each reasoning step sequentially."""
+    steps = list(state.get("steps", []))
+    prompt = state.get("prompt", "")
+    context = state.get("context", "")
+    # Stub: in production, each step calls the LLM.
+    steps.append(
+        {
+            "step": len(steps) + 1,
+            "thought": f"Reason about: {prompt} with context: {context}",
+            "conclusion": "Step completed.",
+        },
+    )
+    return {"steps": steps}
+
+
+def conclude(state: ReasoningState) -> dict[str, Any]:
+    """Synthesize final answer from reasoning steps."""
+    steps = state.get("steps", [])
+    conclusions = [s.get("conclusion", "") for s in steps]
+    answer = " → ".join(conclusions) if conclusions else "No conclusion."
+    return {"final_answer": answer}
+
+
+class ChainOfThoughtGraph:
+    """Chain-of-Thought reasoning implemented as a LangGraph workflow."""
+
+    def __init__(self, max_steps: int = _DEFAULT_MAX_STEPS) -> None:
+        self._max_steps = max_steps
+        self._compiled = self._build().compile()
+
+    def _build(self) -> StateGraph:
+        graph = StateGraph(ReasoningState)
+        graph.add_node("decompose", decompose)
+        graph.add_node("step_through", step_through)
+        graph.add_node("conclude", conclude)
+
+        graph.set_entry_point("decompose")
+        graph.add_edge("decompose", "step_through")
+        graph.add_edge("step_through", "conclude")
+        graph.add_edge("conclude", END)
+        return graph
+
+    def reason(self, state: ReasoningState) -> ReasoningState:
+        """Execute chain-of-thought reasoning."""
+        return self._compiled.invoke(state)
+
+    @property
+    def compiled(self) -> CompiledStateGraph:
+        return self._compiled

--- a/src/openbad/frameworks/workflows/reasoning/mcts.py
+++ b/src/openbad/frameworks/workflows/reasoning/mcts.py
@@ -1,0 +1,154 @@
+"""Monte Carlo Tree Search reasoning as a LangGraph looping graph.
+
+Select → Expand → Simulate → Backpropagate, looped for N iterations.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from openbad.frameworks.workflows.reasoning.state import ReasoningState
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_MAX_ITERATIONS = 10
+_DEFAULT_EXPLORATION_CONSTANT = 1.414
+
+
+def select(state: ReasoningState) -> dict[str, Any]:
+    """Select the most promising node to explore (UCB1)."""
+    branches = state.get("branches", [])
+    scores = state.get("scores", [])
+
+    if not branches:
+        return {"best_branch": 0}
+
+    # Stub: in production, uses UCB1 formula.
+    best_idx = 0
+    if scores:
+        best_idx = scores.index(max(scores))
+    return {"best_branch": best_idx}
+
+
+def expand(state: ReasoningState) -> dict[str, Any]:
+    """Expand the selected node with a new child."""
+    branches = list(state.get("branches", []))
+    iteration = state.get("iteration", 0)
+    prompt = state.get("prompt", "")
+
+    # Stub: in production, calls LLM to generate expansion.
+    branches.append(
+        {
+            "branch_id": len(branches),
+            "thought": f"Expansion {iteration}: {prompt}",
+            "iteration": iteration,
+        },
+    )
+    return {"branches": branches}
+
+
+def simulate(state: ReasoningState) -> dict[str, Any]:
+    """Simulate a random rollout from the expanded node."""
+    branches = state.get("branches", [])
+    scores = list(state.get("scores", []))
+
+    # Stub: in production, calls LLM to simulate outcome.
+    # Pad scores to match branches.
+    while len(scores) < len(branches):
+        scores.append(0.5)
+    # Update latest score.
+    if scores:
+        scores[-1] = 0.5 + (len(scores) * 0.05)
+    return {"scores": scores}
+
+
+def backpropagate(state: ReasoningState) -> dict[str, Any]:
+    """Update statistics along the path."""
+    iteration = state.get("iteration", 0) + 1
+    steps = list(state.get("steps", []))
+    steps.append(
+        {
+            "step": iteration,
+            "thought": f"MCTS iteration {iteration}",
+            "conclusion": f"Backpropagated scores for {len(state.get('branches', []))} branches.",
+        },
+    )
+    return {"iteration": iteration, "steps": steps}
+
+
+def _should_continue(state: ReasoningState) -> str:
+    """Check if we should continue iterating."""
+    iteration = state.get("iteration", 0)
+    max_iter = state.get("max_iterations", _DEFAULT_MAX_ITERATIONS)
+    if iteration >= max_iter:
+        return "done"
+    return "continue"
+
+
+def finalize(state: ReasoningState) -> dict[str, Any]:
+    """Select the final answer from the best branch."""
+    branches = state.get("branches", [])
+    scores = state.get("scores", [])
+
+    if not branches:
+        return {"final_answer": "No branches explored."}
+
+    best_idx = 0
+    if scores:
+        best_idx = scores.index(max(scores))
+
+    best = branches[best_idx] if best_idx < len(branches) else {}
+    return {
+        "best_branch": best_idx,
+        "final_answer": best.get("thought", "No answer."),
+    }
+
+
+class MCTSGraph:
+    """MCTS reasoning implemented as a LangGraph looping workflow."""
+
+    def __init__(
+        self,
+        max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+        exploration_constant: float = _DEFAULT_EXPLORATION_CONSTANT,
+    ) -> None:
+        self._max_iterations = max_iterations
+        self._exploration_constant = exploration_constant
+        self._compiled = self._build().compile()
+
+    def _build(self) -> StateGraph:
+        graph = StateGraph(ReasoningState)
+
+        graph.add_node("select", select)
+        graph.add_node("expand", expand)
+        graph.add_node("simulate", simulate)
+        graph.add_node("backpropagate", backpropagate)
+        graph.add_node("finalize", finalize)
+
+        graph.set_entry_point("select")
+        graph.add_edge("select", "expand")
+        graph.add_edge("expand", "simulate")
+        graph.add_edge("simulate", "backpropagate")
+
+        # Loop or finish.
+        graph.add_conditional_edges(
+            "backpropagate",
+            _should_continue,
+            {"continue": "select", "done": "finalize"},
+        )
+        graph.add_edge("finalize", END)
+        return graph
+
+    def reason(self, state: ReasoningState) -> ReasoningState:
+        """Execute MCTS reasoning."""
+        if "max_iterations" not in state:
+            state = {**state, "max_iterations": self._max_iterations}
+        return self._compiled.invoke(state)
+
+    @property
+    def compiled(self) -> CompiledStateGraph:
+        return self._compiled

--- a/src/openbad/frameworks/workflows/reasoning/state.py
+++ b/src/openbad/frameworks/workflows/reasoning/state.py
@@ -1,0 +1,47 @@
+"""Shared state for reasoning workflow graphs."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class ReasoningState(TypedDict, total=False):
+    """State flowing through reasoning workflow nodes.
+
+    Attributes
+    ----------
+    prompt:
+        The problem/question to reason about.
+    context:
+        Supporting context for reasoning.
+    steps:
+        Accumulated reasoning steps.
+    branches:
+        Parallel reasoning branches (ToT / MCTS).
+    scores:
+        Evaluation scores for branches.
+    best_branch:
+        Index of the selected best branch.
+    final_answer:
+        The concluded answer.
+    total_tokens:
+        Cumulative token usage.
+    iteration:
+        Current iteration counter (MCTS loop).
+    max_iterations:
+        Max iterations for looping strategies.
+    error:
+        Error message if any.
+    """
+
+    prompt: str
+    context: str
+    steps: list[dict[str, Any]]
+    branches: list[dict[str, Any]]
+    scores: list[float]
+    best_branch: int
+    final_answer: str
+    total_tokens: int
+    iteration: int
+    max_iterations: int
+    error: str

--- a/src/openbad/frameworks/workflows/reasoning/tree_of_thoughts.py
+++ b/src/openbad/frameworks/workflows/reasoning/tree_of_thoughts.py
@@ -1,0 +1,100 @@
+"""Tree-of-Thoughts reasoning as a LangGraph branching graph.
+
+Generate N branches → evaluate each → select best → expand.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from openbad.frameworks.workflows.reasoning.state import ReasoningState
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_BRANCHING_FACTOR = 3
+_DEFAULT_MAX_DEPTH = 3
+_DEFAULT_PRUNE_THRESHOLD = 0.3
+
+
+def generate_branches(state: ReasoningState) -> dict[str, Any]:
+    """Generate N candidate reasoning branches."""
+    prompt = state.get("prompt", "")
+    # Stub: in production, calls LLM N times with different temperatures.
+    branches = [
+        {"branch_id": i, "thought": f"Branch {i}: approach to {prompt}"}
+        for i in range(_DEFAULT_BRANCHING_FACTOR)
+    ]
+    return {"branches": branches, "scores": []}
+
+
+def evaluate_branches(state: ReasoningState) -> dict[str, Any]:
+    """Score each branch for quality/promise."""
+    branches = state.get("branches", [])
+    # Stub: in production, calls LLM to evaluate each branch.
+    scores = [0.5 + (0.1 * i) for i in range(len(branches))]
+    return {"scores": scores}
+
+
+def select_best(state: ReasoningState) -> dict[str, Any]:
+    """Select the highest-scoring branch."""
+    scores = state.get("scores", [])
+    if not scores:
+        return {"best_branch": 0, "final_answer": "No branches to select."}
+
+    best_idx = scores.index(max(scores))
+    branches = state.get("branches", [])
+    best = branches[best_idx] if best_idx < len(branches) else {}
+
+    steps = list(state.get("steps", []))
+    steps.append(
+        {
+            "step": len(steps) + 1,
+            "thought": f"Selected branch {best_idx}",
+            "conclusion": best.get("thought", ""),
+        },
+    )
+
+    return {
+        "best_branch": best_idx,
+        "final_answer": best.get("thought", "No answer."),
+        "steps": steps,
+    }
+
+
+class TreeOfThoughtsGraph:
+    """Tree-of-Thoughts reasoning implemented as a LangGraph workflow."""
+
+    def __init__(
+        self,
+        branching_factor: int = _DEFAULT_BRANCHING_FACTOR,
+        max_depth: int = _DEFAULT_MAX_DEPTH,
+        prune_threshold: float = _DEFAULT_PRUNE_THRESHOLD,
+    ) -> None:
+        self._branching_factor = branching_factor
+        self._max_depth = max_depth
+        self._prune_threshold = prune_threshold
+        self._compiled = self._build().compile()
+
+    def _build(self) -> StateGraph:
+        graph = StateGraph(ReasoningState)
+        graph.add_node("generate_branches", generate_branches)
+        graph.add_node("evaluate_branches", evaluate_branches)
+        graph.add_node("select_best", select_best)
+
+        graph.set_entry_point("generate_branches")
+        graph.add_edge("generate_branches", "evaluate_branches")
+        graph.add_edge("evaluate_branches", "select_best")
+        graph.add_edge("select_best", END)
+        return graph
+
+    def reason(self, state: ReasoningState) -> ReasoningState:
+        """Execute tree-of-thoughts reasoning."""
+        return self._compiled.invoke(state)
+
+    @property
+    def compiled(self) -> CompiledStateGraph:
+        return self._compiled

--- a/tests/test_reasoning_workflows.py
+++ b/tests/test_reasoning_workflows.py
@@ -1,0 +1,198 @@
+"""Tests for openbad.frameworks.workflows.reasoning strategies."""
+
+from __future__ import annotations
+
+import pytest
+
+from openbad.frameworks.workflows.reasoning import (
+    ChainOfThoughtGraph,
+    MCTSGraph,
+    ReasoningState,
+    TreeOfThoughtsGraph,
+)
+from openbad.frameworks.workflows.reasoning.chain_of_thought import (
+    conclude,
+    decompose,
+    step_through,
+)
+from openbad.frameworks.workflows.reasoning.mcts import (
+    backpropagate,
+    expand,
+    finalize,
+    select,
+    simulate,
+)
+from openbad.frameworks.workflows.reasoning.tree_of_thoughts import (
+    evaluate_branches,
+    generate_branches,
+    select_best,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────── #
+
+
+def _state(**overrides) -> ReasoningState:
+    base: ReasoningState = {
+        "prompt": "What is 2 + 2?",
+        "context": "",
+        "steps": [],
+        "branches": [],
+        "scores": [],
+        "best_branch": 0,
+        "final_answer": "",
+        "total_tokens": 0,
+        "iteration": 0,
+        "max_iterations": 3,
+        "error": "",
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Chain of Thought ─────────────────────────────────────────────────── #
+
+
+class TestChainOfThought:
+    def test_decompose(self) -> None:
+        result = decompose(_state())
+        assert len(result["steps"]) == 1
+        assert "Decompose" in result["steps"][0]["thought"]
+
+    def test_step_through(self) -> None:
+        result = step_through(_state(steps=[{"step": 1, "thought": "x", "conclusion": "y"}]))
+        assert len(result["steps"]) == 2
+
+    def test_conclude(self) -> None:
+        result = conclude(
+            _state(
+                steps=[
+                    {"conclusion": "step 1 done"},
+                    {"conclusion": "step 2 done"},
+                ],
+            ),
+        )
+        assert "step 1 done" in result["final_answer"]
+        assert "step 2 done" in result["final_answer"]
+
+    def test_full_graph(self) -> None:
+        cot = ChainOfThoughtGraph()
+        result = cot.reason(_state())
+        assert result["final_answer"] != ""
+        assert len(result["steps"]) >= 2
+
+    def test_compiled_property(self) -> None:
+        cot = ChainOfThoughtGraph()
+        assert cot.compiled is not None
+
+
+# ── Tree of Thoughts ─────────────────────────────────────────────────── #
+
+
+class TestTreeOfThoughts:
+    def test_generate_branches(self) -> None:
+        result = generate_branches(_state())
+        assert len(result["branches"]) == 3
+
+    def test_evaluate_branches(self) -> None:
+        branches = [{"branch_id": i} for i in range(3)]
+        result = evaluate_branches(_state(branches=branches))
+        assert len(result["scores"]) == 3
+
+    def test_select_best(self) -> None:
+        branches = [
+            {"branch_id": 0, "thought": "A"},
+            {"branch_id": 1, "thought": "B"},
+            {"branch_id": 2, "thought": "C"},
+        ]
+        result = select_best(_state(branches=branches, scores=[0.3, 0.9, 0.5]))
+        assert result["best_branch"] == 1
+        assert result["final_answer"] == "B"
+
+    def test_select_best_empty(self) -> None:
+        result = select_best(_state())
+        assert result["final_answer"] == "No branches to select."
+
+    def test_full_graph(self) -> None:
+        tot = TreeOfThoughtsGraph()
+        result = tot.reason(_state())
+        assert result["final_answer"] != ""
+        assert len(result["branches"]) == 3
+        assert len(result["scores"]) == 3
+
+    def test_compiled_property(self) -> None:
+        tot = TreeOfThoughtsGraph()
+        assert tot.compiled is not None
+
+
+# ── MCTS ─────────────────────────────────────────────────────────────── #
+
+
+class TestMCTS:
+    def test_select_no_branches(self) -> None:
+        result = select(_state())
+        assert result["best_branch"] == 0
+
+    def test_expand(self) -> None:
+        result = expand(_state(iteration=0))
+        assert len(result["branches"]) == 1
+
+    def test_simulate(self) -> None:
+        result = simulate(_state(branches=[{"branch_id": 0}]))
+        assert len(result["scores"]) == 1
+
+    def test_backpropagate(self) -> None:
+        result = backpropagate(_state(iteration=0))
+        assert result["iteration"] == 1
+        assert len(result["steps"]) == 1
+
+    def test_finalize(self) -> None:
+        branches = [
+            {"thought": "A"},
+            {"thought": "B"},
+        ]
+        result = finalize(_state(branches=branches, scores=[0.3, 0.8]))
+        assert result["final_answer"] == "B"
+        assert result["best_branch"] == 1
+
+    def test_finalize_empty(self) -> None:
+        result = finalize(_state())
+        assert "No branches" in result["final_answer"]
+
+    def test_full_graph_loops(self) -> None:
+        mcts = MCTSGraph(max_iterations=3)
+        result = mcts.reason(_state(max_iterations=3))
+        assert result["iteration"] == 3
+        assert len(result["branches"]) == 3
+        assert result["final_answer"] != ""
+
+    def test_full_graph_respects_max(self) -> None:
+        mcts = MCTSGraph(max_iterations=2)
+        result = mcts.reason(_state(max_iterations=2))
+        assert result["iteration"] == 2
+
+    def test_compiled_property(self) -> None:
+        mcts = MCTSGraph()
+        assert mcts.compiled is not None
+
+
+# ── Common interface ─────────────────────────────────────────────────── #
+
+
+class TestCommonInterface:
+    @pytest.mark.parametrize(
+        "cls",
+        [ChainOfThoughtGraph, TreeOfThoughtsGraph, MCTSGraph],
+    )
+    def test_reason_returns_state(self, cls) -> None:
+        instance = cls()
+        result = instance.reason(_state())
+        assert "final_answer" in result
+        assert result["final_answer"] != ""
+
+    @pytest.mark.parametrize(
+        "cls",
+        [ChainOfThoughtGraph, TreeOfThoughtsGraph, MCTSGraph],
+    )
+    def test_has_compiled(self, cls) -> None:
+        instance = cls()
+        assert instance.compiled is not None


### PR DESCRIPTION
Closes #518

## Summary
Replaces custom reasoning strategy implementations (CoT, ToT, MCTS) with LangGraph graph-based equivalents.

### Changes
- **src/openbad/frameworks/workflows/reasoning/**: Package with state, CoT, ToT, MCTS implementations
- **tests/test_reasoning_workflows.py**: 26 tests

### Strategies

| Strategy | Graph Pattern | Nodes |
|----------|--------------|-------|
| **ChainOfThought** | Linear chain | decompose → step_through → conclude |
| **TreeOfThoughts** | Branching | generate_branches → evaluate_branches → select_best |
| **MCTS** | Looping | select → expand → simulate → backpropagate ↺ → finalize |

### Common Interface
All strategies implement `reason(state: ReasoningState) -> ReasoningState` and expose a `compiled` property for direct LangGraph access.

### How to test
```bash
source .venv/bin/activate
python -m pytest tests/test_reasoning_workflows.py -v
ruff check src/openbad/frameworks/workflows/reasoning/
```

## Depends on
- #512