### PR TITLE
#526: Update configuration for framework integration

### DIFF
--- a/config/cognitive.yaml
+++ b/config/cognitive.yaml
@@ -40,3 +40,39 @@ cognitive:
     high_timeout_ms: 15000
     medium_timeout_ms: 10000
     low_timeout_ms: 5000
+
+  # ── Framework integration (LangChain / LangGraph / CrewAI) ──
+  frameworks:
+    crews:
+      user_facing:
+        verbose: false
+        max_iterations: 10
+        allow_delegation: true
+      internal:
+        verbose: false
+        max_iterations: 15
+        allow_delegation: false
+      maintenance:
+        verbose: false
+        max_iterations: 20
+        allow_delegation: true
+
+    langgraph:
+      checkpoint_format: json
+      checkpoint_retention_hours: 168  # 7 days
+
+    agents:
+      chat:
+        priority: medium
+      task:
+        priority: medium
+      research:
+        priority: low
+      doctor:
+        priority: critical
+      sleep:
+        priority: low
+      immune:
+        priority: high
+      explorer:
+        priority: low

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -28,3 +28,15 @@ chains:
   low:
     - provider: ollama
       model: llama3.2
+
+# Agent-to-priority mappings for CrewAI agent model routing.
+# Each agent is assigned a routing priority that determines which
+# fallback chain is used for its LLM calls.
+agent_priorities:
+  chat: medium
+  task: medium
+  research: low
+  doctor: critical
+  sleep: low
+  immune: high
+  explorer: low

--- a/src/openbad/frameworks/config.py
+++ b/src/openbad/frameworks/config.py
@@ -1,0 +1,186 @@
+"""Configuration loader and validator for framework integration.
+
+Loads the ``frameworks:`` section from ``config/cognitive.yaml`` and the
+``agent_priorities:`` section from ``config/model_routing.yaml``, validates
+their structure, and exposes typed dataclasses for runtime use.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+_CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
+
+_VALID_PRIORITIES = frozenset({"critical", "high", "medium", "low"})
+_VALID_CHECKPOINT_FORMATS = frozenset({"json", "pickle"})
+
+
+# ── Dataclasses ─────────────────────────────────────────────────── #
+
+
+@dataclasses.dataclass(frozen=True)
+class CrewConfig:
+    """Configuration for a single CrewAI crew."""
+
+    verbose: bool = False
+    max_iterations: int = 10
+    allow_delegation: bool = True
+
+
+@dataclasses.dataclass(frozen=True)
+class LangGraphConfig:
+    """LangGraph checkpoint and retention settings."""
+
+    checkpoint_format: str = "json"
+    checkpoint_retention_hours: int = 168
+
+
+@dataclasses.dataclass(frozen=True)
+class AgentConfig:
+    """Per-agent routing priority."""
+
+    priority: str = "medium"
+
+
+@dataclasses.dataclass(frozen=True)
+class FrameworksConfig:
+    """Top-level frameworks configuration."""
+
+    crews: dict[str, CrewConfig] = dataclasses.field(default_factory=dict)
+    langgraph: LangGraphConfig = dataclasses.field(
+        default_factory=LangGraphConfig,
+    )
+    agents: dict[str, AgentConfig] = dataclasses.field(default_factory=dict)
+
+
+# ── Validation ──────────────────────────────────────────────────── #
+
+
+class ConfigValidationError(ValueError):
+    """Raised when framework configuration is invalid."""
+
+
+def _validate_priority(name: str, value: str) -> None:
+    if value not in _VALID_PRIORITIES:
+        raise ConfigValidationError(
+            f"Invalid priority {value!r} for agent {name!r}. "
+            f"Must be one of: {', '.join(sorted(_VALID_PRIORITIES))}"
+        )
+
+
+def _validate_checkpoint_format(fmt: str) -> None:
+    if fmt not in _VALID_CHECKPOINT_FORMATS:
+        raise ConfigValidationError(
+            f"Invalid checkpoint format {fmt!r}. "
+            f"Must be one of: {', '.join(sorted(_VALID_CHECKPOINT_FORMATS))}"
+        )
+
+
+# ── Loading ─────────────────────────────────────────────────────── #
+
+
+def _parse_crew(name: str, raw: dict[str, Any]) -> CrewConfig:
+    return CrewConfig(
+        verbose=bool(raw.get("verbose", False)),
+        max_iterations=int(raw.get("max_iterations", 10)),
+        allow_delegation=bool(raw.get("allow_delegation", True)),
+    )
+
+
+def _parse_langgraph(raw: dict[str, Any]) -> LangGraphConfig:
+    fmt = str(raw.get("checkpoint_format", "json"))
+    _validate_checkpoint_format(fmt)
+    return LangGraphConfig(
+        checkpoint_format=fmt,
+        checkpoint_retention_hours=int(
+            raw.get("checkpoint_retention_hours", 168),
+        ),
+    )
+
+
+def _parse_agent(name: str, raw: dict[str, Any]) -> AgentConfig:
+    priority = str(raw.get("priority", "medium"))
+    _validate_priority(name, priority)
+    return AgentConfig(priority=priority)
+
+
+def load_frameworks_config(
+    config_dir: Path | None = None,
+) -> FrameworksConfig:
+    """Load and validate the ``frameworks:`` section from cognitive.yaml.
+
+    Parameters
+    ----------
+    config_dir:
+        Override the default config directory (useful for testing).
+
+    Returns
+    -------
+    FrameworksConfig
+        Validated configuration, or defaults if the section is absent.
+    """
+    cfg_dir = config_dir or _CONFIG_DIR
+    cognitive_path = cfg_dir / "cognitive.yaml"
+
+    if not cognitive_path.exists():
+        log.warning("cognitive.yaml not found at %s; using defaults", cfg_dir)
+        return FrameworksConfig()
+
+    with cognitive_path.open() as f:
+        data = yaml.safe_load(f) or {}
+
+    frameworks_raw = data.get("cognitive", {}).get("frameworks", {})
+    if not frameworks_raw:
+        log.info("No frameworks section in cognitive.yaml; using defaults")
+        return FrameworksConfig()
+
+    crews = {
+        name: _parse_crew(name, crew_raw)
+        for name, crew_raw in frameworks_raw.get("crews", {}).items()
+    }
+
+    langgraph_raw = frameworks_raw.get("langgraph", {})
+    langgraph = _parse_langgraph(langgraph_raw)
+
+    agents = {
+        name: _parse_agent(name, agent_raw)
+        for name, agent_raw in frameworks_raw.get("agents", {}).items()
+    }
+
+    return FrameworksConfig(crews=crews, langgraph=langgraph, agents=agents)
+
+
+def load_agent_priorities(
+    config_dir: Path | None = None,
+) -> dict[str, str]:
+    """Load ``agent_priorities:`` from model_routing.yaml.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping of agent name → priority string.
+    """
+    cfg_dir = config_dir or _CONFIG_DIR
+    routing_path = cfg_dir / "model_routing.yaml"
+
+    if not routing_path.exists():
+        log.warning(
+            "model_routing.yaml not found at %s; using defaults", cfg_dir,
+        )
+        return {}
+
+    with routing_path.open() as f:
+        data = yaml.safe_load(f) or {}
+
+    priorities = data.get("agent_priorities", {})
+    for name, prio in priorities.items():
+        _validate_priority(name, str(prio))
+
+    return {name: str(prio) for name, prio in priorities.items()}

--- a/tests/test_framework_config.py
+++ b/tests/test_framework_config.py
@@ -1,0 +1,184 @@
+"""Tests for framework configuration loading and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from openbad.frameworks.config import (
+    ConfigValidationError,
+    CrewConfig,
+    FrameworksConfig,
+    LangGraphConfig,
+    load_agent_priorities,
+    load_frameworks_config,
+)
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def _write_cognitive(cfg_dir: Path, data: dict) -> None:
+    (cfg_dir / "cognitive.yaml").write_text(yaml.dump(data))
+
+
+def _write_routing(cfg_dir: Path, data: dict) -> None:
+    (cfg_dir / "model_routing.yaml").write_text(yaml.dump(data))
+
+
+# ── Defaults ──────────────────────────────────────────────────────── #
+
+
+class TestDefaults:
+    def test_missing_file_returns_defaults(self, config_dir: Path) -> None:
+        cfg = load_frameworks_config(config_dir)
+        assert cfg == FrameworksConfig()
+
+    def test_missing_section_returns_defaults(self, config_dir: Path) -> None:
+        _write_cognitive(config_dir, {"cognitive": {"enabled": True}})
+        cfg = load_frameworks_config(config_dir)
+        assert cfg == FrameworksConfig()
+
+    def test_default_crew_values(self) -> None:
+        crew = CrewConfig()
+        assert crew.verbose is False
+        assert crew.max_iterations == 10
+        assert crew.allow_delegation is True
+
+    def test_default_langgraph_values(self) -> None:
+        lg = LangGraphConfig()
+        assert lg.checkpoint_format == "json"
+        assert lg.checkpoint_retention_hours == 168
+
+
+# ── Loading ───────────────────────────────────────────────────────── #
+
+
+class TestLoading:
+    def test_loads_crew_config(self, config_dir: Path) -> None:
+        _write_cognitive(config_dir, {
+            "cognitive": {
+                "frameworks": {
+                    "crews": {
+                        "user_facing": {
+                            "verbose": True,
+                            "max_iterations": 5,
+                            "allow_delegation": False,
+                        },
+                    },
+                },
+            },
+        })
+        cfg = load_frameworks_config(config_dir)
+        assert "user_facing" in cfg.crews
+        assert cfg.crews["user_facing"].verbose is True
+        assert cfg.crews["user_facing"].max_iterations == 5
+        assert cfg.crews["user_facing"].allow_delegation is False
+
+    def test_loads_langgraph_config(self, config_dir: Path) -> None:
+        _write_cognitive(config_dir, {
+            "cognitive": {
+                "frameworks": {
+                    "langgraph": {
+                        "checkpoint_format": "pickle",
+                        "checkpoint_retention_hours": 48,
+                    },
+                },
+            },
+        })
+        cfg = load_frameworks_config(config_dir)
+        assert cfg.langgraph.checkpoint_format == "pickle"
+        assert cfg.langgraph.checkpoint_retention_hours == 48
+
+    def test_loads_agent_config(self, config_dir: Path) -> None:
+        _write_cognitive(config_dir, {
+            "cognitive": {
+                "frameworks": {
+                    "agents": {
+                        "doctor": {"priority": "critical"},
+                        "explorer": {"priority": "low"},
+                    },
+                },
+            },
+        })
+        cfg = load_frameworks_config(config_dir)
+        assert cfg.agents["doctor"].priority == "critical"
+        assert cfg.agents["explorer"].priority == "low"
+
+    def test_loads_agent_priorities_from_routing(
+        self, config_dir: Path,
+    ) -> None:
+        _write_routing(config_dir, {
+            "agent_priorities": {
+                "chat": "medium",
+                "doctor": "critical",
+            },
+        })
+        priorities = load_agent_priorities(config_dir)
+        assert priorities == {"chat": "medium", "doctor": "critical"}
+
+    def test_missing_routing_file(self, config_dir: Path) -> None:
+        priorities = load_agent_priorities(config_dir)
+        assert priorities == {}
+
+
+# ── Validation ────────────────────────────────────────────────────── #
+
+
+class TestValidation:
+    def test_invalid_agent_priority(self, config_dir: Path) -> None:
+        _write_cognitive(config_dir, {
+            "cognitive": {
+                "frameworks": {
+                    "agents": {
+                        "chat": {"priority": "super_high"},
+                    },
+                },
+            },
+        })
+        with pytest.raises(ConfigValidationError, match="super_high"):
+            load_frameworks_config(config_dir)
+
+    def test_invalid_checkpoint_format(self, config_dir: Path) -> None:
+        _write_cognitive(config_dir, {
+            "cognitive": {
+                "frameworks": {
+                    "langgraph": {
+                        "checkpoint_format": "msgpack",
+                    },
+                },
+            },
+        })
+        with pytest.raises(ConfigValidationError, match="msgpack"):
+            load_frameworks_config(config_dir)
+
+    def test_invalid_routing_priority(self, config_dir: Path) -> None:
+        _write_routing(config_dir, {
+            "agent_priorities": {
+                "doctor": "ultra",
+            },
+        })
+        with pytest.raises(ConfigValidationError, match="ultra"):
+            load_agent_priorities(config_dir)
+
+
+# ── Full config file ──────────────────────────────────────────────── #
+
+
+class TestFullConfig:
+    def test_loads_real_config_dir(self) -> None:
+        """Load from the actual project config/ directory."""
+        cfg = load_frameworks_config()
+        assert isinstance(cfg, FrameworksConfig)
+        assert len(cfg.crews) > 0
+        assert len(cfg.agents) > 0
+
+    def test_loads_real_agent_priorities(self) -> None:
+        """Load agent priorities from the actual config/ directory."""
+        priorities = load_agent_priorities()
+        assert isinstance(priorities, dict)
+        assert len(priorities) > 0


### PR DESCRIPTION
Closes #526

## Summary
Adds framework-specific configuration to YAML config files and a config loader/validator module.

### Changes

**config/cognitive.yaml**:
- Added `frameworks:` section with:
  - `crews:` — per-crew settings (verbose, max_iterations, allow_delegation) for user_facing, internal, maintenance
  - `langgraph:` — checkpoint_format, checkpoint_retention_hours
  - `agents:` — per-agent priority (chat, task, research, doctor, sleep, immune, explorer)

**config/model_routing.yaml**:
- Added `agent_priorities:` — agent-to-priority mappings for model routing

**src/openbad/frameworks/config.py**:
- `CrewConfig`, `LangGraphConfig`, `AgentConfig`, `FrameworksConfig` dataclasses
- `load_frameworks_config()` — loads and validates from cognitive.yaml
- `load_agent_priorities()` — loads and validates from model_routing.yaml
- `ConfigValidationError` for clear error messages on invalid config

**tests/test_framework_config.py** — 14 tests:
- Default values when config missing
- Loading crew/langgraph/agent config
- Validation of invalid priorities and checkpoint formats
- Loading from real project config directory

### How to test
```bash
source .venv/bin/activate
python -m pytest tests/test_framework_config.py -v
ruff check src/openbad/frameworks/config.py tests/test_framework_config.py
```

## Depends on
- #524