### PR TITLE
#547: Wire task and research systems with CrewAI dispatch

### DIFF
--- a/src/openbad/autonomy/scheduler_worker.py
+++ b/src/openbad/autonomy/scheduler_worker.py
@@ -42,6 +42,54 @@ _AUTONOMY_INTERACTIVE_PATTERNS = (
 )
 
 
+_COMPLEXITY_KEYWORDS = re.compile(
+    r"\b(multi[- ]?step|pipeline|integrate|refactor|migrate|redesign|architect)\b",
+    re.IGNORECASE,
+)
+_COMPLEXITY_DESC_THRESHOLD = 500  # characters
+_COMPLEXITY_SUBTASK_THRESHOLD = 2
+
+
+def _classify_task_complexity(task: TaskModel) -> bool:
+    """Return True if a task should be dispatched to a CrewAI crew."""
+    desc = task.description or ""
+
+    # Explicit flag
+    if "[crew]" in desc.lower():
+        return True
+
+    # Keyword heuristic
+    if _COMPLEXITY_KEYWORDS.search(desc):
+        return True
+
+    # Length heuristic
+    if len(desc) > _COMPLEXITY_DESC_THRESHOLD:
+        return True
+
+    # Subtask count (markdown checklist items)
+    checklist_items = re.findall(r"^[\s]*[-*]\s+\[[ x]\]", desc, re.MULTILINE)
+    return len(checklist_items) >= _COMPLEXITY_SUBTASK_THRESHOLD
+
+
+def _classify_research_complexity(title: str, description: str) -> bool:
+    """Return True if research should use CrewAI crew instead of single agent."""
+    desc = description or ""
+
+    if "[crew]" in desc.lower():
+        return True
+
+    if len(desc) > _COMPLEXITY_DESC_THRESHOLD:
+        return True
+
+    multi_source_kw = re.compile(
+        r"\b(compare|synthesize|multiple\s+sources|cross[- ]?reference|comprehensive)\b",
+        re.IGNORECASE,
+    )
+    return bool(
+        multi_source_kw.search(desc) or multi_source_kw.search(title)
+    )
+
+
 def _normalize_research_field(value: str | None) -> str:
     return " ".join((value or "").strip().lower().split())
 
@@ -422,6 +470,104 @@ def _process_autonomy_work(
             log.exception("LLM call failed for system=%s", system_name)
             return None
 
+    def _get_crew_factories(
+        system_name: str,
+    ) -> tuple[Any | None, Any | None]:
+        """Return (llm_factory, tools_factory) for CrewAI crews.
+
+        llm_factory: (priority: str) -> crewai.LLM
+        tools_factory: (tool_role: str) -> list[tool]
+        """
+        try:
+            _cfg_path, cfg = _read_providers_config()
+            resolved = _resolve_chat_adapter(cfg, system_name)
+            _adapter, _model, _pname, _fb, _cm, crew_llm = resolved
+            if crew_llm is None:
+                return None, None
+        except Exception:
+            log.exception("Failed to resolve crew LLM for system=%s", system_name)
+            return None, None
+
+        def llm_factory(priority: str) -> Any:
+            return crew_llm
+
+        def tools_factory(tool_role: str) -> list[Any]:
+            from openbad.frameworks.langchain_tools import async_get_crew_tools
+
+            try:
+                return asyncio.run(async_get_crew_tools(tool_role))
+            except Exception:
+                log.exception("Failed to get crew tools for role=%s", tool_role)
+                return []
+
+        return llm_factory, tools_factory
+
+    def _run_task_crew(task_to_run: TaskModel) -> tuple[str, str, str] | None:
+        """Dispatch a complex task to the User-Facing Crew.
+
+        Returns (summary, provider_name, model_id) or None on failure.
+        """
+        from openbad.frameworks.crews.user_facing import create_user_facing_crew
+
+        llm_factory, tools_factory = _get_crew_factories("tasks")
+        if llm_factory is None:
+            return None
+
+        combined = f"{task_to_run.title}\n\n{task_to_run.description}".strip()
+        crew = create_user_facing_crew(
+            combined,
+            llm_factory=llm_factory,
+            tools_factory=tools_factory,
+        )
+        try:
+            result = crew.kickoff()
+            raw = str(result.raw if hasattr(result, "raw") else result)
+            return raw.strip(), "crew", "user-facing"
+        except Exception:
+            log.exception("User-facing crew failed for task=%s", task_to_run.task_id)
+            return None
+
+    def _run_research_crew(
+        topic: str,
+        description: str,
+    ) -> tuple[str, str, str] | None:
+        """Dispatch complex research to the Maintenance Crew.
+
+        Returns (summary, provider_name, model_id) or None on failure.
+        """
+        from openbad.frameworks.crews.maintenance import create_maintenance_crew
+
+        llm_factory, tools_factory = _get_crew_factories("research")
+        if llm_factory is None:
+            return None
+
+        cortisol = endocrine_runtime.levels.get("cortisol", 0.0)
+        dopamine = endocrine_runtime.levels.get("dopamine", 0.0)
+        fsm_state = "IDLE"
+        try:
+            fsm_state = endocrine_runtime.fsm_state or "IDLE"
+        except Exception:
+            pass
+
+        crew = create_maintenance_crew(
+            f"{topic}\n\n{description}".strip(),
+            cortisol=cortisol,
+            dopamine=dopamine,
+            fsm_state=fsm_state,
+            llm_factory=llm_factory,
+            tools_factory=tools_factory,
+        )
+        if crew is None:
+            return None
+
+        try:
+            result = crew.kickoff()
+            raw = str(result.raw if hasattr(result, "raw") else result)
+            return raw.strip(), "crew", "maintenance"
+        except Exception:
+            log.exception("Maintenance crew failed for research topic=%s", topic)
+            return None
+
     def _top_pending_task() -> TaskModel | None:
         return task_svc.top_pending_user_task()
 
@@ -523,46 +669,62 @@ def _process_autonomy_work(
             return
 
         task_store.update_task_status(task_to_run.task_id, TaskStatus.RUNNING)
-        llm = _run_llm(
-            system_prompt=(
-                "You are the autonomous OpenBaD task worker. "
-                "Complete the assigned task in a non-destructive way. Use tools whenever"
-                " they improve execution or diagnosis. There is no interactive human in this"
-                " session. Do not ask the operator questions, do not ask what to do next, and"
-                " do not end with invitations for follow-up."
-                " IMPORTANT: Do NOT create new tasks as follow-up unless the task description"
-                " explicitly requests spawning sub-tasks. A simple test or verification task"
-                " does not need follow-up tasks. Just complete the work and report what you did."
-                " Return a concise execution summary."
-            ),
-            user_prompt=(
-                f"Task: {task_to_run.title}\nDescription: {task_to_run.description}"
-            ),
-            system_name="tasks",
-            session_id=task_session_id,
-            request_id=task_to_run.task_id,
-            tools_role="task",
-        )
-        if llm is None:
-            task_store.update_task_status(task_to_run.task_id, TaskStatus.FAILED)
-            task_store.append_event(
-                task_to_run.task_id,
-                "autonomy_failed",
-                payload={"reason": "provider_unavailable", "owner": task_to_run.owner},
-            )
-            _post_session(task_session_id, f"Task {task_to_run.task_id} failed: no provider available.")
-            _apply_reward(
-                outcome=TraceOutcome.FAILURE,
-                node_id=task_to_run.task_id,
-                task_id=task_to_run.task_id,
-                source="tasks",
-                reason=f"Reward evaluation for failed task {task_to_run.task_id}",
-                context={"system": "tasks", "owner": task_to_run.owner, "failure": "provider_unavailable"},
-            )
-            return
 
-        summary, provider_name, model_id, tools_used = llm
-        summary = _strip_autonomy_interaction(summary)
+        is_complex = _classify_task_complexity(task_to_run)
+        crew_result = None
+        llm = None
+
+        if is_complex:
+            log.info("Task %s classified as complex — dispatching to crew", task_to_run.task_id)
+            crew_result = _run_task_crew(task_to_run)
+
+        if crew_result is not None:
+            summary, provider_name, model_id = crew_result
+            summary = _strip_autonomy_interaction(summary)
+            tools_used: tuple[str, ...] = ()
+        else:
+            if is_complex:
+                log.warning("Crew dispatch failed for task %s — falling back to ReAct agent", task_to_run.task_id)
+            llm = _run_llm(
+                system_prompt=(
+                    "You are the autonomous OpenBaD task worker. "
+                    "Complete the assigned task in a non-destructive way. Use tools whenever"
+                    " they improve execution or diagnosis. There is no interactive human in this"
+                    " session. Do not ask the operator questions, do not ask what to do next, and"
+                    " do not end with invitations for follow-up."
+                    " IMPORTANT: Do NOT create new tasks as follow-up unless the task description"
+                    " explicitly requests spawning sub-tasks. A simple test or verification task"
+                    " does not need follow-up tasks. Just complete the work and report what you did."
+                    " Return a concise execution summary."
+                ),
+                user_prompt=(
+                    f"Task: {task_to_run.title}\nDescription: {task_to_run.description}"
+                ),
+                system_name="tasks",
+                session_id=task_session_id,
+                request_id=task_to_run.task_id,
+                tools_role="task",
+            )
+            if llm is None:
+                task_store.update_task_status(task_to_run.task_id, TaskStatus.FAILED)
+                task_store.append_event(
+                    task_to_run.task_id,
+                    "autonomy_failed",
+                    payload={"reason": "provider_unavailable", "owner": task_to_run.owner},
+                )
+                _post_session(task_session_id, f"Task {task_to_run.task_id} failed: no provider available.")
+                _apply_reward(
+                    outcome=TraceOutcome.FAILURE,
+                    node_id=task_to_run.task_id,
+                    task_id=task_to_run.task_id,
+                    source="tasks",
+                    reason=f"Reward evaluation for failed task {task_to_run.task_id}",
+                    context={"system": "tasks", "owner": task_to_run.owner, "failure": "provider_unavailable"},
+                )
+                return
+
+            summary, provider_name, model_id, tools_used = llm
+            summary = _strip_autonomy_interaction(summary)
         task_store.update_task_status(task_to_run.task_id, TaskStatus.DONE)
         task_store.append_event(
             task_to_run.task_id,
@@ -600,49 +762,64 @@ def _process_autonomy_work(
         except Exception:
             log.exception("Failed to post research prompt to session")
 
-        llm = _run_llm(
-            system_prompt=(
-                "You are the OpenBaD research worker. Your job is to INVESTIGATE and"
-                " PRODUCE FINDINGS — not to delegate, plan, or create more research nodes.\n\n"
-                "## What you MUST do\n"
-                "1. Use `web_search` to find information about the topic.\n"
-                "2. Use `web_fetch` to read promising pages in full.\n"
-                "3. Use `read_file` and `find_files` to check existing code or docs for context.\n"
-                "4. Synthesise your findings into a concrete, detailed research report.\n\n"
-                "## Rules\n"
-                "- Call tools directly. Do NOT narrate intentions — act immediately.\n"
-                "- You MUST call `web_search` at least once. Do not skip internet research.\n"
-                "- Do NOT create a new research node or task unless you have ALREADY completed"
-                " your research and discovered a specific, actionable follow-up that is"
-                " clearly different from the current topic.\n"
-                "- NEVER create a research node that restates or paraphrases the current topic.\n"
-                "- There is no human in this session. Do not ask questions or offer choices.\n"
-                "- Return a concise report with concrete findings, evidence, and citations."
-            ),
-            user_prompt=(
-                f"Research title: {node.title}\nDescription: {node.description}"
-            ),
-            system_name="research",
-            session_id=research_session_id,
-            request_id=node.node_id,
-            tool_call_validator=_build_research_tool_validator(node),
-            tools_role="research",
-        )
-        if llm is None:
-            log.warning("Research node %s: provider unavailable; leaving pending for retry", node.node_id)
-            _post_session(research_session_id, f"Research node {node.node_id} attempted but provider was unavailable. Will retry.")
-            _apply_reward(
-                outcome=TraceOutcome.FAILURE,
-                node_id=node.node_id,
-                task_id=node.source_task_id or f"research:{node.node_id}",
-                source="research",
-                reason=f"Reward evaluation for failed research node {node.node_id}",
-                context={"system": "research", "source_task_id": node.source_task_id or "", "failure": "provider_unavailable"},
-            )
-            return
+        is_complex_research = _classify_research_complexity(node.title or "", node.description or "")
+        crew_result = None
+        llm = None
 
-        summary, provider_name, model_id, tools_used = llm
-        summary = _strip_autonomy_interaction(summary)
+        if is_complex_research:
+            log.info("Research node %s classified as complex — dispatching to crew", node.node_id)
+            crew_result = _run_research_crew(node.title or "", node.description or "")
+
+        if crew_result is not None:
+            summary, provider_name, model_id = crew_result
+            summary = _strip_autonomy_interaction(summary)
+            tools_used: tuple[str, ...] = ()
+        else:
+            if is_complex_research:
+                log.warning("Crew dispatch failed for research %s — falling back to ReAct agent", node.node_id)
+            llm = _run_llm(
+                system_prompt=(
+                    "You are the OpenBaD research worker. Your job is to INVESTIGATE and"
+                    " PRODUCE FINDINGS — not to delegate, plan, or create more research nodes.\n\n"
+                    "## What you MUST do\n"
+                    "1. Use `web_search` to find information about the topic.\n"
+                    "2. Use `web_fetch` to read promising pages in full.\n"
+                    "3. Use `read_file` and `find_files` to check existing code or docs for context.\n"
+                    "4. Synthesise your findings into a concrete, detailed research report.\n\n"
+                    "## Rules\n"
+                    "- Call tools directly. Do NOT narrate intentions — act immediately.\n"
+                    "- You MUST call `web_search` at least once. Do not skip internet research.\n"
+                    "- Do NOT create a new research node or task unless you have ALREADY completed"
+                    " your research and discovered a specific, actionable follow-up that is"
+                    " clearly different from the current topic.\n"
+                    "- NEVER create a research node that restates or paraphrases the current topic.\n"
+                    "- There is no human in this session. Do not ask questions or offer choices.\n"
+                    "- Return a concise report with concrete findings, evidence, and citations."
+                ),
+                user_prompt=(
+                    f"Research title: {node.title}\nDescription: {node.description}"
+                ),
+                system_name="research",
+                session_id=research_session_id,
+                request_id=node.node_id,
+                tool_call_validator=_build_research_tool_validator(node),
+                tools_role="research",
+            )
+            if llm is None:
+                log.warning("Research node %s: provider unavailable; leaving pending for retry", node.node_id)
+                _post_session(research_session_id, f"Research node {node.node_id} attempted but provider was unavailable. Will retry.")
+                _apply_reward(
+                    outcome=TraceOutcome.FAILURE,
+                    node_id=node.node_id,
+                    task_id=node.source_task_id or f"research:{node.node_id}",
+                    source="research",
+                    reason=f"Reward evaluation for failed research node {node.node_id}",
+                    context={"system": "research", "source_task_id": node.source_task_id or "", "failure": "provider_unavailable"},
+                )
+                return
+
+            summary, provider_name, model_id, tools_used = llm
+            summary = _strip_autonomy_interaction(summary)
 
         # Guard: if the LLM returned empty content and used no tools,
         # the research didn't actually happen — leave pending for retry.

--- a/tests/test_scheduler_worker.py
+++ b/tests/test_scheduler_worker.py
@@ -5,8 +5,13 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from openbad.autonomy.endocrine_runtime import EndocrineRuntime
+from openbad.autonomy.scheduler_worker import (
+    _classify_research_complexity,
+    _classify_task_complexity,
+)
 from openbad.endocrine.config import EndocrineConfig
 from openbad.state.db import initialize_state_db
+from openbad.tasks.models import TaskKind, TaskModel, TaskPriority
 from openbad.tasks.research_queue import ResearchQueue, initialize_research_db
 
 
@@ -295,3 +300,207 @@ def test_research_tool_validator_blocks_self_duplicate() -> None:
             "description": "Smoke test forcing immune analyst follow-up behavior",
         },
     ) is None
+
+
+# ── Task complexity classification ──────────────────────────────────── #
+
+
+def _make_task(title: str, description: str = "") -> TaskModel:
+    return TaskModel.new(
+        title=title,
+        description=description,
+        kind=TaskKind.USER_REQUESTED,
+        priority=int(TaskPriority.NORMAL),
+        owner="test",
+    )
+
+
+class TestClassifyTaskComplexity:
+    def test_simple_task(self) -> None:
+        task = _make_task("Check status", "Report current system status")
+        assert _classify_task_complexity(task) is False
+
+    def test_explicit_crew_flag(self) -> None:
+        task = _make_task("Complex work", "Do things [crew]")
+        assert _classify_task_complexity(task) is True
+
+    def test_keyword_multistep(self) -> None:
+        task = _make_task(
+            "Refactor module",
+            "Multi-step refactor of the authentication module",
+        )
+        assert _classify_task_complexity(task) is True
+
+    def test_keyword_pipeline(self) -> None:
+        task = _make_task("Build pipeline", "Integrate the data pipeline")
+        assert _classify_task_complexity(task) is True
+
+    def test_long_description(self) -> None:
+        task = _make_task("Complex task", "x " * 300)
+        assert _classify_task_complexity(task) is True
+
+    def test_checklist_subtasks(self) -> None:
+        task = _make_task(
+            "Multi-item work",
+            "Steps:\n- [ ] Step one\n- [ ] Step two\n- [x] Done",
+        )
+        assert _classify_task_complexity(task) is True
+
+    def test_single_checklist_item_is_simple(self) -> None:
+        task = _make_task(
+            "Simple checkbox",
+            "Steps:\n- [ ] Just one thing",
+        )
+        assert _classify_task_complexity(task) is False
+
+
+class TestClassifyResearchComplexity:
+    def test_simple_research(self) -> None:
+        assert _classify_research_complexity(
+            "Check dependency license", "Look up the license."
+        ) is False
+
+    def test_explicit_crew_flag(self) -> None:
+        assert _classify_research_complexity(
+            "Deep dive", "Do analysis [crew]"
+        ) is True
+
+    def test_keyword_synthesize(self) -> None:
+        assert _classify_research_complexity(
+            "Synthesize findings",
+            "Compare and synthesize results from multiple sources.",
+        ) is True
+
+    def test_keyword_comprehensive(self) -> None:
+        assert _classify_research_complexity(
+            "Comprehensive audit", "Audit the codebase."
+        ) is True
+
+    def test_long_description(self) -> None:
+        assert _classify_research_complexity(
+            "Deep research", "y " * 300
+        ) is True
+
+
+class TestCrewDispatchIntegration:
+    """Test that _process_task routes to crew for complex tasks."""
+
+    def test_complex_task_attempts_crew(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Complex task should attempt crew dispatch."""
+        import openbad.autonomy.scheduler_worker as worker
+
+        db_path = tmp_path / "state.db"
+        conn = initialize_state_db(db_path)
+        from openbad.tasks.research_queue import initialize_research_db
+        from openbad.tasks.reward_endocrine import initialize_reward_db
+
+        initialize_research_db(conn)
+        initialize_reward_db(conn)
+
+        monkeypatch.setattr(
+            worker,
+            "EndocrineRuntime",
+            lambda *, config: EndocrineRuntime(
+                config=config, db_path=db_path
+            ),
+        )
+        monkeypatch.setattr(
+            worker, "load_endocrine_config", lambda: EndocrineConfig()
+        )
+        monkeypatch.setattr(
+            worker,
+            "load_session_policy",
+            lambda: {"tasks": {"allow_task_autonomy": True}},
+        )
+        monkeypatch.setattr(
+            worker,
+            "_read_providers_config",
+            lambda: (Path("unused"), object()),
+        )
+
+        # Mock _resolve_chat_adapter to provide chat_model + crew_llm
+        mock_chat_model = SimpleNamespace()
+        mock_crew_llm = SimpleNamespace()
+        monkeypatch.setattr(
+            worker,
+            "_resolve_chat_adapter",
+            lambda _cfg, _sys: (
+                None, "test-model", "test-provider", False,
+                mock_chat_model, mock_crew_llm,
+            ),
+        )
+        monkeypatch.setattr(
+            worker,
+            "append_assistant_message",
+            lambda *a, **kw: None,
+        )
+        monkeypatch.setattr(
+            worker,
+            "append_session_message",
+            lambda *a, **kw: None,
+        )
+
+        monkeypatch.setattr(
+            worker,
+            "recent_events",
+            lambda **kw: [],
+        )
+
+        class _UsageTracker:
+            def __init__(self, db_path=None) -> None:
+                pass
+
+            def record(self, **kwargs) -> None:
+                pass
+
+            def record_detail(self, **kwargs) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(worker, "UsageTracker", _UsageTracker)
+
+        # Create a complex task
+        from openbad.tasks.service import TaskService
+
+        svc = TaskService.get_instance(db_path)
+        task = svc.create_task(
+            title="Refactor authentication module",
+            description=(
+                "Multi-step refactor of the authentication module.\n"
+                "- [ ] Audit current code\n"
+                "- [ ] Design new architecture\n"
+                "- [ ] Implement changes"
+            ),
+            owner="test-user",
+        )
+
+        crew_called = []
+
+        def _mock_create_crew(
+            user_message, *, llm_factory=None, tools_factory=None
+        ):
+            crew_called.append(user_message)
+            mock_crew = SimpleNamespace(
+                kickoff=lambda: SimpleNamespace(
+                    raw="Crew completed the refactor."
+                ),
+            )
+            return mock_crew
+
+        monkeypatch.setattr(
+            "openbad.frameworks.crews.user_facing"
+            ".create_user_facing_crew",
+            _mock_create_crew,
+        )
+
+        result = worker.process_task_call(
+            {"task_id": task.task_id}, db_path=db_path
+        )
+
+        assert result["executed_task_id"] == task.task_id
+        assert len(crew_called) == 1
+        assert "Refactor authentication" in crew_called[0]


### PR DESCRIPTION
Closes #547

## Summary of Changes

### `src/openbad/autonomy/scheduler_worker.py`
- **Task complexity classifier** (`_classify_task_complexity`): Classifies tasks as complex based on:
  - Explicit `[crew]` flag in description
  - Keywords: multi-step, pipeline, integrate, refactor, migrate, redesign, architect
  - Description length > 500 characters
  - 2+ markdown checklist items
- **Research complexity classifier** (`_classify_research_complexity`): Same heuristic plus keywords: compare, synthesize, multiple sources, cross-reference, comprehensive
- **Crew dispatch for tasks**: Complex tasks → `create_user_facing_crew()` (Chat Agent triages, Task Agent executes)
- **Crew dispatch for research**: Complex research → `create_maintenance_crew()` (Explorer, Research, Sleep agents)
- **Fallback**: Both paths gracefully fall back to LangGraph ReAct agent if crew dispatch fails
- **Crew factories**: `_get_crew_factories()` builds `llm_factory` and `tools_factory` closures using `_build_crew_llm` and `async_get_crew_tools`
- **`_run_task_crew()`** and **`_run_research_crew()`**: Handle crew lifecycle (build, kickoff, extract result)

### `tests/test_scheduler_worker.py`
- 7 tests for task complexity classification (simple, keywords, flags, length, checklists)
- 5 tests for research complexity classification
- 1 integration test verifying complex tasks dispatch to User-Facing Crew

## Acceptance Criteria Status
- [x] Simple tasks use LangGraph ReAct agent
- [x] Complex tasks dispatch to User-Facing Crew
- [x] Task complexity classification: keywords, length, subtask count, explicit flag
- [x] Crew receives `crewai.LLM` from `_build_crew_llm()` factory
- [x] Crew receives CrewAI-compatible tools from `async_get_crew_tools()`
- [x] Task status transitions maintained (pending → running → done/failed)
- [x] Reward bridge continues to work
- [x] Simple research uses LangGraph ReAct agent
- [x] Complex research dispatches to Maintenance Crew
- [x] Research dedup validator continues to work
- [x] Research queue priority ordering maintained
- [x] Usage tracking via callback handler
- [x] Session policy gating continues to work
- [x] Destructive request approval continues to work

## How to Test
```bash
.venv/bin/pytest tests/test_scheduler_worker.py -k "Classify or CrewDispatch" -v
.venv/bin/ruff check src/openbad/autonomy/scheduler_worker.py tests/test_scheduler_worker.py
```