### PR TITLE
#549: Wire Reaction System — endocrine reflex handlers and escalation consumer

### DIFF
--- a/src/openbad/reflex_arc/escalation.py
+++ b/src/openbad/reflex_arc/escalation.py
@@ -14,6 +14,7 @@ import time
 import uuid
 from collections import deque
 from dataclasses import dataclass, field
+from typing import Any
 
 from openbad.nervous_system.schemas.cognitive_pb2 import EscalationRequest
 from openbad.nervous_system.schemas.common_pb2 import Header
@@ -157,6 +158,76 @@ class EscalationGateway:
         return False
 
     # -- introspection ------------------------------------------------------
+
+    @property
+    def escalation_log(self) -> list[EscalationContext]:
+        with self._lock:
+            return list(self._escalation_log)
+
+
+# ── Escalation consumer ──────────────────────────────────────────────── #
+
+
+def consume_escalation(
+    payload: bytes,
+    *,
+    task_store: Any | None = None,
+    research_store: Any | None = None,
+) -> str | None:
+    """Consume an escalation event and create a task or research entry.
+
+    Called by the scheduler or MQTT subscriber when an escalation
+    message arrives on ``agent/cognitive/escalation``.
+
+    Returns the created task/research ID, or None on failure.
+    """
+    try:
+        msg = EscalationRequest()
+        msg.ParseFromString(payload)
+    except Exception:
+        logger.exception("Failed to parse escalation protobuf")
+        return None
+
+    reason = msg.reason or "Escalated from reflex arc"
+    reflex_id = msg.reflex_id or "unknown"
+    priority = msg.priority
+
+    # High-priority escalations → task, low → research
+    if priority >= 2 or "emergency" in reason.lower():
+        if task_store is not None:
+            from openbad.tasks.models import TaskKind, TaskModel, TaskPriority
+
+            task = TaskModel.new(
+                title=f"Escalation: {reason[:80]}",
+                description=(
+                    f"Reflex escalation from {reflex_id}.\n"
+                    f"Reason: {reason}\n"
+                    f"Priority: {priority}"
+                ),
+                kind=TaskKind.SYSTEM,
+                priority=int(TaskPriority.HIGH),
+                owner="escalation-consumer",
+            )
+            created = task_store.create_task(task)
+            logger.info(
+                "Escalation → task %s: %s", created.task_id, reason
+            )
+            return created.task_id
+    else:
+        if research_store is not None:
+            node = research_store.enqueue(
+                f"Investigate: {reason[:80]}",
+                description=(
+                    f"Reflex escalation from {reflex_id}.\n"
+                    f"Reason: {reason}"
+                ),
+            )
+            logger.info(
+                "Escalation → research %s: %s", node.node_id, reason
+            )
+            return node.node_id
+
+    return None
 
     @property
     def escalation_log(self) -> list[EscalationContext]:

--- a/src/openbad/reflex_arc/handlers/endocrine.py
+++ b/src/openbad/reflex_arc/handlers/endocrine.py
@@ -1,0 +1,260 @@
+"""Endocrine reflex handlers — deterministic responses to hormone thresholds.
+
+Handles four scenarios without LLM involvement:
+
+1. **High cortisol**: Throttle non-essential systems, create monitoring task
+2. **Adrenaline spike**: Emergency mode, alert doctor
+3. **Endorphin release**: Trigger sleep/maintenance cycle
+4. **Immune alert**: Quarantine source + escalate to Internal Crew
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Thresholds (severity 3 = CRITICAL in FSM)
+CORTISOL_THROTTLE: float = 0.70
+ADRENALINE_EMERGENCY: float = 0.80
+ENDORPHIN_SLEEP: float = 0.60
+
+
+@dataclass
+class ReflexAction:
+    """Result of a deterministic reflex handler."""
+
+    action: str  # "task", "research", "mqtt", "escalate"
+    title: str
+    description: str
+    metadata: dict[str, Any]
+
+
+def handle_high_cortisol(
+    level: float,
+    *,
+    task_store: Any | None = None,
+    publish_fn: Any | None = None,
+) -> list[ReflexAction]:
+    """React to critical cortisol levels."""
+    actions: list[ReflexAction] = []
+    if level < CORTISOL_THROTTLE:
+        return actions
+
+    # Create monitoring task
+    if task_store is not None:
+        from openbad.tasks.models import TaskKind, TaskModel, TaskPriority
+
+        task = TaskModel.new(
+            title="Cortisol recovery: monitor system load",
+            description=(
+                f"Cortisol level at {level:.2f} exceeded threshold "
+                f"{CORTISOL_THROTTLE:.2f}. Monitor CPU/memory and "
+                "verify non-essential systems are throttled."
+            ),
+            kind=TaskKind.SYSTEM,
+            priority=int(TaskPriority.HIGH),
+            owner="reflex-arc",
+        )
+        task_store.create_task(task)
+        actions.append(
+            ReflexAction(
+                action="task",
+                title=task.title,
+                description=task.description,
+                metadata={"cortisol": level},
+            )
+        )
+
+    # Publish throttle event
+    if publish_fn is not None:
+        publish_fn(
+            "agent/reflex/throttle",
+            f'{{"source":"cortisol","level":{level:.2f}}}'.encode(),
+        )
+        actions.append(
+            ReflexAction(
+                action="mqtt",
+                title="Throttle notification",
+                description=f"Published throttle event (cortisol={level:.2f})",
+                metadata={"topic": "agent/reflex/throttle"},
+            )
+        )
+
+    log.info("Cortisol reflex: level=%.2f, actions=%d", level, len(actions))
+    return actions
+
+
+def handle_adrenaline_spike(
+    level: float,
+    *,
+    task_store: Any | None = None,
+    publish_fn: Any | None = None,
+) -> list[ReflexAction]:
+    """React to critical adrenaline levels."""
+    actions: list[ReflexAction] = []
+    if level < ADRENALINE_EMERGENCY:
+        return actions
+
+    # Create doctor call task
+    if task_store is not None:
+        from openbad.tasks.models import TaskKind, TaskModel, TaskPriority
+
+        task = TaskModel.new(
+            title="Emergency: adrenaline spike detected",
+            description=(
+                f"Adrenaline at {level:.2f} — potential threat or "
+                "critical error. Doctor evaluation required."
+            ),
+            kind=TaskKind.SYSTEM,
+            priority=int(TaskPriority.CRITICAL),
+            owner="reflex-arc",
+        )
+        task_store.create_task(task)
+        actions.append(
+            ReflexAction(
+                action="task",
+                title=task.title,
+                description=task.description,
+                metadata={"adrenaline": level},
+            )
+        )
+
+    # Alert doctor via MQTT
+    if publish_fn is not None:
+        publish_fn(
+            "agent/doctor/call",
+            (
+                f'{{"source":"reflex-arc",'
+                f'"reason":"Adrenaline spike ({level:.2f})"}}'
+            ).encode(),
+        )
+        actions.append(
+            ReflexAction(
+                action="mqtt",
+                title="Doctor alert",
+                description=f"Published doctor call (adrenaline={level:.2f})",
+                metadata={"topic": "agent/doctor/call"},
+            )
+        )
+
+    log.info(
+        "Adrenaline reflex: level=%.2f, actions=%d", level, len(actions)
+    )
+    return actions
+
+
+def handle_endorphin_release(
+    level: float,
+    *,
+    research_store: Any | None = None,
+    publish_fn: Any | None = None,
+) -> list[ReflexAction]:
+    """React to endorphin release — trigger sleep/maintenance."""
+    actions: list[ReflexAction] = []
+    if level < ENDORPHIN_SLEEP:
+        return actions
+
+    # Create maintenance research entry
+    if research_store is not None:
+        research_store.enqueue(
+            "Sleep cycle: memory consolidation",
+            description=(
+                "Endorphin-triggered maintenance cycle. "
+                "Consolidate recent memories, prune stale entries, "
+                "and update semantic indices."
+            ),
+        )
+        actions.append(
+            ReflexAction(
+                action="research",
+                title="Sleep cycle: memory consolidation",
+                description="Endorphin-triggered maintenance",
+                metadata={"endorphin": level},
+            )
+        )
+
+    # Publish sleep trigger
+    if publish_fn is not None:
+        publish_fn(
+            "agent/endocrine/endorphin",
+            f'{{"level":{level:.2f},"severity":3}}'.encode(),
+        )
+        actions.append(
+            ReflexAction(
+                action="mqtt",
+                title="Sleep trigger",
+                description=f"Published endorphin event (level={level:.2f})",
+                metadata={"topic": "agent/endocrine/endorphin"},
+            )
+        )
+
+    log.info(
+        "Endorphin reflex: level=%.2f, actions=%d", level, len(actions)
+    )
+    return actions
+
+
+def handle_immune_alert(
+    source_id: str,
+    threat_type: str,
+    *,
+    task_store: Any | None = None,
+    escalation_gw: Any | None = None,
+    publish_fn: Any | None = None,
+) -> list[ReflexAction]:
+    """React to immune alert — quarantine + escalate."""
+    actions: list[ReflexAction] = []
+
+    # Create quarantine task
+    if task_store is not None:
+        from openbad.tasks.models import TaskKind, TaskModel, TaskPriority
+
+        task = TaskModel.new(
+            title=f"Quarantine: {threat_type} from {source_id}",
+            description=(
+                f"Immune alert: {threat_type} detected from {source_id}. "
+                "Isolate the source and assess impact."
+            ),
+            kind=TaskKind.SYSTEM,
+            priority=int(TaskPriority.CRITICAL),
+            owner="reflex-arc",
+        )
+        task_store.create_task(task)
+        actions.append(
+            ReflexAction(
+                action="task",
+                title=task.title,
+                description=task.description,
+                metadata={
+                    "source_id": source_id,
+                    "threat_type": threat_type,
+                },
+            )
+        )
+
+    # Escalate to Internal Crew
+    if escalation_gw is not None:
+        escalation_gw.escalate(
+            event_topic="agent/immune/alert",
+            event_payload=f'{{"source_id":"{source_id}","threat_type":"{threat_type}"}}'.encode(),
+            reason=f"Immune alert: {threat_type} from {source_id}",
+            reflex_id="immune_handler",
+            current_state="EMERGENCY",
+        )
+        actions.append(
+            ReflexAction(
+                action="escalate",
+                title="Escalated to cognitive engine",
+                description=f"{threat_type} from {source_id}",
+                metadata={"source_id": source_id},
+            )
+        )
+
+    log.info(
+        "Immune reflex: source=%s, type=%s, actions=%d",
+        source_id, threat_type, len(actions),
+    )
+    return actions

--- a/tests/test_reflex_arc.py
+++ b/tests/test_reflex_arc.py
@@ -1,0 +1,192 @@
+"""Tests for openbad.reflex_arc — handlers, FSM, and escalation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from openbad.reflex_arc.escalation import EscalationGateway, consume_escalation
+from openbad.reflex_arc.handlers.endocrine import (
+    ADRENALINE_EMERGENCY,
+    CORTISOL_THROTTLE,
+    ENDORPHIN_SLEEP,
+    handle_adrenaline_spike,
+    handle_endorphin_release,
+    handle_high_cortisol,
+    handle_immune_alert,
+)
+
+# ── Endocrine handlers ───────────────────────────────────────────────── #
+
+
+class TestHighCortisol:
+    def test_below_threshold_no_action(self) -> None:
+        actions = handle_high_cortisol(0.5)
+        assert actions == []
+
+    def test_above_threshold_creates_task(self) -> None:
+        store = MagicMock()
+        store.create_task.return_value = SimpleNamespace(task_id="t1")
+        actions = handle_high_cortisol(
+            CORTISOL_THROTTLE + 0.01, task_store=store,
+        )
+        assert len(actions) >= 1
+        assert any(a.action == "task" for a in actions)
+        store.create_task.assert_called_once()
+
+    def test_publishes_throttle_event(self) -> None:
+        publish = MagicMock()
+        actions = handle_high_cortisol(
+            0.85, publish_fn=publish,
+        )
+        assert any(a.action == "mqtt" for a in actions)
+        publish.assert_called_once()
+        topic = publish.call_args[0][0]
+        assert "throttle" in topic
+
+
+class TestAdrenalineSpike:
+    def test_below_threshold_no_action(self) -> None:
+        actions = handle_adrenaline_spike(0.5)
+        assert actions == []
+
+    def test_above_threshold_creates_task(self) -> None:
+        store = MagicMock()
+        store.create_task.return_value = SimpleNamespace(task_id="t2")
+        actions = handle_adrenaline_spike(
+            ADRENALINE_EMERGENCY + 0.01, task_store=store,
+        )
+        assert any(a.action == "task" for a in actions)
+        store.create_task.assert_called_once()
+
+    def test_alerts_doctor(self) -> None:
+        publish = MagicMock()
+        actions = handle_adrenaline_spike(
+            0.9, publish_fn=publish,
+        )
+        assert any(a.action == "mqtt" for a in actions)
+        topic = publish.call_args[0][0]
+        assert "doctor" in topic
+
+
+class TestEndorphinRelease:
+    def test_below_threshold_no_action(self) -> None:
+        actions = handle_endorphin_release(0.3)
+        assert actions == []
+
+    def test_creates_research_entry(self) -> None:
+        store = MagicMock()
+        store.enqueue.return_value = SimpleNamespace(node_id="r1")
+        actions = handle_endorphin_release(
+            ENDORPHIN_SLEEP + 0.05, research_store=store,
+        )
+        assert any(a.action == "research" for a in actions)
+        store.enqueue.assert_called_once()
+
+
+class TestImmuneAlert:
+    def test_creates_quarantine_task(self) -> None:
+        store = MagicMock()
+        store.create_task.return_value = SimpleNamespace(task_id="t3")
+        actions = handle_immune_alert(
+            "plugin-xyz", "injection", task_store=store,
+        )
+        assert any(a.action == "task" for a in actions)
+        assert "quarantine" in actions[0].title.lower()
+
+    def test_escalates_to_cognitive(self) -> None:
+        gw = MagicMock()
+        actions = handle_immune_alert(
+            "plugin-xyz", "injection", escalation_gw=gw,
+        )
+        assert any(a.action == "escalate" for a in actions)
+        gw.escalate.assert_called_once()
+
+
+# ── Escalation gateway ───────────────────────────────────────────────── #
+
+
+class TestEscalationGateway:
+    def test_escalate_publishes(self) -> None:
+        publish = MagicMock()
+        gw = EscalationGateway(publish_fn=publish)
+        ctx = gw.escalate(
+            event_topic="agent/immune/alert",
+            event_payload=b"test",
+            reason="Test escalation",
+            reflex_id="test",
+            current_state="EMERGENCY",
+        )
+        assert ctx.correlation_id
+        publish.assert_called_once()
+
+    def test_flap_detection(self) -> None:
+        gw = EscalationGateway(
+            publish_fn=MagicMock(),
+            flap_threshold=3,
+            flap_window=10.0,
+        )
+        assert gw.record_transition("IDLE", "ACTIVE") is False
+        assert gw.record_transition("ACTIVE", "IDLE") is False
+        assert gw.record_transition("IDLE", "ACTIVE") is True  # 3rd
+
+    def test_escalation_log(self) -> None:
+        gw = EscalationGateway()
+        gw.escalate(
+            event_topic="t", event_payload=b"",
+            reason="test", reflex_id="r",
+        )
+        assert len(gw.escalation_log) == 1
+
+
+# ── Escalation consumer ─────────────────────────────────────────────── #
+
+
+class TestConsumeEscalation:
+    def _make_escalation_payload(
+        self, reason: str, priority: int = 0
+    ) -> bytes:
+        from openbad.nervous_system.schemas.cognitive_pb2 import (
+            EscalationRequest,
+        )
+        from openbad.nervous_system.schemas.common_pb2 import Header
+
+        msg = EscalationRequest(
+            header=Header(timestamp_unix=1.0),
+            event_topic="agent/immune/alert",
+            event_payload=b"test",
+            reason=reason,
+            priority=priority,
+            reflex_id="test",
+        )
+        return msg.SerializeToString()
+
+    def test_high_priority_creates_task(self) -> None:
+        store = MagicMock()
+        created = SimpleNamespace(task_id="t-esc-1")
+        store.create_task.return_value = created
+        payload = self._make_escalation_payload(
+            "Emergency detected", priority=3,
+        )
+        result = consume_escalation(
+            payload, task_store=store,
+        )
+        assert result == "t-esc-1"
+        store.create_task.assert_called_once()
+
+    def test_low_priority_creates_research(self) -> None:
+        store = MagicMock()
+        node = SimpleNamespace(node_id="r-esc-1")
+        store.enqueue.return_value = node
+        payload = self._make_escalation_payload(
+            "Minor anomaly", priority=0,
+        )
+        result = consume_escalation(
+            payload, research_store=store,
+        )
+        assert result == "r-esc-1"
+        store.enqueue.assert_called_once()
+
+    def test_invalid_payload_returns_none(self) -> None:
+        result = consume_escalation(b"not-a-protobuf")
+        assert result is None


### PR DESCRIPTION
Closes #549

## Summary of Changes

### New: Endocrine Reflex Handlers (`src/openbad/reflex_arc/handlers/endocrine.py`)
- `handle_high_cortisol()` — Creates monitoring task + publishes throttle event when cortisol ≥ 0.70
- `handle_adrenaline_spike()` — Creates emergency task + publishes doctor call when adrenaline ≥ 0.80
- `handle_endorphin_release()` — Creates maintenance research entry + publishes endorphin event when level ≥ 0.60
- `handle_immune_alert()` — Creates quarantine task + escalates to cognitive engine
- All return `list[ReflexAction]` dataclass instances for deterministic, testable behavior

### New: Escalation Consumer (`src/openbad/reflex_arc/escalation.py`)
- `consume_escalation()` — Parses `EscalationRequest` protobuf payloads from `agent/cognitive/escalation`
- High-priority escalations (priority ≥ 2 or "emergency") → task creation
- Low-priority escalations → research entry creation
- Gracefully handles invalid payloads

### New: Tests (`tests/test_reflex_arc.py`)
- 16 tests covering all handlers, escalation gateway, and escalation consumer
- Tests for threshold behavior, task/research creation, MQTT publishing, and flap detection

## How to Test
```bash
.venv/bin/pytest tests/test_reflex_arc.py -v
.venv/bin/ruff check src/openbad/reflex_arc/handlers/endocrine.py src/openbad/reflex_arc/escalation.py tests/test_reflex_arc.py
```