### PR TITLE
#561: Add library schema, sqlite-vec, LibraryStore, and text chunker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "langgraph>=0.4,<1.0",
     "langgraph-checkpoint>=2.0,<3.0",
     "crewai>=1.0,<2.0",
+    "sqlite-vec>=0.1.6",
 ]
 
 [project.scripts]

--- a/src/openbad/library/__init__.py
+++ b/src/openbad/library/__init__.py
@@ -1,0 +1,5 @@
+"""Library system — hierarchical knowledge storage with vector search."""
+
+from openbad.library.store import LibraryStore
+
+__all__ = ["LibraryStore"]

--- a/src/openbad/library/embedder.py
+++ b/src/openbad/library/embedder.py
@@ -1,0 +1,91 @@
+"""Recursive character text splitter for library book content."""
+
+from __future__ import annotations
+
+_CHARS_PER_TOKEN = 4
+_DEFAULT_CHUNK_TOKENS = 500
+_DEFAULT_OVERLAP_TOKENS = 50
+
+
+def chunk_text(
+    text: str,
+    *,
+    chunk_tokens: int = _DEFAULT_CHUNK_TOKENS,
+    overlap_tokens: int = _DEFAULT_OVERLAP_TOKENS,
+) -> list[tuple[str, int]]:
+    """Split *text* into overlapping chunks.
+
+    Returns a list of ``(chunk_text, chunk_index)`` tuples.  Token counts
+    are estimated using the ``chars / 4`` heuristic consistent with
+    ``context_manager.py``.
+    """
+    if not text:
+        return []
+
+    chunk_chars = chunk_tokens * _CHARS_PER_TOKEN
+    overlap_chars = overlap_tokens * _CHARS_PER_TOKEN
+
+    separators = ["\n\n", "\n", ". ", " "]
+    return _split_recursive(text, chunk_chars, overlap_chars, separators)
+
+
+def _split_recursive(
+    text: str,
+    chunk_chars: int,
+    overlap_chars: int,
+    separators: list[str],
+) -> list[tuple[str, int]]:
+    """Recursively split text using the first separator that produces chunks."""
+    if len(text) <= chunk_chars:
+        return [(text, 0)]
+
+    sep = separators[0] if separators else ""
+    remaining_seps = separators[1:] if separators else []
+
+    parts = text.split(sep) if sep else list(text)
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for part in parts:
+        part_len = len(part) + (len(sep) if current else 0)
+        if current_len + part_len > chunk_chars and current:
+            chunk = sep.join(current)
+            if len(chunk) > chunk_chars and remaining_seps:
+                sub_chunks = _split_recursive(
+                    chunk, chunk_chars, overlap_chars, remaining_seps
+                )
+                chunks.extend(t for t, _ in sub_chunks)
+            else:
+                chunks.append(chunk)
+
+            # Keep overlap from end of current chunk
+            overlap_parts: list[str] = []
+            overlap_len = 0
+            for p in reversed(current):
+                p_len = len(p) + len(sep)
+                if overlap_len + p_len > overlap_chars:
+                    break
+                overlap_parts.insert(0, p)
+                overlap_len += p_len
+
+            current = overlap_parts + [part]
+            current_len = sum(len(p) for p in current) + len(sep) * (
+                len(current) - 1
+            )
+        else:
+            current.append(part)
+            current_len += part_len
+
+    if current:
+        final = sep.join(current)
+        if len(final) > chunk_chars and remaining_seps:
+            sub_chunks = _split_recursive(
+                final, chunk_chars, overlap_chars, remaining_seps
+            )
+            chunks.extend(t for t, _ in sub_chunks)
+        else:
+            chunks.append(final)
+
+    return [(chunk, idx) for idx, chunk in enumerate(chunks)]

--- a/src/openbad/library/store.py
+++ b/src/openbad/library/store.py
@@ -1,0 +1,318 @@
+"""CRUD operations for the Library hierarchy backed by SQLite."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass, field
+
+from openbad.library.embedder import chunk_text  # noqa: I001
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BookEdge:
+    source_book_id: str
+    target_book_id: str
+    relation_type: str
+
+
+@dataclass(frozen=True)
+class Book:
+    book_id: str
+    section_id: str
+    title: str
+    summary: str
+    content: str
+    author: str
+    created_at: float
+    updated_at: float
+    edges: list[BookEdge] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ChunkMatch:
+    chunk_text: str
+    book_id: str
+    book_title: str
+    score: float
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class LibraryStore:
+    """Provides CRUD operations for libraries, shelves, sections, and books."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    # ------------------------------------------------------------------
+    # Library
+    # ------------------------------------------------------------------
+
+    def create_library(self, name: str, description: str = "") -> str:
+        library_id = str(uuid.uuid4())
+        self._conn.execute(
+            "INSERT INTO libraries (library_id, name, description) VALUES (?, ?, ?)",
+            (library_id, name, description),
+        )
+        self._conn.commit()
+        return library_id
+
+    # ------------------------------------------------------------------
+    # Shelf
+    # ------------------------------------------------------------------
+
+    def create_shelf(
+        self, library_id: str, name: str, description: str = ""
+    ) -> str:
+        shelf_id = str(uuid.uuid4())
+        self._conn.execute(
+            "INSERT INTO shelves (shelf_id, library_id, name, description)"
+            " VALUES (?, ?, ?, ?)",
+            (shelf_id, library_id, name, description),
+        )
+        self._conn.commit()
+        return shelf_id
+
+    # ------------------------------------------------------------------
+    # Section
+    # ------------------------------------------------------------------
+
+    def create_section(self, shelf_id: str, name: str) -> str:
+        section_id = str(uuid.uuid4())
+        self._conn.execute(
+            "INSERT INTO sections (section_id, shelf_id, name) VALUES (?, ?, ?)",
+            (section_id, shelf_id, name),
+        )
+        self._conn.commit()
+        return section_id
+
+    # ------------------------------------------------------------------
+    # Book
+    # ------------------------------------------------------------------
+
+    def create_book(
+        self,
+        section_id: str,
+        title: str,
+        content: str,
+        author: str = "user",
+        summary: str = "",
+    ) -> str:
+        book_id = str(uuid.uuid4())
+        now = time.time()
+        self._conn.execute(
+            "INSERT INTO books (book_id, section_id, title, summary, content,"
+            " author, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (book_id, section_id, title, summary, content, author, now, now),
+        )
+        self._store_chunks(book_id, content)
+        self._conn.commit()
+        return book_id
+
+    def update_book(
+        self,
+        book_id: str,
+        content: str,
+        summary: str = "",
+    ) -> None:
+        now = time.time()
+        self._conn.execute(
+            "UPDATE books SET content = ?, summary = ?, updated_at = ?"
+            " WHERE book_id = ?",
+            (content, summary, now, book_id),
+        )
+        # Remove old chunks and vectors, then re-chunk
+        old_chunk_ids = [
+            row["chunk_id"]
+            for row in self._conn.execute(
+                "SELECT chunk_id FROM book_chunks WHERE book_id = ?", (book_id,)
+            ).fetchall()
+        ]
+        if old_chunk_ids:
+            placeholders = ",".join("?" for _ in old_chunk_ids)
+            self._conn.execute(
+                f"DELETE FROM book_chunk_vectors WHERE chunk_id IN ({placeholders})",  # noqa: S608
+                old_chunk_ids,
+            )
+        self._conn.execute(
+            "DELETE FROM book_chunks WHERE book_id = ?", (book_id,)
+        )
+        self._store_chunks(book_id, content)
+        self._conn.commit()
+
+    def get_book(self, book_id: str) -> Book | None:
+        row = self._conn.execute(
+            "SELECT * FROM books WHERE book_id = ?", (book_id,)
+        ).fetchone()
+        if not row:
+            return None
+
+        edge_rows = self._conn.execute(
+            "SELECT source_book_id, target_book_id, relation_type"
+            " FROM book_edges"
+            " WHERE source_book_id = ? OR target_book_id = ?",
+            (book_id, book_id),
+        ).fetchall()
+        edges = [
+            BookEdge(
+                source_book_id=e["source_book_id"],
+                target_book_id=e["target_book_id"],
+                relation_type=e["relation_type"],
+            )
+            for e in edge_rows
+        ]
+
+        return Book(
+            book_id=row["book_id"],
+            section_id=row["section_id"],
+            title=row["title"],
+            summary=row["summary"],
+            content=row["content"],
+            author=row["author"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            edges=edges,
+        )
+
+    # ------------------------------------------------------------------
+    # Tree
+    # ------------------------------------------------------------------
+
+    def get_tree(self) -> list[dict]:
+        """Return nested hierarchy: libraries → shelves → sections → books."""
+        libraries = self._conn.execute(
+            "SELECT library_id, name FROM libraries ORDER BY name"
+        ).fetchall()
+
+        result = []
+        for lib in libraries:
+            lib_dict: dict = {
+                "library_id": lib["library_id"],
+                "name": lib["name"],
+                "shelves": [],
+            }
+            shelves = self._conn.execute(
+                "SELECT shelf_id, name FROM shelves WHERE library_id = ? ORDER BY name",
+                (lib["library_id"],),
+            ).fetchall()
+            for shelf in shelves:
+                shelf_dict: dict = {
+                    "shelf_id": shelf["shelf_id"],
+                    "name": shelf["name"],
+                    "sections": [],
+                }
+                sections = self._conn.execute(
+                    "SELECT section_id, name FROM sections"
+                    " WHERE shelf_id = ? ORDER BY name",
+                    (shelf["shelf_id"],),
+                ).fetchall()
+                for sec in sections:
+                    books = self._conn.execute(
+                        "SELECT book_id, title FROM books"
+                        " WHERE section_id = ? ORDER BY title",
+                        (sec["section_id"],),
+                    ).fetchall()
+                    shelf_dict["sections"].append(
+                        {
+                            "section_id": sec["section_id"],
+                            "name": sec["name"],
+                            "books": [
+                                {"book_id": b["book_id"], "title": b["title"]}
+                                for b in books
+                            ],
+                        }
+                    )
+                lib_dict["shelves"].append(shelf_dict)
+            result.append(lib_dict)
+        return result
+
+    # ------------------------------------------------------------------
+    # Edges
+    # ------------------------------------------------------------------
+
+    def link_books(
+        self, source_id: str, target_id: str, relation_type: str
+    ) -> None:
+        self._conn.execute(
+            "INSERT OR IGNORE INTO book_edges"
+            " (source_book_id, target_book_id, relation_type)"
+            " VALUES (?, ?, ?)",
+            (source_id, target_id, relation_type),
+        )
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Vector search
+    # ------------------------------------------------------------------
+
+    def search_chunks(
+        self, embedding: list[float], top_k: int = 5
+    ) -> list[ChunkMatch]:
+        rows = self._conn.execute(
+            "SELECT v.chunk_id, v.distance, c.text_content, c.book_id"
+            " FROM book_chunk_vectors AS v"
+            " JOIN book_chunks AS c ON c.chunk_id = v.chunk_id"
+            " WHERE v.embedding MATCH ? AND k = ?",
+            (serialize_float32(embedding), top_k),
+        ).fetchall()
+
+        results: list[ChunkMatch] = []
+        for row in rows:
+            title_row = self._conn.execute(
+                "SELECT title FROM books WHERE book_id = ?", (row["book_id"],)
+            ).fetchone()
+            results.append(
+                ChunkMatch(
+                    chunk_text=row["text_content"],
+                    book_id=row["book_id"],
+                    book_title=title_row["title"] if title_row else "",
+                    score=row["distance"],
+                )
+            )
+        return results
+
+    def store_chunk_vectors(
+        self, chunk_ids: list[str], embeddings: list[list[float]]
+    ) -> None:
+        for chunk_id, emb in zip(chunk_ids, embeddings, strict=True):
+            self._conn.execute(
+                "INSERT INTO book_chunk_vectors (chunk_id, embedding)"
+                " VALUES (?, ?)",
+                (chunk_id, serialize_float32(emb)),
+            )
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _store_chunks(self, book_id: str, content: str) -> None:
+        """Chunk *content* and insert rows into ``book_chunks``."""
+        chunks = chunk_text(content)
+        for text, idx in chunks:
+            chunk_id = str(uuid.uuid4())
+            self._conn.execute(
+                "INSERT INTO book_chunks (chunk_id, book_id, chunk_index,"
+                " text_content) VALUES (?, ?, ?, ?)",
+                (chunk_id, book_id, idx, text),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def serialize_float32(vec: list[float]) -> bytes:
+    """Serialize a float list to the binary format expected by sqlite-vec."""
+    import struct
+
+    return struct.pack(f"{len(vec)}f", *vec)

--- a/src/openbad/state/db.py
+++ b/src/openbad/state/db.py
@@ -6,6 +6,8 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
+import sqlite_vec
+
 DEFAULT_STATE_DB_PATH = Path("data/state.db")
 _MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
 
@@ -66,6 +68,9 @@ def initialize_state_db(
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA foreign_keys = ON")
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
 
     effective_dir = migrations_dir if migrations_dir is not None else _MIGRATIONS_DIR
 

--- a/src/openbad/state/migrations/0006_library.sql
+++ b/src/openbad/state/migrations/0006_library.sql
@@ -1,0 +1,66 @@
+CREATE TABLE IF NOT EXISTS libraries (
+    library_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL DEFAULT (unixepoch('now'))
+);
+
+CREATE TABLE IF NOT EXISTS shelves (
+    shelf_id TEXT PRIMARY KEY,
+    library_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL DEFAULT (unixepoch('now')),
+    FOREIGN KEY(library_id) REFERENCES libraries(library_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_shelves_library ON shelves(library_id);
+
+CREATE TABLE IF NOT EXISTS sections (
+    section_id TEXT PRIMARY KEY,
+    shelf_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    created_at REAL NOT NULL DEFAULT (unixepoch('now')),
+    FOREIGN KEY(shelf_id) REFERENCES shelves(shelf_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sections_shelf ON sections(shelf_id);
+
+CREATE TABLE IF NOT EXISTS books (
+    book_id TEXT PRIMARY KEY,
+    section_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    summary TEXT NOT NULL DEFAULT '',
+    content TEXT NOT NULL DEFAULT '',
+    author TEXT NOT NULL DEFAULT 'user' CHECK(author IN ('user', 'system')),
+    created_at REAL NOT NULL DEFAULT (unixepoch('now')),
+    updated_at REAL NOT NULL DEFAULT (unixepoch('now')),
+    FOREIGN KEY(section_id) REFERENCES sections(section_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_books_section ON books(section_id);
+
+CREATE TABLE IF NOT EXISTS book_edges (
+    source_book_id TEXT NOT NULL,
+    target_book_id TEXT NOT NULL,
+    relation_type TEXT NOT NULL CHECK(relation_type IN ('supersedes', 'relies_on', 'contradicts', 'references')),
+    PRIMARY KEY (source_book_id, target_book_id),
+    FOREIGN KEY(source_book_id) REFERENCES books(book_id) ON DELETE CASCADE,
+    FOREIGN KEY(target_book_id) REFERENCES books(book_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS book_chunks (
+    chunk_id TEXT PRIMARY KEY,
+    book_id TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    text_content TEXT NOT NULL,
+    created_at REAL NOT NULL DEFAULT (unixepoch('now')),
+    FOREIGN KEY(book_id) REFERENCES books(book_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_book_chunks_book ON book_chunks(book_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS book_chunk_vectors USING vec0(
+    chunk_id TEXT PRIMARY KEY,
+    embedding float[768]
+);

--- a/tests/test_library_embedder.py
+++ b/tests/test_library_embedder.py
@@ -1,0 +1,69 @@
+"""Tests for the text chunker."""
+
+from __future__ import annotations
+
+from openbad.library.embedder import chunk_text
+
+
+class TestChunkText:
+    def test_empty_string_returns_empty(self) -> None:
+        assert chunk_text("") == []
+
+    def test_short_text_returns_single_chunk(self) -> None:
+        text = "Hello world."
+        result = chunk_text(text)
+        assert len(result) == 1
+        assert result[0] == (text, 0)
+
+    def test_text_at_exact_limit_returns_single_chunk(self) -> None:
+        # Default chunk_tokens=500, chars_per_token=4 → 2000 chars
+        text = "a" * 2000
+        result = chunk_text(text)
+        assert len(result) == 1
+
+    def test_long_text_produces_multiple_chunks(self) -> None:
+        # Create text well beyond 2000 chars
+        text = "word " * 1000  # 5000 chars
+        result = chunk_text(text)
+        assert len(result) > 1
+        # Each chunk index should be sequential
+        for i, (_, idx) in enumerate(result):
+            assert idx == i
+
+    def test_chunk_indices_are_sequential(self) -> None:
+        text = ("paragraph one. " * 200) + "\n\n" + ("paragraph two. " * 200)
+        result = chunk_text(text)
+        indices = [idx for _, idx in result]
+        assert indices == list(range(len(result)))
+
+    def test_custom_chunk_size(self) -> None:
+        text = "word " * 100  # 500 chars
+        result = chunk_text(text, chunk_tokens=25)  # 100 chars per chunk
+        assert len(result) > 1
+
+    def test_splits_on_paragraph_boundaries(self) -> None:
+        para_a = "A" * 1500
+        para_b = "B" * 1500
+        text = para_a + "\n\n" + para_b
+        result = chunk_text(text)
+        assert len(result) >= 2
+        # First chunk should start with A, last with B
+        assert result[0][0].startswith("A")
+        assert result[-1][0].startswith("B") or "B" in result[-1][0]
+
+    def test_overlap_produces_shared_content(self) -> None:
+        # With overlap, consecutive chunks should share some text
+        sentences = [f"Sentence number {i}. " for i in range(100)]
+        text = " ".join(sentences)
+        result = chunk_text(text, chunk_tokens=50, overlap_tokens=10)
+        if len(result) >= 2:
+            # Last words of chunk 0 should appear near start of chunk 1
+            words_end_0 = set(result[0][0].split()[-5:])
+            words_start_1 = set(result[1][0].split()[:20])
+            assert words_end_0 & words_start_1, "Expected overlap between chunks"
+
+    def test_no_empty_chunks(self) -> None:
+        text = "hello " * 500
+        result = chunk_text(text)
+        for chunk, _ in result:
+            assert chunk.strip() != ""

--- a/tests/test_library_store.py
+++ b/tests/test_library_store.py
@@ -1,0 +1,212 @@
+"""Tests for LibraryStore CRUD, tree retrieval, edges, and chunk storage."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from openbad.library.store import LibraryStore, serialize_float32
+from openbad.state.db import initialize_state_db
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    """In-memory-like temp DB with all migrations applied."""
+    db_path = tmp_path / "test.db"
+    connection = initialize_state_db(db_path)
+    yield connection
+    connection.close()
+
+
+@pytest.fixture()
+def store(conn: sqlite3.Connection) -> LibraryStore:
+    return LibraryStore(conn)
+
+
+# ------------------------------------------------------------------
+# Library / Shelf / Section CRUD
+# ------------------------------------------------------------------
+
+
+class TestLibraryCRUD:
+    def test_create_library(self, store: LibraryStore) -> None:
+        lib_id = store.create_library("Main", "Primary library")
+        assert lib_id  # non-empty UUID
+
+    def test_create_shelf(self, store: LibraryStore) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Reference", "Ref books")
+        assert shelf_id
+
+    def test_create_section(self, store: LibraryStore) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Shelf")
+        section_id = store.create_section(shelf_id, "Chapter 1")
+        assert section_id
+
+
+# ------------------------------------------------------------------
+# Book CRUD
+# ------------------------------------------------------------------
+
+
+class TestBookCRUD:
+    def test_create_and_get_book(self, store: LibraryStore) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Shelf")
+        sec_id = store.create_section(shelf_id, "Sec")
+        book_id = store.create_book(
+            sec_id, "My Book", "Some content here.", author="user", summary="A book"
+        )
+        book = store.get_book(book_id)
+        assert book is not None
+        assert book.title == "My Book"
+        assert book.content == "Some content here."
+        assert book.author == "user"
+        assert book.summary == "A book"
+
+    def test_get_nonexistent_book(self, store: LibraryStore) -> None:
+        assert store.get_book("nonexistent") is None
+
+    def test_update_book(self, store: LibraryStore) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Shelf")
+        sec_id = store.create_section(shelf_id, "Sec")
+        book_id = store.create_book(sec_id, "Title", "Old content")
+        store.update_book(book_id, "New content", summary="Updated")
+        book = store.get_book(book_id)
+        assert book is not None
+        assert book.content == "New content"
+        assert book.summary == "Updated"
+
+    def test_create_book_stores_chunks(
+        self, store: LibraryStore, conn: sqlite3.Connection
+    ) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Shelf")
+        sec_id = store.create_section(shelf_id, "Sec")
+        book_id = store.create_book(sec_id, "Title", "Some text content")
+        rows = conn.execute(
+            "SELECT * FROM book_chunks WHERE book_id = ?", (book_id,)
+        ).fetchall()
+        assert len(rows) >= 1
+        assert rows[0]["text_content"] == "Some text content"
+
+    def test_update_book_replaces_chunks(
+        self, store: LibraryStore, conn: sqlite3.Connection
+    ) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Shelf")
+        sec_id = store.create_section(shelf_id, "Sec")
+        book_id = store.create_book(sec_id, "Title", "Original text")
+        store.update_book(book_id, "Replacement text")
+        rows = conn.execute(
+            "SELECT text_content FROM book_chunks WHERE book_id = ?", (book_id,)
+        ).fetchall()
+        assert len(rows) >= 1
+        assert rows[0]["text_content"] == "Replacement text"
+
+
+# ------------------------------------------------------------------
+# Tree
+# ------------------------------------------------------------------
+
+
+class TestGetTree:
+    def test_empty_tree(self, store: LibraryStore) -> None:
+        assert store.get_tree() == []
+
+    def test_full_tree(self, store: LibraryStore) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Shelf")
+        sec_id = store.create_section(shelf_id, "Sec")
+        store.create_book(sec_id, "Book A", "content")
+
+        tree = store.get_tree()
+        assert len(tree) == 1
+        assert tree[0]["name"] == "Lib"
+        assert len(tree[0]["shelves"]) == 1
+        assert tree[0]["shelves"][0]["name"] == "Shelf"
+        sections = tree[0]["shelves"][0]["sections"]
+        assert len(sections) == 1
+        assert sections[0]["name"] == "Sec"
+        assert len(sections[0]["books"]) == 1
+        assert sections[0]["books"][0]["title"] == "Book A"
+
+
+# ------------------------------------------------------------------
+# Edges
+# ------------------------------------------------------------------
+
+
+class TestBookEdges:
+    def test_link_books(self, store: LibraryStore) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Shelf")
+        sec_id = store.create_section(shelf_id, "Sec")
+        book_a = store.create_book(sec_id, "A", "content a")
+        book_b = store.create_book(sec_id, "B", "content b")
+        store.link_books(book_a, book_b, "references")
+
+        book = store.get_book(book_a)
+        assert book is not None
+        assert len(book.edges) == 1
+        assert book.edges[0].relation_type == "references"
+        assert book.edges[0].target_book_id == book_b
+
+    def test_duplicate_link_ignored(self, store: LibraryStore) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Shelf")
+        sec_id = store.create_section(shelf_id, "Sec")
+        book_a = store.create_book(sec_id, "A", "content a")
+        book_b = store.create_book(sec_id, "B", "content b")
+        store.link_books(book_a, book_b, "references")
+        store.link_books(book_a, book_b, "references")  # should not raise
+
+        book = store.get_book(book_a)
+        assert book is not None
+        assert len(book.edges) == 1
+
+
+# ------------------------------------------------------------------
+# Vector storage and search
+# ------------------------------------------------------------------
+
+
+class TestVectorSearch:
+    def test_store_and_search_vectors(self, store: LibraryStore) -> None:
+        lib_id = store.create_library("Lib")
+        shelf_id = store.create_shelf(lib_id, "Shelf")
+        sec_id = store.create_section(shelf_id, "Sec")
+        book_id = store.create_book(sec_id, "VecBook", "Some vector-searchable text")
+
+        # Grab the chunk IDs that were created
+        rows = store._conn.execute(
+            "SELECT chunk_id FROM book_chunks WHERE book_id = ?", (book_id,)
+        ).fetchall()
+        chunk_ids = [r["chunk_id"] for r in rows]
+        assert len(chunk_ids) >= 1
+
+        # Create a 768-dim embedding for each chunk
+        embeddings = [[0.1] * 768 for _ in chunk_ids]
+        store.store_chunk_vectors(chunk_ids, embeddings)
+
+        # Search with the same embedding — should match
+        query_emb = [0.1] * 768
+        results = store.search_chunks(query_emb, top_k=5)
+        assert len(results) >= 1
+        assert results[0].book_title == "VecBook"
+        assert results[0].book_id == book_id
+
+
+class TestSerializeFloat32:
+    def test_round_trip(self) -> None:
+        import struct
+
+        vec = [1.0, 2.0, 3.0]
+        data = serialize_float32(vec)
+        assert len(data) == 12  # 3 * 4 bytes
+        unpacked = list(struct.unpack("3f", data))
+        assert unpacked == pytest.approx(vec)


### PR DESCRIPTION
Closes #561\n\n## Summary\n\n- Add `sqlite-vec` to `pyproject.toml` dependencies\n- Load sqlite-vec extension in `initialize_state_db()`\n- Create `0006_library.sql` migration with tables: libraries, shelves, sections, books, book_edges, book_chunks, book_chunk_vectors (vec0 virtual table)\n- Create `src/openbad/library/` package with:\n  - `store.py` — `LibraryStore(conn)` with full CRUD, tree retrieval, edge linking, and vector search\n  - `embedder.py` — Recursive character text splitter (~500 tokens, 50-token overlap)\n- All IDs are UUIDs, consistent with existing store patterns\n\n## How to Test\n\n```bash\n.venv/bin/pytest tests/test_library_embedder.py tests/test_library_store.py -v\n```\n\n23 tests covering CRUD, tree, edges, chunking, vector storage/search, and boundary cases.