### PR TITLE
#562: Add embedding provider with OllamaProvider.embed() and fallback wiring

### DIFF
--- a/config/cognitive.yaml
+++ b/config/cognitive.yaml
@@ -16,6 +16,11 @@ cognitive:
     sleep:
       provider: ollama
       model: bonsai-8b
+  # Embedding configuration for Library & SemanticMemory
+  embedding:
+    provider: ollama
+    model: nomic-embed-text
+    dimensions: 768
   # Shared fallback chain used when the assigned system provider is unavailable.
   default_fallback_chain:
     - provider: ollama

--- a/src/openbad/cognitive/providers/base.py
+++ b/src/openbad/cognitive/providers/base.py
@@ -82,3 +82,9 @@ class ProviderAdapter(ABC):
     @abstractmethod
     async def health_check(self) -> HealthStatus:
         """Check provider availability."""
+
+    async def embed(
+        self, texts: list[str], model_id: str | None = None
+    ) -> list[list[float]]:
+        """Return embedding vectors for *texts*."""
+        raise NotImplementedError("Embedding not supported by this provider")

--- a/src/openbad/cognitive/providers/ollama.py
+++ b/src/openbad/cognitive/providers/ollama.py
@@ -138,6 +138,13 @@ class OllamaProvider(ProviderAdapter):
         except (aiohttp.ClientError, TimeoutError, OSError):
             return HealthStatus(provider="ollama", available=False)
 
+    async def embed(
+        self, texts: list[str], model_id: str | None = None
+    ) -> list[list[float]]:
+        model = model_id or "nomic-embed-text"
+        data = await self._post("/api/embed", {"model": model, "input": texts})
+        return data["embeddings"]
+
     # ------------------------------------------------------------------ #
     # Internals
     # ------------------------------------------------------------------ #

--- a/src/openbad/memory/controller.py
+++ b/src/openbad/memory/controller.py
@@ -6,6 +6,7 @@ STM to LTM, and exposes a unified query API across all memory tiers.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from collections.abc import Callable
@@ -16,13 +17,49 @@ from openbad.memory.base import MemoryEntry, MemoryTier
 from openbad.memory.config import MemoryConfig
 from openbad.memory.episodic import EpisodicMemory
 from openbad.memory.procedural import ProceduralMemory, Skill
-from openbad.memory.semantic import SemanticMemory
+from openbad.memory.semantic import SemanticMemory, hash_embedding
 from openbad.memory.stm import ShortTermMemory
 
 logger = logging.getLogger(__name__)
 
 # Type for an optional MQTT publish callback
 PublishFn = Callable[[str, bytes], None]
+
+
+def make_ollama_embed_fn(
+    base_url: str = "http://localhost:11434",
+    model: str = "nomic-embed-text",
+) -> Callable[[str], list[float]]:
+    """Create a sync embedding function backed by OllamaProvider.
+
+    Falls back to ``hash_embedding`` when Ollama is unreachable.
+    """
+    from openbad.cognitive.providers.ollama import OllamaProvider
+
+    provider = OllamaProvider(base_url=base_url)
+
+    def _embed(text: str) -> list[float]:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        try:
+            if loop and loop.is_running():
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    result = pool.submit(
+                        asyncio.run, provider.embed([text], model_id=model)
+                    ).result(timeout=30)
+            else:
+                result = asyncio.run(provider.embed([text], model_id=model))
+            return result[0]
+        except Exception:
+            logger.debug("Ollama embed unavailable, falling back to hash_embedding")
+            return hash_embedding(text, dim=768)
+
+    return _embed
 
 
 class MemoryController:

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -1,0 +1,87 @@
+"""Tests for embedding provider — base.embed(), OllamaProvider.embed(), fallback."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openbad.cognitive.providers.base import ProviderAdapter
+from openbad.cognitive.providers.ollama import OllamaProvider
+from openbad.memory.controller import make_ollama_embed_fn
+from openbad.memory.semantic import hash_embedding
+
+
+class TestProviderAdapterEmbed:
+    """The base class embed() should raise NotImplementedError."""
+
+    @pytest.mark.asyncio
+    async def test_embed_not_implemented(self) -> None:
+        # Create a concrete subclass with stubs for the abstract methods
+        class StubProvider(ProviderAdapter):
+            async def complete(self, prompt, model_id=None, **kw):  # type: ignore[override]
+                ...
+
+            async def stream(self, prompt, model_id=None, **kw):  # type: ignore[override]
+                yield ""
+
+            async def list_models(self):  # type: ignore[override]
+                return []
+
+            async def health_check(self):  # type: ignore[override]
+                ...
+
+        provider = StubProvider()
+        with pytest.raises(NotImplementedError, match="not supported"):
+            await provider.embed(["hello"])
+
+
+class TestOllamaProviderEmbed:
+    """OllamaProvider.embed() should call /api/embed and return embeddings."""
+
+    @pytest.mark.asyncio
+    async def test_embed_calls_api(self) -> None:
+        provider = OllamaProvider()
+        fake_response = {"embeddings": [[0.1] * 768, [0.2] * 768]}
+        with patch.object(
+            provider, "_post", new_callable=AsyncMock, return_value=fake_response
+        ) as mock_post:
+            result = await provider.embed(["hello", "world"])
+            mock_post.assert_called_once_with(
+                "/api/embed",
+                {"model": "nomic-embed-text", "input": ["hello", "world"]},
+            )
+            assert len(result) == 2
+            assert len(result[0]) == 768
+
+    @pytest.mark.asyncio
+    async def test_embed_custom_model(self) -> None:
+        provider = OllamaProvider()
+        fake_response = {"embeddings": [[0.5] * 384]}
+        with patch.object(
+            provider, "_post", new_callable=AsyncMock, return_value=fake_response
+        ) as mock_post:
+            result = await provider.embed(["test"], model_id="custom-embed")
+            mock_post.assert_called_once_with(
+                "/api/embed",
+                {"model": "custom-embed", "input": ["test"]},
+            )
+            assert len(result) == 1
+
+
+class TestMakeOllamaEmbedFn:
+    """make_ollama_embed_fn should produce a sync callable with fallback."""
+
+    def test_fallback_to_hash_embedding(self) -> None:
+        """When Ollama is unreachable, should fall back to hash_embedding."""
+        embed_fn = make_ollama_embed_fn(base_url="http://localhost:99999")
+        vec = embed_fn("hello world")
+        # Should return 768-dim hash_embedding fallback
+        assert len(vec) == 768
+        # Should match hash_embedding output
+        expected = hash_embedding("hello world", dim=768)
+        assert vec == expected
+
+    def test_returns_callable(self) -> None:
+        embed_fn = make_ollama_embed_fn()
+        assert callable(embed_fn)


### PR DESCRIPTION
Closes #562\n\n## Summary\n\n- Add `embed()` method to `ProviderAdapter` base class (raises `NotImplementedError` by default)\n- Implement `OllamaProvider.embed()` calling `POST /api/embed` with retry logic\n- Add `embedding` section to `config/cognitive.yaml` (nomic-embed-text, 768 dims)\n- Add `make_ollama_embed_fn()` factory in `controller.py` — creates a sync wrapper around async Ollama embed with `hash_embedding()` fallback when Ollama is unreachable\n- Import `hash_embedding` in controller for fallback use\n\n## How to Test\n\n```bash\n.venv/bin/pytest tests/test_embedding_provider.py -v\n```\n\n5 tests: base embed not-implemented, Ollama mock API calls, custom model, fallback behavior, callable return.