### PR TITLE
#564: Add Memory Bridge with library ref annotations and recall()

### DIFF
--- a/src/openbad/memory/base.py
+++ b/src/openbad/memory/base.py
@@ -20,7 +20,13 @@ class MemoryTier(Enum):
 
 @dataclass
 class MemoryEntry:
-    """A single entry in the memory system."""
+    """A single entry in the memory system.
+
+    **Library refs convention** — Semantic entries that reference Library
+    books should include ``metadata={"library_refs": ["book-uuid-1", ...]}``.
+    When recalled, these pointers are expanded into annotations so the LLM
+    knows exhaustive documentation is available in the Library.
+    """
 
     key: str
     value: Any

--- a/src/openbad/memory/controller.py
+++ b/src/openbad/memory/controller.py
@@ -187,6 +187,49 @@ class MemoryController:
             "procedural": self.procedural.query(prefix),
         }
 
+    def recall(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        """Recall memories ranked by relevance, with library ref annotations.
+
+        Searches semantic (scored) and episodic (recency) stores, then
+        annotates results whose ``metadata["library_refs"]`` contain book
+        IDs so the LLM knows exhaustive documentation is available.
+        """
+        results: list[dict[str, Any]] = []
+
+        # Semantic search — scored
+        try:
+            for entry, score in self.semantic.search(query, top_k=top_k):
+                item: dict[str, Any] = {
+                    "key": entry.key,
+                    "value": str(entry.value),
+                    "tier": MemoryTier.SEMANTIC.value,
+                    "score": score,
+                    "metadata": entry.metadata,
+                }
+                _annotate_library_refs(item, entry)
+                results.append(item)
+        except Exception:
+            logger.exception("Semantic recall failed")
+
+        # Episodic prefix search — unscored, ordered by recency
+        try:
+            for entry in self.episodic.query(query)[:top_k]:
+                item = {
+                    "key": entry.key,
+                    "value": str(entry.value),
+                    "tier": MemoryTier.EPISODIC.value,
+                    "score": 0.0,
+                    "metadata": entry.metadata,
+                }
+                _annotate_library_refs(item, entry)
+                results.append(item)
+        except Exception:
+            logger.exception("Episodic recall failed")
+
+        # Semantic scored results first, then episodic
+        results.sort(key=lambda r: r["score"], reverse=True)
+        return results[:top_k]
+
     # ------------------------------------------------------------------ #
     # Stats
     # ------------------------------------------------------------------ #
@@ -204,3 +247,22 @@ class MemoryController:
     def flush_stm(self) -> list[str]:
         """Flush all STM entries. Returns list of flushed keys."""
         return self.stm.flush()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _annotate_library_refs(item: dict[str, Any], entry: MemoryEntry) -> None:
+    """Append library pointer annotations when ``library_refs`` exist."""
+    refs = entry.metadata.get("library_refs")
+    if not refs:
+        return
+    annotations = []
+    for book_id in refs:
+        annotations.append(
+            f"[Knowledge Node: {entry.key}. Detail: {entry.value}.\n"
+            f" Exhaustive documentation available in Library Book ID: {book_id}]"
+        )
+    item["library_annotations"] = annotations

--- a/src/openbad/skills/memory_tool.py
+++ b/src/openbad/skills/memory_tool.py
@@ -41,45 +41,26 @@ class MemoryToolAdapter:
     def recall(self, query: str, top_k: int = 5) -> list[RecallResult]:
         """Search across episodic + semantic stores.
 
-        Returns ranked results by relevance.
+        Delegates to ``MemoryController.recall()`` which provides library
+        ref annotations.  Returns ranked results by relevance.
         """
+        raw = self._ctrl.recall(query, top_k=top_k)
         results: list[RecallResult] = []
-
-        # Semantic search (scored)
-        if self._ctrl.semantic is not None:
-            try:
-                semantic_hits = self._ctrl.semantic.search(
-                    query, top_k=top_k,
+        for item in raw:
+            value = item["value"]
+            annotations = item.get("library_annotations")
+            if annotations:
+                value = value + "\n" + "\n".join(annotations)
+            results.append(
+                RecallResult(
+                    key=item["key"],
+                    value=value,
+                    tier=item["tier"],
+                    score=item["score"],
+                    metadata=item["metadata"],
                 )
-                for entry, score in semantic_hits:
-                    results.append(RecallResult(
-                        key=entry.key,
-                        value=str(entry.value),
-                        tier=MemoryTier.SEMANTIC.value,
-                        score=score,
-                        metadata=entry.metadata,
-                    ))
-            except Exception:
-                logger.exception("Semantic recall failed")
-
-        # Episodic prefix search (unscored — use timestamp proximity)
-        if self._ctrl.episodic is not None:
-            try:
-                episodic_hits = self._ctrl.episodic.query(query)
-                for entry in episodic_hits[:top_k]:
-                    results.append(RecallResult(
-                        key=entry.key,
-                        value=str(entry.value),
-                        tier=MemoryTier.EPISODIC.value,
-                        score=0.0,
-                        metadata=entry.metadata,
-                    ))
-            except Exception:
-                logger.exception("Episodic recall failed")
-
-        # Sort by score descending (semantic results rank higher)
-        results.sort(key=lambda r: r.score, reverse=True)
-        return results[:top_k]
+            )
+        return results
 
     def store(
         self,

--- a/tests/test_memory_bridge.py
+++ b/tests/test_memory_bridge.py
@@ -1,0 +1,146 @@
+"""Tests for Memory Bridge — library ref annotation and recall()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.config import MemoryConfig
+from openbad.memory.controller import MemoryController, _annotate_library_refs
+from openbad.skills.memory_tool import MemoryToolAdapter
+
+
+@pytest.fixture()
+def mc(tmp_path: Path) -> MemoryController:
+    return MemoryController(config=MemoryConfig(ltm_storage_dir=tmp_path))
+
+
+# ------------------------------------------------------------------
+# _annotate_library_refs helper
+# ------------------------------------------------------------------
+
+
+class TestAnnotateLibraryRefs:
+    def test_no_refs_no_annotation(self) -> None:
+        entry = MemoryEntry(key="k", value="v", tier=MemoryTier.SEMANTIC)
+        item: dict = {"key": "k", "value": "v", "tier": "semantic", "score": 1.0, "metadata": {}}
+        _annotate_library_refs(item, entry)
+        assert "library_annotations" not in item
+
+    def test_empty_refs_no_annotation(self) -> None:
+        entry = MemoryEntry(
+            key="k", value="v", tier=MemoryTier.SEMANTIC, metadata={"library_refs": []}
+        )
+        item: dict = {
+            "key": "k", "value": "v", "tier": "semantic",
+            "score": 1.0, "metadata": entry.metadata,
+        }
+        _annotate_library_refs(item, entry)
+        assert "library_annotations" not in item
+
+    def test_single_ref_produces_annotation(self) -> None:
+        entry = MemoryEntry(
+            key="topic",
+            value="summary of topic",
+            tier=MemoryTier.SEMANTIC,
+            metadata={"library_refs": ["book-123"]},
+        )
+        item: dict = {
+            "key": "topic", "value": "summary of topic",
+            "tier": "semantic", "score": 0.9, "metadata": entry.metadata,
+        }
+        _annotate_library_refs(item, entry)
+        assert len(item["library_annotations"]) == 1
+        assert "book-123" in item["library_annotations"][0]
+        assert "Knowledge Node" in item["library_annotations"][0]
+
+    def test_multiple_refs(self) -> None:
+        entry = MemoryEntry(
+            key="topic",
+            value="summary",
+            tier=MemoryTier.SEMANTIC,
+            metadata={"library_refs": ["book-a", "book-b"]},
+        )
+        item: dict = {
+            "key": "topic", "value": "summary",
+            "tier": "semantic", "score": 0.9, "metadata": entry.metadata,
+        }
+        _annotate_library_refs(item, entry)
+        assert len(item["library_annotations"]) == 2
+
+
+# ------------------------------------------------------------------
+# MemoryController.recall()
+# ------------------------------------------------------------------
+
+
+class TestControllerRecall:
+    def test_recall_empty(self, mc: MemoryController) -> None:
+        results = mc.recall("anything")
+        assert results == []
+
+    def test_recall_semantic_results(self, mc: MemoryController) -> None:
+        mc.write_semantic("python-gc", "Python uses reference counting and GC")
+        results = mc.recall("python-gc")
+        assert len(results) >= 1
+        assert results[0]["key"] == "python-gc"
+        assert results[0]["tier"] == "semantic"
+
+    def test_recall_with_library_refs(self, mc: MemoryController) -> None:
+        mc.write_semantic(
+            "api-design",
+            "REST API best practices",
+            metadata={"library_refs": ["book-uuid-1"]},
+        )
+        results = mc.recall("api-design")
+        assert len(results) >= 1
+        ref_result = results[0]
+        assert "library_annotations" in ref_result
+        assert "book-uuid-1" in ref_result["library_annotations"][0]
+
+    def test_recall_without_refs_has_no_annotations(self, mc: MemoryController) -> None:
+        mc.write_semantic("plain-fact", "The sky is blue")
+        results = mc.recall("plain-fact")
+        assert len(results) >= 1
+        assert "library_annotations" not in results[0]
+
+    def test_recall_respects_top_k(self, mc: MemoryController) -> None:
+        for i in range(10):
+            mc.write_semantic(f"fact-{i}", f"Fact number {i}")
+        results = mc.recall("fact", top_k=3)
+        assert len(results) <= 3
+
+
+# ------------------------------------------------------------------
+# MemoryToolAdapter backward compatibility
+# ------------------------------------------------------------------
+
+
+class TestMemoryToolAdapterRecall:
+    def test_recall_delegates_to_controller(self, mc: MemoryController) -> None:
+        mc.write_semantic("topic-x", "Some knowledge")
+        adapter = MemoryToolAdapter(mc)
+        results = adapter.recall("topic-x")
+        assert len(results) >= 1
+        assert results[0].key == "topic-x"
+
+    def test_recall_includes_annotations_in_value(self, mc: MemoryController) -> None:
+        mc.write_semantic(
+            "topic-y",
+            "Summary of Y",
+            metadata={"library_refs": ["book-abc"]},
+        )
+        adapter = MemoryToolAdapter(mc)
+        results = adapter.recall("topic-y")
+        assert len(results) >= 1
+        assert "book-abc" in results[0].value
+        assert "Knowledge Node" in results[0].value
+
+    def test_recall_without_refs_no_extra_text(self, mc: MemoryController) -> None:
+        mc.write_semantic("topic-z", "Plain fact")
+        adapter = MemoryToolAdapter(mc)
+        results = adapter.recall("topic-z")
+        assert len(results) >= 1
+        assert results[0].value == "Plain fact"


### PR DESCRIPTION
Closes #564\n\n## Summary\n\n- Document `library_refs` metadata convention in `MemoryEntry` docstring\n- Add `recall()` method to `MemoryController` — combines semantic (scored) and episodic results with library pointer annotations\n- Add `_annotate_library_refs()` helper that expands `metadata[\"library_refs\"]` into Knowledge Node annotations\n- Update `MemoryToolAdapter.recall()` to delegate to `MemoryController.recall()`, appending library annotations to value text\n\n## How to Test\n\n```bash\n.venv/bin/pytest tests/test_memory_bridge.py -v\n```\n\n12 tests: annotation helper, controller recall with/without refs, top_k, adapter delegation, backward compat.