### PR TITLE
#563: Add FastMCP library skills — search, read, draft, link

### DIFF
--- a/src/openbad/frameworks/langchain_tools.py
+++ b/src/openbad/frameworks/langchain_tools.py
@@ -61,6 +61,9 @@ _ROLE_TOOLS: dict[str, set[str]] = {
         "web_search",
         "web_fetch",
         "ask_user",
+        "search_library",
+        "read_book",
+        "draft_book",
     },
     "research": {
         "web_search",
@@ -74,6 +77,8 @@ _ROLE_TOOLS: dict[str, set[str]] = {
         "work_on_next_research",
         "get_research_nodes",
         "read_events",
+        "search_library",
+        "read_book",
     },
     "doctor": {
         "call_doctor",
@@ -94,6 +99,10 @@ _ROLE_TOOLS: dict[str, set[str]] = {
         "write_memory",
         "prune_memory",
         "query_semantic",
+        "search_library",
+        "read_book",
+        "draft_book",
+        "link_books",
     },
     "immune": {
         "get_mqtt_records",
@@ -110,6 +119,8 @@ _ROLE_TOOLS: dict[str, set[str]] = {
         "create_research_node",
         "read_events",
         "get_endocrine_status",
+        "search_library",
+        "read_book",
     },
 }
 

--- a/src/openbad/skills/library_tool.py
+++ b/src/openbad/skills/library_tool.py
@@ -1,0 +1,151 @@
+"""Library tool — CRUD helpers for FastMCP skill registration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sqlite3
+
+from openbad.library.store import LibraryStore
+from openbad.state.db import initialize_state_db
+
+log = logging.getLogger(__name__)
+
+# Singleton database connection and store
+_conn: sqlite3.Connection | None = None
+_store: LibraryStore | None = None
+
+
+def _get_store() -> LibraryStore:
+    global _conn, _store  # noqa: PLW0603
+    if _store is None:
+        _conn = initialize_state_db()
+        _store = LibraryStore(_conn)
+    return _store
+
+
+async def _embed_and_store_vectors(
+    store: LibraryStore,
+    book_id: str,
+) -> None:
+    """Background task: embed chunks and store vectors."""
+    from openbad.memory.controller import make_ollama_embed_fn
+
+    try:
+        embed_fn = make_ollama_embed_fn()
+        rows = store._conn.execute(
+            "SELECT chunk_id, text_content FROM book_chunks WHERE book_id = ?",
+            (book_id,),
+        ).fetchall()
+        if not rows:
+            return
+        chunk_ids = [r["chunk_id"] for r in rows]
+        texts = [r["text_content"] for r in rows]
+        embeddings = [embed_fn(t) for t in texts]
+        store.store_chunk_vectors(chunk_ids, embeddings)
+        log.info("Embedded %d chunks for book %s", len(chunk_ids), book_id)
+    except Exception:
+        log.exception("Background embedding failed for book %s", book_id)
+
+
+def search_library(query: str, top_k: int = 5) -> str:
+    """Search the Library by vector similarity.
+
+    Returns top matching chunks with book title and ID.
+    Requires embeddings to be stored for the books.
+    """
+    from openbad.memory.controller import make_ollama_embed_fn
+
+    store = _get_store()
+    try:
+        embed_fn = make_ollama_embed_fn()
+        query_embedding = embed_fn(query)
+        results = store.search_chunks(query_embedding, top_k=top_k)
+    except Exception:
+        log.exception("Library search failed")
+        return "Library search failed — embeddings may not be available."
+
+    if not results:
+        return "No matching library content found."
+
+    lines = [f"Found {len(results)} matches:\n"]
+    for r in results:
+        preview = r.chunk_text[:200]
+        lines.append(
+            f"- [{r.book_title}] (book_id={r.book_id}, "
+            f"score={r.score:.4f}): {preview}"
+        )
+    return "\n".join(lines)
+
+
+def read_book(book_id: str) -> str:
+    """Read a Library book by ID.
+
+    Returns the full content, summary, author, and edges.
+    """
+    store = _get_store()
+    book = store.get_book(book_id)
+    if book is None:
+        return f"Book not found: {book_id}"
+
+    edges_text = ""
+    if book.edges:
+        edge_lines = [
+            f"  - {e.relation_type}: {e.target_book_id}"
+            for e in book.edges
+        ]
+        edges_text = "\nEdges:\n" + "\n".join(edge_lines)
+
+    return (
+        f"Title: {book.title}\n"
+        f"Author: {book.author}\n"
+        f"Summary: {book.summary}\n"
+        f"Content:\n{book.content}"
+        f"{edges_text}"
+    )
+
+
+def draft_book(section_id: str, title: str, content: str) -> str:
+    """Create a new book in the Library.
+
+    Auto-chunks the content synchronously and enqueues background
+    embedding so the cognitive router is not blocked.
+    """
+    store = _get_store()
+    book_id = store.create_book(section_id, title, content, author="system")
+
+    # Enqueue background embedding
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_embed_and_store_vectors(store, book_id))
+    except RuntimeError:
+        log.debug("No running loop — skipping background embedding")
+
+    return json.dumps({"book_id": book_id, "title": title, "status": "created"})
+
+
+_VALID_RELATIONS = {"supersedes", "relies_on", "contradicts", "references"}
+
+
+def link_books(
+    source_id: str, target_id: str, relation_type: str
+) -> str:
+    """Create a citation edge between two books.
+
+    relation_type must be one of: supersedes, relies_on, contradicts,
+    references.
+    """
+    if relation_type not in _VALID_RELATIONS:
+        return (
+            f"Invalid relation_type: {relation_type!r}. "
+            f"Must be one of: {', '.join(sorted(_VALID_RELATIONS))}"
+        )
+    store = _get_store()
+    store.link_books(source_id, target_id, relation_type)
+    return json.dumps({
+        "source_id": source_id,
+        "target_id": target_id,
+        "relation_type": relation_type,
+        "status": "linked",
+    })

--- a/src/openbad/skills/server.py
+++ b/src/openbad/skills/server.py
@@ -839,6 +839,53 @@ def query_semantic(query: str, top_k: int = 5) -> str:
     return "\n".join(lines)
 
 
+# ── Library skills ───────────────────────────────────────────────────── #
+
+
+@skill_server.tool()
+def search_library(query: str, top_k: int = 5) -> str:
+    """Search the Library for relevant content by semantic similarity.
+
+    Returns the top matching text chunks with book title and ID.
+    """
+    from openbad.skills.library_tool import search_library as _search
+
+    return _search(query, top_k=top_k)
+
+
+@skill_server.tool()
+def read_book(book_id: str) -> str:
+    """Read a Library book — returns full content, summary, and edges."""
+    from openbad.skills.library_tool import read_book as _read
+
+    return _read(book_id)
+
+
+@skill_server.tool()
+def draft_book(section_id: str, title: str, content: str) -> str:
+    """Create a new book in the Library.
+
+    Auto-chunks the content and enqueues background embedding.
+    """
+    from openbad.skills.library_tool import draft_book as _draft
+
+    return _draft(section_id, title, content)
+
+
+@skill_server.tool()
+def link_books(
+    source_id: str, target_id: str, relation_type: str
+) -> str:
+    """Create a citation edge between two Library books.
+
+    relation_type must be one of: supersedes, relies_on, contradicts,
+    references.
+    """
+    from openbad.skills.library_tool import link_books as _link
+
+    return _link(source_id, target_id, relation_type)
+
+
 # ── Public API for the agentic loop ──────────────────────────────────── #
 
 

--- a/tests/test_library_tool.py
+++ b/tests/test_library_tool.py
@@ -1,0 +1,137 @@
+"""Tests for library tool skill functions."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from openbad.library.store import LibraryStore
+from openbad.skills import library_tool
+from openbad.state.db import initialize_state_db
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    db_path = tmp_path / "test.db"
+    connection = initialize_state_db(db_path)
+    yield connection
+    connection.close()
+
+
+@pytest.fixture()
+def store(conn: sqlite3.Connection) -> LibraryStore:
+    return LibraryStore(conn)
+
+
+@pytest.fixture(autouse=True)
+def _patch_store(store: LibraryStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inject test store into the library_tool module."""
+    monkeypatch.setattr(library_tool, "_store", store)
+    monkeypatch.setattr(library_tool, "_conn", store._conn)
+
+
+def _scaffold(store: LibraryStore) -> tuple[str, str, str]:
+    """Create library → shelf → section and return (lib_id, shelf_id, sec_id)."""
+    lib_id = store.create_library("TestLib")
+    shelf_id = store.create_shelf(lib_id, "TestShelf")
+    sec_id = store.create_section(shelf_id, "TestSection")
+    return lib_id, shelf_id, sec_id
+
+
+class TestReadBook:
+    def test_read_existing_book(self, store: LibraryStore) -> None:
+        _, _, sec_id = _scaffold(store)
+        book_id = store.create_book(sec_id, "My Book", "Book content here")
+        result = library_tool.read_book(book_id)
+        assert "My Book" in result
+        assert "Book content here" in result
+
+    def test_read_nonexistent_book(self) -> None:
+        result = library_tool.read_book("nonexistent-id")
+        assert "not found" in result.lower()
+
+    def test_read_book_with_edges(self, store: LibraryStore) -> None:
+        _, _, sec_id = _scaffold(store)
+        book_a = store.create_book(sec_id, "A", "Content A")
+        book_b = store.create_book(sec_id, "B", "Content B")
+        store.link_books(book_a, book_b, "references")
+        result = library_tool.read_book(book_a)
+        assert "references" in result
+        assert book_b in result
+
+
+class TestDraftBook:
+    def test_draft_creates_book(self, store: LibraryStore) -> None:
+        _, _, sec_id = _scaffold(store)
+        result = library_tool.draft_book(sec_id, "New Book", "Some content")
+        data = json.loads(result)
+        assert data["status"] == "created"
+        assert data["title"] == "New Book"
+        assert data["book_id"]
+
+        # Verify book exists in store
+        book = store.get_book(data["book_id"])
+        assert book is not None
+        assert book.content == "Some content"
+        assert book.author == "system"
+
+
+class TestLinkBooks:
+    def test_valid_relation(self, store: LibraryStore) -> None:
+        _, _, sec_id = _scaffold(store)
+        a = store.create_book(sec_id, "A", "a")
+        b = store.create_book(sec_id, "B", "b")
+        result = library_tool.link_books(a, b, "supersedes")
+        data = json.loads(result)
+        assert data["status"] == "linked"
+        assert data["relation_type"] == "supersedes"
+
+    def test_invalid_relation(self, store: LibraryStore) -> None:
+        _, _, sec_id = _scaffold(store)
+        a = store.create_book(sec_id, "A", "a")
+        b = store.create_book(sec_id, "B", "b")
+        result = library_tool.link_books(a, b, "invalid_type")
+        assert "Invalid" in result
+
+    def test_all_valid_relations(self, store: LibraryStore) -> None:
+        _, _, sec_id = _scaffold(store)
+        for rel in ("supersedes", "relies_on", "contradicts", "references"):
+            a = store.create_book(sec_id, f"A-{rel}", "a")
+            b = store.create_book(sec_id, f"B-{rel}", "b")
+            result = library_tool.link_books(a, b, rel)
+            data = json.loads(result)
+            assert data["status"] == "linked"
+
+
+class TestSearchLibrary:
+    def test_search_no_embeddings_returns_message(
+        self, store: LibraryStore
+    ) -> None:
+        # Without embeddings stored, search should return a "no matches" message
+        result = library_tool.search_library("test query")
+        assert "no matching" in result.lower() or "failed" in result.lower()
+
+    def test_search_with_embeddings(self, store: LibraryStore) -> None:
+        _, _, sec_id = _scaffold(store)
+        book_id = store.create_book(sec_id, "Embedded Book", "Content to search")
+
+        # Store vectors manually
+        rows = store._conn.execute(
+            "SELECT chunk_id FROM book_chunks WHERE book_id = ?", (book_id,)
+        ).fetchall()
+        chunk_ids = [r["chunk_id"] for r in rows]
+        embeddings = [[0.1] * 768 for _ in chunk_ids]
+        store.store_chunk_vectors(chunk_ids, embeddings)
+
+        # Monkey-patch embed_fn to return matching vector
+        from unittest.mock import patch
+
+        with patch(
+            "openbad.memory.controller.make_ollama_embed_fn",
+            return_value=lambda text: [0.1] * 768,
+        ):
+            result = library_tool.search_library("content")
+            assert "Embedded Book" in result


### PR DESCRIPTION
Closes #563\n\n## Summary\n\n- Create `src/openbad/skills/library_tool.py` with 4 library functions: `search_library`, `read_book`, `draft_book`, `link_books`\n- Register all 4 as `@skill_server.tool()` in `server.py`\n- `draft_book` writes synchronously and enqueues background embedding via `asyncio.create_task()`\n- `link_books` validates relation_type against allowed set\n- Add library tools to agent roles in `langchain_tools.py`:\n  - research: search_library, read_book\n  - task: search_library, read_book, draft_book\n  - sleep: search_library, read_book, draft_book, link_books\n  - explorer: search_library, read_book\n\n## How to Test\n\n```bash\n.venv/bin/pytest tests/test_library_tool.py -v\n```\n\n9 tests: read existing/nonexistent/with-edges, draft, all relation types, invalid relation, search with/without embeddings.