### PR TITLE
#565: Autonomic reconciliation — surprise-triggered book updates

### DIFF
--- a/src/openbad/active_inference/engine.py
+++ b/src/openbad/active_inference/engine.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 from dataclasses import dataclass, field
+from typing import Any
 
 from openbad.active_inference.budget import ExplorationBudget
 from openbad.active_inference.config import ActiveInferenceConfig
@@ -35,6 +36,9 @@ class ExplorationEngine:
         world_model: WorldModel,
         budget: ExplorationBudget,
         plugins: list[ObservationPlugin] | None = None,
+        *,
+        memory_controller: Any | None = None,
+        task_store: Any | None = None,
     ) -> None:
         self._config = config
         self._world_model = world_model
@@ -42,6 +46,8 @@ class ExplorationEngine:
         self._plugins: list[ObservationPlugin] = plugins or []
         self._suppressed_states: set[str] = set(config.suppressed_in_states)
         self._current_state: str = "NOMINAL"
+        self._memory_controller = memory_controller
+        self._task_store = task_store
 
     # -- Plugin management ------------------------------------------------- #
 
@@ -80,6 +86,7 @@ class ExplorationEngine:
         ):
             self._budget.spend()
             explored = True
+            self._check_reconciliation(plugin.source_id, surprise)
 
         return ExplorationEvent(
             source_id=plugin.source_id,
@@ -87,6 +94,34 @@ class ExplorationEngine:
             explored=explored,
             errors=errors,
         )
+
+    def _check_reconciliation(self, source_id: str, surprise: float) -> None:
+        """Check if high surprise warrants library reconciliation."""
+        if self._memory_controller is None or self._task_store is None:
+            return
+
+        from openbad.active_inference.reconciliation import (
+            check_library_reconciliation,
+            create_reconciliation_task,
+        )
+
+        try:
+            entries = self._memory_controller.semantic.query(source_id)
+            for entry in entries:
+                book_ids = check_library_reconciliation(entry, surprise)
+                for book_id in book_ids:
+                    create_reconciliation_task(
+                        self._task_store,
+                        book_id,
+                        new_fact=str(entry.value),
+                        reason=f"surprise={surprise:.2f} on {source_id}",
+                    )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Reconciliation check failed for %s",
+                source_id,
+                exc_info=True,
+            )
 
     async def run_cycle(self) -> list[ExplorationEvent]:
         """Run one pass over all registered plugins (sequentially)."""

--- a/src/openbad/active_inference/reconciliation.py
+++ b/src/openbad/active_inference/reconciliation.py
@@ -1,0 +1,88 @@
+"""Library reconciliation — surprise-triggered book updates.
+
+When the Active Inference engine detects high surprise on a semantic entry
+that contains ``library_refs``, a reconciliation task is created so the
+scheduler can update the referenced Library book with new information.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from openbad.memory.base import MemoryEntry
+from openbad.tasks.models import TaskKind, TaskModel, TaskPriority
+
+logger = logging.getLogger(__name__)
+
+#: Surprise threshold above which reconciliation is triggered.
+RECONCILIATION_SURPRISE_THRESHOLD = 0.7
+
+
+def check_library_reconciliation(
+    semantic_entry: MemoryEntry,
+    surprise_score: float,
+) -> list[str]:
+    """Check if *semantic_entry* needs library reconciliation.
+
+    Returns the list of book IDs that need reconciliation, or an empty
+    list if no action is needed.
+    """
+    if surprise_score < RECONCILIATION_SURPRISE_THRESHOLD:
+        return []
+    refs = semantic_entry.metadata.get("library_refs", [])
+    if not refs:
+        return []
+    logger.info(
+        "Reconciliation triggered for %s (surprise=%.2f, refs=%s)",
+        semantic_entry.key,
+        surprise_score,
+        refs,
+    )
+    return list(refs)
+
+
+def create_reconciliation_task(
+    task_store: Any,
+    book_id: str,
+    new_fact: str,
+    reason: str = "",
+) -> str:
+    """Create a system task to reconcile a Library book with a new fact.
+
+    Returns the created task_id.
+    """
+    task = TaskModel.new(
+        title=f"Library Reconciliation: {book_id[:8]}",
+        description=(
+            f"Reconcile Library book {book_id} with new information.\n\n"
+            f"New fact: {new_fact}\n"
+            f"Reason: {reason}\n\n"
+            f"[reconcile] book_id={book_id}"
+        ),
+        kind=TaskKind.SYSTEM,
+        priority=TaskPriority.NORMAL,
+    )
+    task_id = task.task_id
+    task_store.create_task(task)
+    logger.info("Created reconciliation task %s for book %s", task_id, book_id)
+    return task_id
+
+
+def is_reconcile_task(task: TaskModel) -> bool:
+    """Return True if *task* is a library reconciliation task."""
+    return task.title.startswith("Library Reconciliation:")
+
+
+def parse_reconcile_metadata(task: TaskModel) -> dict[str, str]:
+    """Extract book_id and new_fact from a reconciliation task description."""
+    desc = task.description or ""
+    result: dict[str, str] = {}
+
+    for line in desc.split("\n"):
+        if line.startswith("New fact: "):
+            result["new_fact"] = line[len("New fact: "):]
+        if "[reconcile] book_id=" in line:
+            result["book_id"] = line.split("book_id=", 1)[1].strip()
+
+    return result

--- a/src/openbad/autonomy/scheduler_worker.py
+++ b/src/openbad/autonomy/scheduler_worker.py
@@ -684,8 +684,107 @@ def _process_autonomy_work(
                 extra_metadata={"doctor_revelation": True, "health_decision": True},
             )
 
+    def _process_reconcile_task(task_to_run: TaskModel) -> None:
+        """Handle a Library Reconciliation task."""
+        from openbad.active_inference.reconciliation import parse_reconcile_metadata
+
+        meta = parse_reconcile_metadata(task_to_run)
+        book_id = meta.get("book_id", "")
+        new_fact = meta.get("new_fact", "")
+        if not book_id:
+            task_store.update_task_status(task_to_run.task_id, TaskStatus.FAILED)
+            task_store.append_event(
+                task_to_run.task_id,
+                "reconcile_failed",
+                payload={"reason": "missing_book_id"},
+            )
+            return
+
+        task_store.update_task_status(task_to_run.task_id, TaskStatus.RUNNING)
+
+        try:
+            from openbad.library.store import LibraryStore
+
+            lib_store = LibraryStore(conn)
+            book = lib_store.get_book(book_id)
+            if book is None:
+                task_store.update_task_status(task_to_run.task_id, TaskStatus.FAILED)
+                task_store.append_event(
+                    task_to_run.task_id,
+                    "reconcile_failed",
+                    payload={"reason": "book_not_found", "book_id": book_id},
+                )
+                return
+
+            llm = _run_llm(
+                system_prompt=(
+                    "You are rewriting a Library book section to incorporate new information. "
+                    "Preserve existing accurate content. Only update or extend what the new "
+                    "fact changes. Return ONLY the updated book content, no commentary."
+                ),
+                user_prompt=(
+                    f"Current book content:\n{book.content}\n\n"
+                    f"New fact to incorporate:\n{new_fact}"
+                ),
+                system_name="tasks",
+                session_id=task_session_id,
+                request_id=task_to_run.task_id,
+                tools_role="sleep",
+            )
+            if llm is None:
+                task_store.update_task_status(task_to_run.task_id, TaskStatus.FAILED)
+                task_store.append_event(
+                    task_to_run.task_id,
+                    "reconcile_failed",
+                    payload={"reason": "provider_unavailable"},
+                )
+                return
+
+            updated_content, provider_name, model_id, _tools = llm
+            updated_content = _strip_autonomy_interaction(updated_content)
+            lib_store.update_book(book_id, updated_content, summary=book.summary)
+
+            task_store.update_task_status(task_to_run.task_id, TaskStatus.DONE)
+            task_store.append_event(
+                task_to_run.task_id,
+                "reconcile_completed",
+                payload={
+                    "book_id": book_id,
+                    "provider": provider_name,
+                    "model": model_id,
+                },
+            )
+            _apply_reward(
+                outcome=TraceOutcome.SUCCESS,
+                node_id=task_to_run.task_id,
+                task_id=task_to_run.task_id,
+                source="tasks",
+                reason=f"Library reconciliation completed for book {book_id}",
+                context={"system": "tasks", "reconcile": True},
+            )
+        except Exception:
+            log.exception("Reconcile task failed for %s", book_id)
+            task_store.update_task_status(task_to_run.task_id, TaskStatus.FAILED)
+            task_store.append_event(
+                task_to_run.task_id,
+                "reconcile_failed",
+                payload={"reason": "exception", "book_id": book_id},
+            )
+
     def _process_task(task_to_run: TaskModel) -> None:
         nonlocal executed_task_id
+
+        # Handle library reconciliation tasks
+        from openbad.active_inference.reconciliation import (
+            is_reconcile_task,
+            parse_reconcile_metadata,
+        )
+
+        if is_reconcile_task(task_to_run):
+            _process_reconcile_task(task_to_run)
+            executed_task_id = task_to_run.task_id
+            return
+
         combined = f"{task_to_run.title}\n\n{task_to_run.description}".strip()
         allow_destructive = session_allows(policy, "tasks", "allow_destructive", False)
         if is_destructive_request(combined) and not allow_destructive:

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -1,0 +1,216 @@
+"""Tests for library reconciliation — surprise-triggered book updates."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from openbad.active_inference.reconciliation import (
+    RECONCILIATION_SURPRISE_THRESHOLD,
+    check_library_reconciliation,
+    create_reconciliation_task,
+    is_reconcile_task,
+    parse_reconcile_metadata,
+)
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.tasks.models import TaskKind, TaskModel, TaskPriority, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _entry(
+    key: str = "test-key",
+    value: str = "test",
+    library_refs: list[str] | None = None,
+) -> MemoryEntry:
+    metadata: dict[str, Any] = {}
+    if library_refs is not None:
+        metadata["library_refs"] = library_refs
+    return MemoryEntry(key=key, value=value, tier=MemoryTier.SEMANTIC, metadata=metadata)
+
+
+class FakeTaskStore:
+    """Minimal task store recording create_task calls."""
+
+    def __init__(self) -> None:
+        self.tasks: list[TaskModel] = []
+
+    def create_task(self, task: TaskModel) -> None:
+        self.tasks.append(task)
+
+
+# ---------------------------------------------------------------------------
+# check_library_reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestCheckLibraryReconciliation:
+    def test_below_threshold_returns_empty(self) -> None:
+        entry = _entry(library_refs=["book-1"])
+        assert check_library_reconciliation(entry, RECONCILIATION_SURPRISE_THRESHOLD - 0.01) == []
+
+    def test_no_library_refs_returns_empty(self) -> None:
+        entry = _entry()
+        assert check_library_reconciliation(entry, 0.9) == []
+
+    def test_empty_library_refs_returns_empty(self) -> None:
+        entry = _entry(library_refs=[])
+        assert check_library_reconciliation(entry, 0.9) == []
+
+    def test_above_threshold_with_refs_returns_book_ids(self) -> None:
+        entry = _entry(library_refs=["book-1", "book-2"])
+        result = check_library_reconciliation(entry, RECONCILIATION_SURPRISE_THRESHOLD + 0.01)
+        assert result == ["book-1", "book-2"]
+
+    def test_exact_threshold_triggers(self) -> None:
+        entry = _entry(library_refs=["book-1"])
+        result = check_library_reconciliation(entry, RECONCILIATION_SURPRISE_THRESHOLD)
+        assert result == ["book-1"]
+
+
+# ---------------------------------------------------------------------------
+# create_reconciliation_task
+# ---------------------------------------------------------------------------
+
+
+class TestCreateReconciliationTask:
+    def test_creates_system_task(self) -> None:
+        store = FakeTaskStore()
+        task_id = create_reconciliation_task(
+            store,
+            book_id="abc-123",
+            new_fact="The sky is blue",
+            reason="surprise=0.85",
+        )
+        assert len(store.tasks) == 1
+        task = store.tasks[0]
+        assert task.task_id == task_id
+        assert task.title.startswith("Library Reconciliation:")
+        assert task.kind == TaskKind.SYSTEM
+        assert task.priority == int(TaskPriority.NORMAL)
+        assert task.status == TaskStatus.PENDING
+        assert "abc-123" in task.description
+        assert "The sky is blue" in task.description
+        assert "[reconcile] book_id=abc-123" in task.description
+
+
+# ---------------------------------------------------------------------------
+# is_reconcile_task
+# ---------------------------------------------------------------------------
+
+
+class TestIsReconcileTask:
+    def test_positive(self) -> None:
+        task = TaskModel.new(
+            "Library Reconciliation: abc12345",
+            kind=TaskKind.SYSTEM,
+        )
+        assert is_reconcile_task(task) is True
+
+    def test_negative(self) -> None:
+        task = TaskModel.new("Regular task")
+        assert is_reconcile_task(task) is False
+
+
+# ---------------------------------------------------------------------------
+# parse_reconcile_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestParseReconcileMetadata:
+    def test_extracts_book_id_and_fact(self) -> None:
+        task = TaskModel.new(
+            "Library Reconciliation: abc12345",
+            description=(
+                "Reconcile Library book abc-full-id with new information.\n\n"
+                "New fact: Water is wet\n"
+                "Reason: surprise=0.85\n\n"
+                "[reconcile] book_id=abc-full-id"
+            ),
+            kind=TaskKind.SYSTEM,
+        )
+        meta = parse_reconcile_metadata(task)
+        assert meta["book_id"] == "abc-full-id"
+        assert meta["new_fact"] == "Water is wet"
+
+    def test_missing_fields_returns_partial(self) -> None:
+        task = TaskModel.new(
+            "Library Reconciliation: x",
+            description="No structured content here",
+            kind=TaskKind.SYSTEM,
+        )
+        meta = parse_reconcile_metadata(task)
+        assert "book_id" not in meta
+        assert "new_fact" not in meta
+
+
+# ---------------------------------------------------------------------------
+# Engine integration — _check_reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestEngineCheckReconciliation:
+    def test_poll_plugin_triggers_reconciliation(self) -> None:
+        from openbad.active_inference.budget import ExplorationBudget
+        from openbad.active_inference.config import ActiveInferenceConfig
+        from openbad.active_inference.engine import ExplorationEngine
+        from openbad.active_inference.world_model import WorldModel
+
+        config = ActiveInferenceConfig(surprise_threshold=0.5)
+        wm = WorldModel()
+        budget = ExplorationBudget()
+
+        mem_ctrl = MagicMock()
+        entry = _entry(library_refs=["book-1"])
+        mem_ctrl.semantic.query.return_value = [entry]
+
+        task_store = FakeTaskStore()
+
+        engine = ExplorationEngine(
+            config, wm, budget,
+            memory_controller=mem_ctrl,
+            task_store=task_store,
+        )
+
+        # Simulate high surprise by calling _check_reconciliation directly
+        engine._check_reconciliation("source-1", 0.85)
+
+        assert len(task_store.tasks) == 1
+        assert task_store.tasks[0].title.startswith("Library Reconciliation:")
+
+    def test_no_reconciliation_when_no_controller(self) -> None:
+        from openbad.active_inference.budget import ExplorationBudget
+        from openbad.active_inference.config import ActiveInferenceConfig
+        from openbad.active_inference.engine import ExplorationEngine
+        from openbad.active_inference.world_model import WorldModel
+
+        config = ActiveInferenceConfig(surprise_threshold=0.5)
+        wm = WorldModel()
+        budget = ExplorationBudget()
+
+        engine = ExplorationEngine(config, wm, budget)
+        # Should not raise
+        engine._check_reconciliation("source-1", 0.85)
+
+    def test_reconciliation_error_logged_not_raised(self) -> None:
+        from openbad.active_inference.budget import ExplorationBudget
+        from openbad.active_inference.config import ActiveInferenceConfig
+        from openbad.active_inference.engine import ExplorationEngine
+        from openbad.active_inference.world_model import WorldModel
+
+        config = ActiveInferenceConfig(surprise_threshold=0.5)
+        wm = WorldModel()
+        budget = ExplorationBudget()
+
+        mem_ctrl = MagicMock()
+        mem_ctrl.semantic.query.side_effect = RuntimeError("DB error")
+
+        engine = ExplorationEngine(
+            config, wm, budget,
+            memory_controller=mem_ctrl,
+            task_store=MagicMock(),
+        )
+        # Should not raise
+        engine._check_reconciliation("source-1", 0.85)


### PR DESCRIPTION
Closes #565

## Summary of Changes

- **`src/openbad/active_inference/reconciliation.py`** (new): Core reconciliation module with:
  - `check_library_reconciliation()` — checks if a semantic entry with `library_refs` exceeds the surprise threshold (0.7)
  - `create_reconciliation_task()` — creates a `TaskKind.SYSTEM` task with structured description containing book_id and new_fact
  - `is_reconcile_task()` / `parse_reconcile_metadata()` — helpers to detect and parse reconciliation tasks

- **`src/openbad/active_inference/engine.py`**: Added `_check_reconciliation()` method to `ExplorationEngine`, called after high-surprise exploration triggers. Engine now accepts optional `memory_controller` and `task_store` kwargs.

- **`src/openbad/autonomy/scheduler_worker.py`**: Added `_process_reconcile_task()` function that:
  - Detects reconciliation tasks via `is_reconcile_task()`
  - Loads the Library book, sends current content + new fact to LLM
  - Updates the book with reconciled content
  - Applies reward trace on success

- **`tests/test_reconciliation.py`**: 13 unit tests covering threshold checks, task creation, parsing, engine integration, and error handling.

## How to Test

```bash
.venv/bin/pytest tests/test_reconciliation.py -v
```