### PR TITLE
Add Memory Inspector UI — tabbed dashboard with recall testing

### DIFF
--- a/src/openbad/wui/memory_api.py
+++ b/src/openbad/wui/memory_api.py
@@ -1,0 +1,189 @@
+"""Memory Inspector API endpoints.
+
+Registers the following routes on a supplied :class:`aiohttp.web.Application`:
+
+- ``GET  /api/memory/stats``         — tier counts + STM token usage
+- ``GET  /api/memory/stm``           — list all STM entries
+- ``GET  /api/memory/episodic``      — list recent episodic entries
+- ``GET  /api/memory/semantic``      — list all semantic entries
+- ``GET  /api/memory/procedural``    — list all procedural entries (with skills)
+- ``GET  /api/memory/entry/{key}``   — read a single entry from any tier
+- ``POST /api/memory/recall``        — run a recall query (semantic + episodic)
+
+Call :func:`setup_memory_routes` to register all routes.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from aiohttp import web
+
+from openbad.memory.controller import MemoryController
+
+_KEY_CTRL = "memory_api_controller"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entry_to_dict(entry: Any) -> dict[str, Any]:
+    """Serialise a MemoryEntry for JSON response."""
+    return {
+        "key": entry.key,
+        "value": str(entry.value),
+        "tier": entry.tier.value,
+        "entry_id": entry.entry_id,
+        "created_at": entry.created_at,
+        "accessed_at": entry.accessed_at,
+        "access_count": entry.access_count,
+        "ttl_seconds": entry.ttl_seconds,
+        "context": entry.context,
+        "metadata": entry.metadata,
+    }
+
+
+def _skill_to_dict(skill: Any) -> dict[str, Any]:
+    """Serialise a Skill for JSON response."""
+    return skill.to_dict() if hasattr(skill, "to_dict") else {"raw": str(skill)}
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def _get_stats(request: web.Request) -> web.Response:
+    ctrl: MemoryController = request.app[_KEY_CTRL]
+    return web.json_response(ctrl.stats())
+
+
+async def _get_stm(request: web.Request) -> web.Response:
+    ctrl: MemoryController = request.app[_KEY_CTRL]
+    keys = ctrl.stm.list_keys()
+    entries = []
+    now = time.time()
+    for key in keys:
+        entry = ctrl.stm.read(key)
+        if entry is not None:
+            d = _entry_to_dict(entry)
+            # Add computed fields useful for the UI
+            d["age_seconds"] = now - entry.created_at if entry.created_at else 0
+            ttl = entry.ttl_seconds
+            if ttl and ttl > 0 and entry.created_at:
+                d["ttl_remaining"] = max(
+                    0, ttl - (now - entry.created_at)
+                )
+            else:
+                d["ttl_remaining"] = None
+            entries.append(d)
+    usage = ctrl.stm.usage()
+    return web.json_response({"entries": entries, "usage": usage})
+
+
+async def _get_episodic(request: web.Request) -> web.Response:
+    ctrl: MemoryController = request.app[_KEY_CTRL]
+    limit_str = request.rel_url.query.get("limit", "50")
+    try:
+        limit = int(limit_str)
+    except (TypeError, ValueError):
+        limit = 50
+    entries = ctrl.episodic.recent(n=limit)
+    return web.json_response({
+        "entries": [_entry_to_dict(e) for e in reversed(entries)],
+        "total": ctrl.episodic.size(),
+    })
+
+
+async def _get_semantic(request: web.Request) -> web.Response:
+    ctrl: MemoryController = request.app[_KEY_CTRL]
+    keys = ctrl.semantic.list_keys()
+    entries = []
+    for key in keys:
+        entry = ctrl.semantic.read(key)
+        if entry is not None:
+            d = _entry_to_dict(entry)
+            d["has_vector"] = ctrl.semantic.get_vector(key) is not None
+            entries.append(d)
+    return web.json_response({
+        "entries": entries,
+        "total": ctrl.semantic.size(),
+    })
+
+
+async def _get_procedural(request: web.Request) -> web.Response:
+    ctrl: MemoryController = request.app[_KEY_CTRL]
+    keys = ctrl.procedural.list_keys()
+    entries = []
+    for key in keys:
+        entry = ctrl.procedural.read(key)
+        if entry is not None:
+            d = _entry_to_dict(entry)
+            skill = ctrl.procedural.get_skill(key)
+            d["skill"] = _skill_to_dict(skill) if skill else None
+            entries.append(d)
+    return web.json_response({
+        "entries": entries,
+        "total": ctrl.procedural.size(),
+    })
+
+
+async def _get_entry(request: web.Request) -> web.Response:
+    ctrl: MemoryController = request.app[_KEY_CTRL]
+    key = request.match_info["key"]
+    entry = ctrl.read(key)
+    if entry is None:
+        raise web.HTTPNotFound(text=f"memory entry {key!r} not found")
+    return web.json_response(_entry_to_dict(entry))
+
+
+async def _post_recall(request: web.Request) -> web.Response:
+    ctrl: MemoryController = request.app[_KEY_CTRL]
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise web.HTTPBadRequest(text="request body must be an object")
+
+    query = str(body.get("query", "")).strip()
+    if not query:
+        raise web.HTTPBadRequest(text="query is required")
+
+    top_k = body.get("top_k", 10)
+    try:
+        top_k = int(top_k)
+    except (TypeError, ValueError) as exc:
+        raise web.HTTPBadRequest(text="top_k must be an integer") from exc
+
+    results = ctrl.recall(query, top_k=top_k)
+    return web.json_response({"results": results})
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def setup_memory_routes(
+    app: web.Application,
+    controller: MemoryController,
+) -> None:
+    """Register Memory Inspector API routes on *app*.
+
+    Parameters
+    ----------
+    app:
+        The :class:`aiohttp.web.Application` to register routes on.
+    controller:
+        A fully-initialised :class:`MemoryController` instance.
+    """
+    app[_KEY_CTRL] = controller
+
+    app.router.add_get("/api/memory/stats", _get_stats)
+    app.router.add_get("/api/memory/stm", _get_stm)
+    app.router.add_get("/api/memory/episodic", _get_episodic)
+    app.router.add_get("/api/memory/semantic", _get_semantic)
+    app.router.add_get("/api/memory/procedural", _get_procedural)
+    app.router.add_get("/api/memory/entry/{key}", _get_entry)
+    app.router.add_post("/api/memory/recall", _post_recall)

--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -3593,6 +3593,13 @@ def create_app(
 
     app.on_cleanup.append(_close_library_conn)
 
+    # Memory Inspector API
+    from openbad.memory.controller import MemoryController  # noqa: PLC0415
+    from openbad.wui.memory_api import setup_memory_routes  # noqa: PLC0415
+
+    _mem_ctrl = MemoryController()
+    setup_memory_routes(app, _mem_ctrl)
+
     # SvelteKit static assets + SPA fallback for client-side routing
     _app_dir = BUILD_DIR / "_app"
     if _app_dir.is_dir():

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -1,0 +1,242 @@
+"""Tests for Memory Inspector API endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient
+
+from openbad.memory.config import MemoryConfig
+from openbad.memory.controller import MemoryController
+from openbad.wui.memory_api import setup_memory_routes
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def ctrl(tmp_path) -> MemoryController:
+    cfg = MemoryConfig(ltm_storage_dir=tmp_path)
+    return MemoryController(config=cfg)
+
+
+@pytest.fixture()
+def app(ctrl: MemoryController) -> web.Application:
+    a = web.Application()
+    setup_memory_routes(a, ctrl)
+    return a
+
+
+@pytest.fixture()
+async def client(app, aiohttp_client) -> TestClient:
+    return await aiohttp_client(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory/stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stats_empty(client: TestClient) -> None:
+    resp = await client.get("/api/memory/stats")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "stm" in data
+    assert "episodic" in data
+    assert "semantic" in data
+    assert "procedural" in data
+    assert data["stm"]["entry_count"] == 0
+    assert data["episodic"]["entry_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stats_with_entries(
+    client: TestClient, ctrl: MemoryController,
+) -> None:
+    ctrl.write_stm("s1", "hello")
+    ctrl.write_episodic("e1", "event")
+    resp = await client.get("/api/memory/stats")
+    data = await resp.json()
+    assert data["stm"]["entry_count"] == 1
+    assert data["episodic"]["entry_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory/stm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stm_empty(client: TestClient) -> None:
+    resp = await client.get("/api/memory/stm")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["entries"] == []
+    assert data["usage"]["entry_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stm_with_entries(
+    client: TestClient, ctrl: MemoryController,
+) -> None:
+    ctrl.write_stm("key1", "value1")
+    ctrl.write_stm("key2", "value2")
+    resp = await client.get("/api/memory/stm")
+    data = await resp.json()
+    assert len(data["entries"]) == 2
+    keys = {e["key"] for e in data["entries"]}
+    assert keys == {"key1", "key2"}
+    # Check computed fields
+    for entry in data["entries"]:
+        assert "age_seconds" in entry
+        assert "ttl_remaining" in entry
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory/episodic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_episodic_empty(client: TestClient) -> None:
+    resp = await client.get("/api/memory/episodic")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["entries"] == []
+    assert data["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_episodic_with_entries(
+    client: TestClient, ctrl: MemoryController,
+) -> None:
+    ctrl.write_episodic("ep1", "event one")
+    ctrl.write_episodic("ep2", "event two")
+    resp = await client.get("/api/memory/episodic")
+    data = await resp.json()
+    assert len(data["entries"]) == 2
+    assert data["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory/semantic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semantic_empty(client: TestClient) -> None:
+    resp = await client.get("/api/memory/semantic")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["entries"] == []
+
+
+@pytest.mark.asyncio
+async def test_semantic_with_entries(
+    client: TestClient, ctrl: MemoryController,
+) -> None:
+    ctrl.write_semantic("fact1", "water is wet")
+    resp = await client.get("/api/memory/semantic")
+    data = await resp.json()
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["key"] == "fact1"
+    assert "has_vector" in data["entries"][0]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory/procedural
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_procedural_empty(client: TestClient) -> None:
+    resp = await client.get("/api/memory/procedural")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["entries"] == []
+
+
+@pytest.mark.asyncio
+async def test_procedural_with_skill(
+    client: TestClient, ctrl: MemoryController,
+) -> None:
+    from openbad.memory.procedural import Skill
+
+    skill = Skill(name="greet", description="Say hello", capabilities=["chat"])
+    ctrl.write_procedural("greet", skill)
+    resp = await client.get("/api/memory/procedural")
+    data = await resp.json()
+    assert len(data["entries"]) == 1
+    entry = data["entries"][0]
+    assert entry["skill"] is not None
+    assert entry["skill"]["name"] == "greet"
+    assert entry["skill"]["confidence"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory/entry/{key}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_entry_found(
+    client: TestClient, ctrl: MemoryController,
+) -> None:
+    ctrl.write_stm("lookup", "found me")
+    resp = await client.get("/api/memory/entry/lookup")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["key"] == "lookup"
+    assert data["value"] == "found me"
+
+
+@pytest.mark.asyncio
+async def test_get_entry_not_found(client: TestClient) -> None:
+    resp = await client.get("/api/memory/entry/ghost")
+    assert resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/memory/recall
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_empty(client: TestClient) -> None:
+    resp = await client.post(
+        "/api/memory/recall", json={"query": "anything"},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_recall_with_data(
+    client: TestClient, ctrl: MemoryController,
+) -> None:
+    ctrl.write_semantic("water", "water is H2O")
+    resp = await client.post(
+        "/api/memory/recall", json={"query": "water", "top_k": 5},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert len(data["results"]) >= 1
+    assert any(r["key"] == "water" for r in data["results"])
+
+
+@pytest.mark.asyncio
+async def test_recall_missing_query(client: TestClient) -> None:
+    resp = await client.post("/api/memory/recall", json={})
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_recall_invalid_body(client: TestClient) -> None:
+    resp = await client.post(
+        "/api/memory/recall",
+        json="not an object",
+    )
+    assert resp.status == 400

--- a/wui-svelte/src/routes/+layout.svelte
+++ b/wui-svelte/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
     { href: '/tasks',     label: 'Tasks',     icon: '📋' },
     { href: '/research',  label: 'Research',  icon: '🔬' },
     { href: '/library',   label: 'Library',   icon: '📚' },
+    { href: '/memory',    label: 'Memory',    icon: '🧠' },
     { href: '/usage',     label: 'Usage',     icon: '◔' },
     { href: '/providers', label: 'Providers', icon: '⚙' },
     { href: '/senses',    label: 'Senses',    icon: '👁' },

--- a/wui-svelte/src/routes/memory/+page.svelte
+++ b/wui-svelte/src/routes/memory/+page.svelte
@@ -1,0 +1,818 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { get as apiGet, post as apiPost } from '$lib/api/client';
+  import Card from '$lib/components/Card.svelte';
+
+  // -- Types ------------------------------------------------------------------
+
+  interface StmUsage {
+    tokens_used: number;
+    tokens_max: number;
+    entry_count: number;
+    oldest_entry_age: number;
+  }
+
+  interface MemoryStats {
+    stm: StmUsage;
+    episodic: { entry_count: number };
+    semantic: { entry_count: number };
+    procedural: { entry_count: number };
+    timestamp: number;
+  }
+
+  interface MemEntry {
+    key: string;
+    value: string;
+    tier: string;
+    entry_id: string;
+    created_at: number;
+    accessed_at: number;
+    access_count: number;
+    ttl_seconds: number | null;
+    context: string;
+    metadata: Record<string, any>;
+    // STM extras
+    age_seconds?: number;
+    ttl_remaining?: number | null;
+    // Semantic extras
+    has_vector?: boolean;
+    // Procedural extras
+    skill?: SkillInfo | null;
+  }
+
+  interface SkillInfo {
+    name: string;
+    description: string;
+    capabilities: string[];
+    code: string;
+    confidence: number;
+    success_count: number;
+    failure_count: number;
+  }
+
+  interface RecallResult {
+    key: string;
+    value: string;
+    tier: string;
+    score: number;
+    metadata: Record<string, any>;
+    library_annotations?: string[];
+  }
+
+  // -- State ------------------------------------------------------------------
+
+  type Tab = 'overview' | 'stm' | 'episodic' | 'semantic' | 'procedural';
+
+  let activeTab: Tab = $state('overview');
+  let stats: MemoryStats | null = $state(null);
+  let stmEntries: MemEntry[] = $state([]);
+  let stmUsage: StmUsage | null = $state(null);
+  let episodicEntries: MemEntry[] = $state([]);
+  let episodicTotal = $state(0);
+  let semanticEntries: MemEntry[] = $state([]);
+  let semanticTotal = $state(0);
+  let proceduralEntries: MemEntry[] = $state([]);
+  let proceduralTotal = $state(0);
+  let loading = $state(false);
+  let error = $state('');
+  let expandedKey = $state('');
+
+  // Recall
+  let recallQuery = $state('');
+  let recallResults: RecallResult[] = $state([]);
+  let recalling = $state(false);
+
+  // -- Helpers ----------------------------------------------------------------
+
+  function fmtTime(ts: number): string {
+    if (!ts) return '—';
+    const diff = (Date.now() / 1000) - ts;
+    if (diff < 0) return 'future';
+    if (diff < 60) return `${Math.floor(diff)}s ago`;
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+    return `${Math.floor(diff / 86400)}d ago`;
+  }
+
+  function fmtDuration(seconds: number): string {
+    if (seconds < 60) return `${Math.floor(seconds)}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
+    return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+  }
+
+  function truncate(text: string, max: number = 120): string {
+    return text.length > max ? text.slice(0, max) + '…' : text;
+  }
+
+  function pct(used: number, total: number): number {
+    return total > 0 ? Math.round((used / total) * 100) : 0;
+  }
+
+  function tierIcon(tier: string): string {
+    const icons: Record<string, string> = {
+      stm: '⚡', episodic: '📅', semantic: '🧠', procedural: '🔧',
+    };
+    return icons[tier] ?? '📦';
+  }
+
+  // -- Data loading -----------------------------------------------------------
+
+  async function loadStats() {
+    try {
+      stats = await apiGet<MemoryStats>('/api/memory/stats');
+    } catch (e: any) {
+      error = e.message ?? 'Failed to load stats';
+    }
+  }
+
+  async function loadStm() {
+    loading = true;
+    error = '';
+    try {
+      const data = await apiGet<{ entries: MemEntry[]; usage: StmUsage }>('/api/memory/stm');
+      stmEntries = data.entries;
+      stmUsage = data.usage;
+    } catch (e: any) {
+      error = e.message ?? 'Failed to load STM';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadEpisodic() {
+    loading = true;
+    error = '';
+    try {
+      const data = await apiGet<{ entries: MemEntry[]; total: number }>('/api/memory/episodic?limit=100');
+      episodicEntries = data.entries;
+      episodicTotal = data.total;
+    } catch (e: any) {
+      error = e.message ?? 'Failed to load episodic';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadSemantic() {
+    loading = true;
+    error = '';
+    try {
+      const data = await apiGet<{ entries: MemEntry[]; total: number }>('/api/memory/semantic');
+      semanticEntries = data.entries;
+      semanticTotal = data.total;
+    } catch (e: any) {
+      error = e.message ?? 'Failed to load semantic';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadProcedural() {
+    loading = true;
+    error = '';
+    try {
+      const data = await apiGet<{ entries: MemEntry[]; total: number }>('/api/memory/procedural');
+      proceduralEntries = data.entries;
+      proceduralTotal = data.total;
+    } catch (e: any) {
+      error = e.message ?? 'Failed to load procedural';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleRecall() {
+    const q = recallQuery.trim();
+    if (!q) return;
+    recalling = true;
+    error = '';
+    try {
+      const data = await apiPost<{ results: RecallResult[] }>('/api/memory/recall', {
+        query: q,
+        top_k: 10,
+      });
+      recallResults = data.results;
+    } catch (e: any) {
+      error = e.message ?? 'Recall failed';
+    } finally {
+      recalling = false;
+    }
+  }
+
+  function switchTab(tab: Tab) {
+    activeTab = tab;
+    expandedKey = '';
+    if (tab === 'overview') loadStats();
+    else if (tab === 'stm') loadStm();
+    else if (tab === 'episodic') loadEpisodic();
+    else if (tab === 'semantic') loadSemantic();
+    else if (tab === 'procedural') loadProcedural();
+  }
+
+  function toggleExpand(key: string) {
+    expandedKey = expandedKey === key ? '' : key;
+  }
+
+  onMount(loadStats);
+</script>
+
+<div class="page-header">
+  <h2>🧠 Memory Inspector</h2>
+  <p>Browse and verify all memory tiers</p>
+</div>
+
+<!-- Tab Bar -->
+<div class="tab-bar">
+  <button class:active={activeTab === 'overview'} onclick={() => switchTab('overview')}>Overview</button>
+  <button class:active={activeTab === 'stm'} onclick={() => switchTab('stm')}>⚡ STM</button>
+  <button class:active={activeTab === 'episodic'} onclick={() => switchTab('episodic')}>📅 Episodic</button>
+  <button class:active={activeTab === 'semantic'} onclick={() => switchTab('semantic')}>🧠 Semantic</button>
+  <button class:active={activeTab === 'procedural'} onclick={() => switchTab('procedural')}>🔧 Procedural</button>
+</div>
+
+{#if error}
+  <p class="text-red">{error}</p>
+{/if}
+
+<!-- ═══════ OVERVIEW TAB ═══════ -->
+{#if activeTab === 'overview'}
+  <div class="overview-grid">
+    {#if stats}
+      <Card label="Tier Counts">
+        <div class="stat-row">
+          <div class="stat-card">
+            <span class="stat-icon">⚡</span>
+            <span class="stat-value">{stats.stm.entry_count}</span>
+            <span class="stat-label">STM</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-icon">📅</span>
+            <span class="stat-value">{stats.episodic.entry_count}</span>
+            <span class="stat-label">Episodic</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-icon">🧠</span>
+            <span class="stat-value">{stats.semantic.entry_count}</span>
+            <span class="stat-label">Semantic</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-icon">🔧</span>
+            <span class="stat-value">{stats.procedural.entry_count}</span>
+            <span class="stat-label">Procedural</span>
+          </div>
+        </div>
+      </Card>
+
+      <Card label="STM Token Usage">
+        <div class="token-bar-container">
+          <div class="token-bar">
+            <div
+              class="token-fill"
+              class:warning={pct(stats.stm.tokens_used, stats.stm.tokens_max) > 80}
+              style="width: {pct(stats.stm.tokens_used, stats.stm.tokens_max)}%"
+            ></div>
+          </div>
+          <span class="token-label">
+            {stats.stm.tokens_used.toLocaleString()} / {stats.stm.tokens_max.toLocaleString()} tokens
+            ({pct(stats.stm.tokens_used, stats.stm.tokens_max)}%)
+          </span>
+        </div>
+      </Card>
+    {:else}
+      <Card label="Loading...">
+        <p class="muted">Fetching memory statistics…</p>
+      </Card>
+    {/if}
+
+    <Card label="Recall Test">
+      <p class="muted recall-desc">Test what the LLM would retrieve for a query — validates the full recall pipeline.</p>
+      <form class="recall-form" onsubmit={(e) => { e.preventDefault(); handleRecall(); }}>
+        <input
+          type="text"
+          placeholder="Enter recall query..."
+          bind:value={recallQuery}
+        />
+        <button type="submit" disabled={recalling || !recallQuery.trim()}>
+          {recalling ? '⏳' : '🔍'} Recall
+        </button>
+      </form>
+
+      {#if recallResults.length > 0}
+        <div class="recall-results">
+          {#each recallResults as r, i}
+            <div class="recall-item">
+              <div class="recall-header">
+                <span class="rank">#{i + 1}</span>
+                <span class="badge">{tierIcon(r.tier)} {r.tier}</span>
+                <span class="score badge">{r.score.toFixed(4)}</span>
+                <span class="recall-key">{r.key}</span>
+              </div>
+              <p class="recall-value">{truncate(r.value, 200)}</p>
+              {#if r.library_annotations && r.library_annotations.length > 0}
+                <div class="lib-annotations">
+                  {#each r.library_annotations as ann}
+                    <p class="annotation text-blue">{ann}</p>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {:else if recallQuery && !recalling}
+        <p class="muted">No results — try a different query or add some memories first.</p>
+      {/if}
+    </Card>
+  </div>
+
+<!-- ═══════ STM TAB ═══════ -->
+{:else if activeTab === 'stm'}
+  <div class="toolbar">
+    <span class="count">{stmEntries.length} entries</span>
+    {#if stmUsage}
+      <span class="muted">
+        | {stmUsage.tokens_used.toLocaleString()} / {stmUsage.tokens_max.toLocaleString()} tokens
+      </span>
+    {/if}
+    <button class="secondary" onclick={loadStm}>↻ Refresh</button>
+  </div>
+
+  <Card label="Short-Term Memory">
+    {#if loading}
+      <p class="muted">Loading…</p>
+    {:else if stmEntries.length === 0}
+      <p class="muted">STM is empty — no active short-term memories.</p>
+    {:else}
+      <div class="entry-list">
+        {#each stmEntries as entry}
+          <div class="entry-row" class:expanded={expandedKey === entry.key}>
+            <button class="ghost entry-toggle" onclick={() => toggleExpand(entry.key)}>
+              <span class="entry-key">{entry.key}</span>
+              <span class="entry-preview muted">{truncate(entry.value, 80)}</span>
+              <div class="entry-badges">
+                {#if entry.ttl_remaining != null}
+                  <span class="badge" class:text-yellow={entry.ttl_remaining < 300}>
+                    TTL: {fmtDuration(entry.ttl_remaining)}
+                  </span>
+                {/if}
+                <span class="badge">{fmtTime(entry.created_at)}</span>
+              </div>
+            </button>
+            {#if expandedKey === entry.key}
+              <div class="entry-detail">
+                <div class="detail-grid">
+                  <div><strong>Entry ID:</strong> <code>{entry.entry_id}</code></div>
+                  <div><strong>Created:</strong> {new Date(entry.created_at * 1000).toLocaleString()}</div>
+                  <div><strong>Accessed:</strong> {fmtTime(entry.accessed_at)} ({entry.access_count}×)</div>
+                  <div><strong>Context:</strong> {entry.context || '—'}</div>
+                </div>
+                <div class="detail-value">
+                  <strong>Value:</strong>
+                  <pre>{entry.value}</pre>
+                </div>
+                {#if Object.keys(entry.metadata).length > 0}
+                  <div class="detail-meta">
+                    <strong>Metadata:</strong>
+                    <pre>{JSON.stringify(entry.metadata, null, 2)}</pre>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </Card>
+
+<!-- ═══════ EPISODIC TAB ═══════ -->
+{:else if activeTab === 'episodic'}
+  <div class="toolbar">
+    <span class="count">{episodicEntries.length} of {episodicTotal} entries</span>
+    <button class="secondary" onclick={loadEpisodic}>↻ Refresh</button>
+  </div>
+
+  <Card label="Episodic Memory (Recent)">
+    {#if loading}
+      <p class="muted">Loading…</p>
+    {:else if episodicEntries.length === 0}
+      <p class="muted">No episodic memories recorded yet.</p>
+    {:else}
+      <div class="entry-list">
+        {#each episodicEntries as entry}
+          <div class="entry-row" class:expanded={expandedKey === entry.key}>
+            <button class="ghost entry-toggle" onclick={() => toggleExpand(entry.key)}>
+              <span class="entry-key">{entry.key}</span>
+              <span class="entry-preview muted">{truncate(entry.value, 80)}</span>
+              <div class="entry-badges">
+                <span class="badge">{fmtTime(entry.created_at)}</span>
+                <span class="badge">{entry.access_count}×</span>
+              </div>
+            </button>
+            {#if expandedKey === entry.key}
+              <div class="entry-detail">
+                <div class="detail-grid">
+                  <div><strong>Entry ID:</strong> <code>{entry.entry_id}</code></div>
+                  <div><strong>Created:</strong> {new Date(entry.created_at * 1000).toLocaleString()}</div>
+                  <div><strong>Context:</strong> {entry.context || '—'}</div>
+                </div>
+                <div class="detail-value">
+                  <strong>Value:</strong>
+                  <pre>{entry.value}</pre>
+                </div>
+                {#if Object.keys(entry.metadata).length > 0}
+                  <div class="detail-meta">
+                    <strong>Metadata:</strong>
+                    <pre>{JSON.stringify(entry.metadata, null, 2)}</pre>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </Card>
+
+<!-- ═══════ SEMANTIC TAB ═══════ -->
+{:else if activeTab === 'semantic'}
+  <div class="toolbar">
+    <span class="count">{semanticEntries.length} entries</span>
+    <button class="secondary" onclick={loadSemantic}>↻ Refresh</button>
+  </div>
+
+  <Card label="Semantic Memory">
+    {#if loading}
+      <p class="muted">Loading…</p>
+    {:else if semanticEntries.length === 0}
+      <p class="muted">No semantic memories stored yet.</p>
+    {:else}
+      <div class="entry-list">
+        {#each semanticEntries as entry}
+          <div class="entry-row" class:expanded={expandedKey === entry.key}>
+            <button class="ghost entry-toggle" onclick={() => toggleExpand(entry.key)}>
+              <span class="entry-key">{entry.key}</span>
+              <span class="entry-preview muted">{truncate(entry.value, 80)}</span>
+              <div class="entry-badges">
+                {#if entry.has_vector}
+                  <span class="badge text-green">🔢 vectorized</span>
+                {/if}
+                {#if entry.metadata?.library_refs?.length}
+                  <span class="badge text-blue">📚 {entry.metadata.library_refs.length} refs</span>
+                {/if}
+                {#if entry.metadata?.tags?.length}
+                  {#each entry.metadata.tags as tag}
+                    <span class="badge">{tag}</span>
+                  {/each}
+                {/if}
+                <span class="badge">{fmtTime(entry.created_at)}</span>
+              </div>
+            </button>
+            {#if expandedKey === entry.key}
+              <div class="entry-detail">
+                <div class="detail-grid">
+                  <div><strong>Entry ID:</strong> <code>{entry.entry_id}</code></div>
+                  <div><strong>Created:</strong> {new Date(entry.created_at * 1000).toLocaleString()}</div>
+                  <div><strong>Accessed:</strong> {fmtTime(entry.accessed_at)} ({entry.access_count}×)</div>
+                  <div><strong>Has Vector:</strong> {entry.has_vector ? 'Yes' : 'No'}</div>
+                </div>
+                <div class="detail-value">
+                  <strong>Value:</strong>
+                  <pre>{entry.value}</pre>
+                </div>
+                {#if Object.keys(entry.metadata).length > 0}
+                  <div class="detail-meta">
+                    <strong>Metadata:</strong>
+                    <pre>{JSON.stringify(entry.metadata, null, 2)}</pre>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </Card>
+
+<!-- ═══════ PROCEDURAL TAB ═══════ -->
+{:else if activeTab === 'procedural'}
+  <div class="toolbar">
+    <span class="count">{proceduralEntries.length} skills</span>
+    <button class="secondary" onclick={loadProcedural}>↻ Refresh</button>
+  </div>
+
+  <Card label="Procedural Memory (Skills)">
+    {#if loading}
+      <p class="muted">Loading…</p>
+    {:else if proceduralEntries.length === 0}
+      <p class="muted">No procedural skills stored yet.</p>
+    {:else}
+      <div class="entry-list">
+        {#each proceduralEntries as entry}
+          <div class="entry-row" class:expanded={expandedKey === entry.key}>
+            <button class="ghost entry-toggle" onclick={() => toggleExpand(entry.key)}>
+              <span class="entry-key">{entry.key}</span>
+              {#if entry.skill}
+                <span class="entry-preview muted">{entry.skill.description}</span>
+              {:else}
+                <span class="entry-preview muted">{truncate(entry.value, 80)}</span>
+              {/if}
+              <div class="entry-badges">
+                {#if entry.skill}
+                  <span class="badge confidence" title="Bayesian confidence">
+                    {(entry.skill.confidence * 100).toFixed(0)}%
+                  </span>
+                  <span class="badge text-green">✓ {entry.skill.success_count}</span>
+                  <span class="badge text-red">✗ {entry.skill.failure_count}</span>
+                {/if}
+              </div>
+            </button>
+            {#if expandedKey === entry.key}
+              <div class="entry-detail">
+                {#if entry.skill}
+                  <div class="detail-grid">
+                    <div><strong>Name:</strong> {entry.skill.name}</div>
+                    <div><strong>Confidence:</strong> {(entry.skill.confidence * 100).toFixed(1)}%</div>
+                    <div><strong>Success / Fail:</strong> {entry.skill.success_count} / {entry.skill.failure_count}</div>
+                  </div>
+                  {#if entry.skill.capabilities.length > 0}
+                    <div class="caps-row">
+                      <strong>Capabilities:</strong>
+                      {#each entry.skill.capabilities as cap}
+                        <span class="badge">{cap}</span>
+                      {/each}
+                    </div>
+                  {/if}
+                  <div class="confidence-bar-container">
+                    <strong>Confidence:</strong>
+                    <div class="confidence-bar">
+                      <div
+                        class="confidence-fill"
+                        class:low={entry.skill.confidence < 0.3}
+                        class:mid={entry.skill.confidence >= 0.3 && entry.skill.confidence < 0.7}
+                        class:high={entry.skill.confidence >= 0.7}
+                        style="width: {entry.skill.confidence * 100}%"
+                      ></div>
+                    </div>
+                  </div>
+                  {#if entry.skill.code}
+                    <div class="detail-value">
+                      <strong>Code:</strong>
+                      <pre>{entry.skill.code}</pre>
+                    </div>
+                  {/if}
+                {:else}
+                  <div class="detail-value">
+                    <strong>Value:</strong>
+                    <pre>{entry.value}</pre>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </Card>
+{/if}
+
+<style>
+  /* -- Tab Bar -- */
+  .tab-bar {
+    display: flex;
+    gap: 0;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--bg-surface2);
+  }
+  .tab-bar button {
+    padding: 0.5rem 1rem;
+    background: transparent;
+    color: var(--text-dim);
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: color 0.15s, border-color 0.15s;
+  }
+  .tab-bar button:hover {
+    color: var(--text);
+  }
+  .tab-bar button.active {
+    color: var(--blue);
+    border-bottom-color: var(--blue);
+  }
+
+  /* -- Overview -- */
+  .overview-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .stat-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.75rem;
+  }
+  .stat-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.75rem;
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface0);
+    border: 1px solid var(--bg-surface1);
+  }
+  .stat-icon { font-size: 1.5rem; }
+  .stat-value { font-size: 1.75rem; font-weight: 700; color: var(--text); }
+  .stat-label { font-size: 0.8rem; color: var(--text-dim); text-transform: uppercase; }
+
+  /* -- Token bar -- */
+  .token-bar-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .token-bar {
+    height: 1.25rem;
+    background: var(--bg-surface1);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+  .token-fill {
+    height: 100%;
+    background: var(--green);
+    transition: width 0.3s;
+    border-radius: var(--radius-sm);
+  }
+  .token-fill.warning { background: var(--yellow); }
+  .token-label { font-size: 0.85rem; color: var(--text-sub); }
+
+  /* -- Recall -- */
+  .recall-desc { margin: 0 0 0.5rem; font-size: 0.85rem; }
+  .recall-form {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+  .recall-form input {
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--bg-surface2);
+    background: var(--bg-surface0);
+    color: var(--text);
+    font-size: 0.9rem;
+  }
+  .recall-form input::placeholder { color: var(--text-dim); }
+  .recall-results {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .recall-item {
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface0);
+    border: 1px solid var(--bg-surface1);
+  }
+  .recall-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+  .rank { font-weight: 700; color: var(--text-dim); min-width: 2rem; }
+  .score { font-family: monospace; font-size: 0.8rem; }
+  .recall-key { font-weight: 600; color: var(--text); }
+  .recall-value {
+    font-size: 0.85rem;
+    color: var(--text-sub);
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .lib-annotations { margin-top: 0.25rem; }
+  .annotation { font-size: 0.8rem; margin: 0; }
+
+  /* -- Toolbar -- */
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.9rem;
+  }
+  .count { font-weight: 600; }
+
+  /* -- Entry list -- */
+  .entry-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+  .entry-row {
+    border-bottom: 1px solid var(--bg-surface1);
+  }
+  .entry-row:last-child { border-bottom: none; }
+  .entry-toggle {
+    display: grid;
+    grid-template-columns: minmax(120px, auto) 1fr auto;
+    gap: 0.5rem;
+    align-items: center;
+    width: 100%;
+    padding: 0.5rem 0.25rem;
+    text-align: left;
+    font-size: 0.85rem;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+  }
+  .entry-toggle:hover { background: var(--bg-surface1); }
+  .entry-key {
+    font-weight: 600;
+    color: var(--blue);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .entry-preview {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .entry-badges {
+    display: flex;
+    gap: 0.35rem;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  /* -- Entry detail -- */
+  .entry-detail {
+    padding: 0.75rem;
+    background: var(--bg-surface0);
+    border-radius: var(--radius-sm);
+    margin-bottom: 0.5rem;
+    font-size: 0.85rem;
+  }
+  .detail-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.25rem 1rem;
+    margin-bottom: 0.5rem;
+  }
+  .detail-value pre,
+  .detail-meta pre {
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: 0.85rem;
+    background: var(--bg-mantle);
+    padding: 0.5rem;
+    border-radius: var(--radius-sm);
+    margin: 0.25rem 0 0.5rem;
+    max-height: 300px;
+    overflow-y: auto;
+  }
+  .detail-value code,
+  .detail-grid code {
+    font-size: 0.8rem;
+    color: var(--text-sub);
+  }
+
+  /* -- Procedural extras -- */
+  .confidence {
+    font-weight: 700;
+  }
+  .caps-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+  .confidence-bar-container {
+    margin: 0.5rem 0;
+  }
+  .confidence-bar {
+    height: 0.75rem;
+    background: var(--bg-surface1);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    margin-top: 0.25rem;
+  }
+  .confidence-fill {
+    height: 100%;
+    border-radius: var(--radius-sm);
+    transition: width 0.3s;
+  }
+  .confidence-fill.low { background: var(--red); }
+  .confidence-fill.mid { background: var(--yellow); }
+  .confidence-fill.high { background: var(--green); }
+
+  @media (max-width: 768px) {
+    .stat-row {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .entry-toggle {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

Adds a Memory Inspector page to the web UI for browsing and verifying all memory system tiers.

### Backend — `src/openbad/wui/memory_api.py` (new)

7 REST endpoints following the `setup_*_routes()` pattern:

| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/api/memory/stats` | Tier counts + STM token usage |
| `GET` | `/api/memory/stm` | All STM entries with computed age/TTL remaining |
| `GET` | `/api/memory/episodic` | Recent episodic entries (limit param) |
| `GET` | `/api/memory/semantic` | All semantic entries with vector status |
| `GET` | `/api/memory/procedural` | All skills with confidence/success/failure |
| `GET` | `/api/memory/entry/{key}` | Single entry from any tier |
| `POST` | `/api/memory/recall` | Full recall pipeline test (semantic + episodic, ranked) |

### Frontend — `wui-svelte/src/routes/memory/+page.svelte` (new)

Tabbed dashboard with 5 views:

- **Overview**: Tier count cards, STM token usage gauge, Recall Test box (the key verification tool — enter a query, see exactly what the LLM would retrieve with scores and library annotations)
- **STM**: Live buffer entries with TTL countdown, age, expandable detail
- **Episodic**: Chronological timeline with expandable rows
- **Semantic**: Entries showing vector status, library_refs badges, tags
- **Procedural**: Skill cards with Bayesian confidence bars, success/failure counts, capability tags, code preview

### Wiring

- `src/openbad/wui/server.py`: Creates `MemoryController()` and calls `setup_memory_routes()` in `create_app()`
- `wui-svelte/src/routes/+layout.svelte`: Added `{ href: '/memory', label: 'Memory', icon: '🧠' }` to nav

### Tests — `tests/test_memory_api.py`

16 tests covering all endpoints: empty states, populated data, procedural skills, entry lookup, recall with/without data, validation errors.

## How to Test

```bash
.venv/bin/pytest tests/test_memory_api.py -v
cd wui-svelte && npm run build
```