### PR TITLE
#578: CognitiveMemoryStore with activate() pipeline

### DIFF
--- a/src/openbad/memory/cognitive_store.py
+++ b/src/openbad/memory/cognitive_store.py
@@ -1,0 +1,381 @@
+"""SQLite-backed memory store with cognitive retrieval.
+
+Implements the ``MemoryStore`` ABC using the engrams schema from
+migration 0007.  Retrieval is scored by a composite of BM25 full-text
+match, ACT-R temporal activation, and Hebbian association weights.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+
+from openbad.memory.base import MemoryEntry, MemoryStore, MemoryTier
+from openbad.memory.cognitive import (
+    act_r_activation,
+    composite_score,
+    hebbian_update,
+)
+
+logger = logging.getLogger(__name__)
+
+_ACTIVATION_LOG_LIMIT = 50  # ring-buffer size per tier
+
+
+@dataclass
+class ActivationResult:
+    """A scored retrieval result with explainability."""
+
+    entry: MemoryEntry
+    score: float
+    why: str  # e.g. "BM25(0.78) + act_r(0.94) + hebbian(0.16) confidence=0.95"
+
+
+class CognitiveMemoryStore(MemoryStore):
+    """SQLite-backed memory store with cognitive retrieval.
+
+    Parameters
+    ----------
+    conn:
+        Open SQLite connection (WAL mode, foreign keys ON).
+    tier:
+        Which memory tier this store manages.
+    """
+
+    def __init__(self, conn: sqlite3.Connection, tier: MemoryTier) -> None:
+        self._conn = conn
+        self._tier = tier.value
+
+    # ------------------------------------------------------------------
+    # MemoryStore ABC
+    # ------------------------------------------------------------------
+
+    def write(self, entry: MemoryEntry) -> str:
+        now = time.time()
+        engram_id = entry.entry_id or uuid.uuid4().hex[:16]
+        metadata_json = json.dumps(entry.metadata) if entry.metadata else "{}"
+        concept = entry.context or ""
+        content = entry.value if isinstance(entry.value, str) else json.dumps(entry.value)
+
+        self._conn.execute(
+            """INSERT INTO engrams
+               (engram_id, tier, key, concept, content, confidence,
+                access_count, last_access_at, created_at, updated_at,
+                ttl_seconds, context, metadata, state)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+               ON CONFLICT(engram_id) DO UPDATE SET
+                 content    = excluded.content,
+                 concept    = excluded.concept,
+                 confidence = excluded.confidence,
+                 context    = excluded.context,
+                 metadata   = excluded.metadata,
+                 ttl_seconds = excluded.ttl_seconds,
+                 updated_at = excluded.updated_at""",
+            (
+                engram_id,
+                self._tier,
+                entry.key,
+                concept,
+                content,
+                entry.metadata.get("confidence", 0.5),
+                entry.access_count,
+                entry.accessed_at or now,
+                entry.created_at or now,
+                now,
+                entry.ttl_seconds,
+                entry.context or "",
+                metadata_json,
+            ),
+        )
+        self._conn.commit()
+        return engram_id
+
+    def read(self, key: str) -> MemoryEntry | None:
+        now = time.time()
+        row = self._conn.execute(
+            """SELECT * FROM engrams
+               WHERE key = ? AND tier = ? AND state = 'active'""",
+            (key, self._tier),
+        ).fetchone()
+        if row is None:
+            return None
+
+        # STM TTL check
+        if (
+            row["ttl_seconds"] is not None
+            and row["ttl_seconds"] > 0
+            and (now - row["created_at"]) > row["ttl_seconds"]
+        ):
+            self.delete(key)
+            return None
+
+        # Learning on every read: touch access stats
+        self._conn.execute(
+            """UPDATE engrams
+               SET access_count = access_count + 1,
+                   last_access_at = ?,
+                   updated_at = ?
+               WHERE engram_id = ?""",
+            (now, now, row["engram_id"]),
+        )
+        self._conn.commit()
+
+        return self._row_to_entry(row)
+
+    def delete(self, key: str) -> bool:
+        cursor = self._conn.execute(
+            "DELETE FROM engrams WHERE key = ? AND tier = ?",
+            (key, self._tier),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def query(self, prefix: str) -> list[MemoryEntry]:
+        if prefix:
+            rows = self._conn.execute(
+                """SELECT * FROM engrams
+                   WHERE tier = ? AND state = 'active' AND key LIKE ?
+                   ORDER BY last_access_at DESC""",
+                (self._tier, f"{prefix}%"),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """SELECT * FROM engrams
+                   WHERE tier = ? AND state = 'active'
+                   ORDER BY last_access_at DESC""",
+                (self._tier,),
+            ).fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
+    def list_keys(self) -> list[str]:
+        rows = self._conn.execute(
+            "SELECT key FROM engrams WHERE tier = ? AND state = 'active'",
+            (self._tier,),
+        ).fetchall()
+        return [r["key"] for r in rows]
+
+    def size(self) -> int:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM engrams WHERE tier = ? AND state = 'active'",
+            (self._tier,),
+        ).fetchone()
+        return row[0]
+
+    # ------------------------------------------------------------------
+    # Cognitive retrieval
+    # ------------------------------------------------------------------
+
+    def activate(
+        self,
+        context: str,
+        limit: int = 10,
+    ) -> list[ActivationResult]:
+        """Full cognitive retrieval pipeline.
+
+        1. FTS5 BM25 candidate selection
+        2. ACT-R temporal scoring
+        3. Hebbian association boost
+        4. Composite ranking
+        5. Record activation + update Hebbian weights
+        """
+        now = time.time()
+
+        # 1. FTS candidates
+        candidates = self._fts_candidates(context, limit * 3)
+        if not candidates:
+            return []
+
+        # 2+3+4. Score each candidate
+        results: list[ActivationResult] = []
+        for engram_id, bm25 in candidates:
+            row = self._conn.execute(
+                "SELECT * FROM engrams WHERE engram_id = ? AND state = 'active'",
+                (engram_id,),
+            ).fetchone()
+            if row is None:
+                continue
+
+            # STM TTL check
+            if (
+                row["ttl_seconds"] is not None
+                and row["ttl_seconds"] > 0
+                and (now - row["created_at"]) > row["ttl_seconds"]
+            ):
+                continue
+
+            # ACT-R activation
+            age_days = max((now - row["last_access_at"]) / 86400.0, 0.001)
+            act_r = act_r_activation(row["access_count"], age_days)
+
+            # Hebbian boost
+            hebb = self._hebbian_boost(engram_id)
+
+            # Confidence
+            conf = row["confidence"]
+
+            # Composite
+            score = composite_score(abs(bm25), act_r, hebb, conf)
+
+            why = (
+                f"BM25({abs(bm25):.2f}) + act_r({act_r:.2f})"
+                f" + hebbian({hebb:.2f}) confidence={conf:.2f}"
+            )
+
+            results.append(ActivationResult(
+                entry=self._row_to_entry(row),
+                score=score,
+                why=why,
+            ))
+
+        # Sort by score descending
+        results.sort(key=lambda r: r.score, reverse=True)
+        results = results[:limit]
+
+        # 5. Record activation and update Hebbian
+        activated_ids = [r.entry.entry_id for r in results]
+        self._record_activations(activated_ids, context, now)
+        self._update_hebbian_weights(activated_ids, now)
+        self._prune_activation_log()
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _fts_candidates(
+        self, query: str, limit: int,
+    ) -> list[tuple[str, float]]:
+        """Return (engram_id, bm25_score) from FTS5."""
+        try:
+            rows = self._conn.execute(
+                """SELECT f.engram_id, f.rank
+                   FROM engrams_fts f
+                   JOIN engrams e ON e.engram_id = f.engram_id
+                   WHERE engrams_fts MATCH ?
+                     AND e.tier = ?
+                     AND e.state = 'active'
+                   ORDER BY f.rank
+                   LIMIT ?""",
+                (query, self._tier, limit),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            # Invalid FTS query syntax
+            return []
+        return [(r["engram_id"], r["rank"]) for r in rows]
+
+    def _hebbian_boost(self, engram_id: str) -> float:
+        """Sum of association weights to recently activated engrams."""
+        row = self._conn.execute(
+            """SELECT COALESCE(SUM(a.weight), 0.0) AS total
+               FROM engram_associations a
+               WHERE a.source_id = ? OR a.target_id = ?""",
+            (engram_id, engram_id),
+        ).fetchone()
+        return row["total"] if row else 0.0
+
+    def _record_activations(
+        self,
+        engram_ids: list[str],
+        context: str,
+        now: float,
+    ) -> None:
+        """Insert into activation_log and bump access stats."""
+        for eid in engram_ids:
+            self._conn.execute(
+                "INSERT INTO activation_log"
+                " (engram_id, activated_at, query_context)"
+                " VALUES (?, ?, ?)",
+                (eid, now, context),
+            )
+            self._conn.execute(
+                """UPDATE engrams
+                   SET access_count = access_count + 1,
+                       last_access_at = ?,
+                       updated_at = ?
+                   WHERE engram_id = ?""",
+                (now, now, eid),
+            )
+        self._conn.commit()
+
+    def _update_hebbian_weights(
+        self, engram_ids: list[str], now: float,
+    ) -> None:
+        """Strengthen associations between co-activated engrams."""
+        if len(engram_ids) < 2:
+            return
+        for i, a in enumerate(engram_ids):
+            for b in engram_ids[i + 1 :]:
+                self._strengthen_pair(a, b, now)
+        self._conn.commit()
+
+    def _strengthen_pair(self, a: str, b: str, now: float) -> None:
+        """Bidirectional Hebbian weight update for a pair."""
+        for src, tgt in ((a, b), (b, a)):
+            row = self._conn.execute(
+                "SELECT weight FROM engram_associations WHERE source_id = ? AND target_id = ?",
+                (src, tgt),
+            ).fetchone()
+            if row is not None:
+                new_w = hebbian_update(row["weight"])
+                self._conn.execute(
+                    """UPDATE engram_associations
+                       SET weight = ?,
+                           co_activation_count = co_activation_count + 1,
+                           updated_at = ?
+                       WHERE source_id = ? AND target_id = ?""",
+                    (new_w, now, src, tgt),
+                )
+            else:
+                self._conn.execute(
+                    """INSERT INTO engram_associations
+                       (source_id, target_id, weight, co_activation_count, created_at, updated_at)
+                       VALUES (?, ?, 0.1, 1, ?, ?)""",
+                    (src, tgt, now, now),
+                )
+
+    def _prune_activation_log(self) -> None:
+        """Keep only the last N activation entries per tier."""
+        self._conn.execute(
+            """DELETE FROM activation_log
+               WHERE log_id NOT IN (
+                   SELECT al.log_id
+                   FROM activation_log al
+                   JOIN engrams e ON e.engram_id = al.engram_id
+                   WHERE e.tier = ?
+                   ORDER BY al.activated_at DESC
+                   LIMIT ?
+               )
+               AND engram_id IN (
+                   SELECT engram_id FROM engrams WHERE tier = ?
+               )""",
+            (self._tier, _ACTIVATION_LOG_LIMIT, self._tier),
+        )
+        self._conn.commit()
+
+    def _row_to_entry(self, row: sqlite3.Row) -> MemoryEntry:
+        """Convert a database row to a ``MemoryEntry``."""
+        metadata = json.loads(row["metadata"]) if row["metadata"] else {}
+        # Preserve content: try parsing as JSON; if not, keep as string
+        content = row["content"]
+        try:
+            value = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            value = content
+
+        return MemoryEntry(
+            entry_id=row["engram_id"],
+            key=row["key"],
+            value=value,
+            tier=MemoryTier(row["tier"]),
+            created_at=row["created_at"],
+            accessed_at=row["last_access_at"],
+            access_count=row["access_count"],
+            ttl_seconds=row["ttl_seconds"],
+            context=row["context"],
+            metadata=metadata,
+        )

--- a/tests/test_cognitive_store.py
+++ b/tests/test_cognitive_store.py
@@ -1,0 +1,309 @@
+"""Tests for CognitiveMemoryStore (MemoryStore ABC + cognitive retrieval)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.cognitive_store import ActivationResult, CognitiveMemoryStore
+from openbad.state.db import initialize_state_db
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    """Fresh state DB with all migrations applied."""
+    db = initialize_state_db(tmp_path / "state.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture()
+def store(conn):
+    """Semantic-tier cognitive store."""
+    return CognitiveMemoryStore(conn, MemoryTier.SEMANTIC)
+
+
+@pytest.fixture()
+def stm_store(conn):
+    """STM-tier store for TTL tests."""
+    return CognitiveMemoryStore(conn, MemoryTier.STM)
+
+
+def _make_entry(key: str, value: str = "test", **kwargs) -> MemoryEntry:
+    return MemoryEntry(
+        key=key,
+        value=value,
+        tier=kwargs.pop("tier", MemoryTier.SEMANTIC),
+        context=kwargs.pop("context", ""),
+        **kwargs,
+    )
+
+
+# ------------------------------------------------------------------
+# Basic CRUD (MemoryStore ABC)
+# ------------------------------------------------------------------
+
+
+class TestCRUD:
+    """MemoryStore ABC contract tests."""
+
+    def test_write_and_read(self, store):
+        entry = _make_entry("greeting", "hello world")
+        eid = store.write(entry)
+        assert eid
+        result = store.read("greeting")
+        assert result is not None
+        assert result.key == "greeting"
+        assert result.value == "hello world"
+
+    def test_read_nonexistent(self, store):
+        assert store.read("no-such-key") is None
+
+    def test_write_upsert(self, store):
+        e1 = _make_entry("k", "v1")
+        eid = store.write(e1)
+        e2 = MemoryEntry(
+            entry_id=eid,
+            key="k",
+            value="v2",
+            tier=MemoryTier.SEMANTIC,
+        )
+        store.write(e2)
+        result = store.read("k")
+        assert result is not None
+        assert result.value == "v2"
+
+    def test_delete(self, store):
+        store.write(_make_entry("del-me", "gone"))
+        assert store.delete("del-me")
+        assert store.read("del-me") is None
+
+    def test_delete_nonexistent(self, store):
+        assert not store.delete("nope")
+
+    def test_list_keys(self, store):
+        store.write(_make_entry("a", "1"))
+        store.write(_make_entry("b", "2"))
+        keys = store.list_keys()
+        assert sorted(keys) == ["a", "b"]
+
+    def test_size(self, store):
+        assert store.size() == 0
+        store.write(_make_entry("x", "y"))
+        assert store.size() == 1
+
+    def test_query_by_prefix(self, store):
+        store.write(_make_entry("memory-actr", "actr stuff"))
+        store.write(_make_entry("memory-hebb", "hebb stuff"))
+        store.write(_make_entry("other", "other stuff"))
+        results = store.query("memory-")
+        assert len(results) == 2
+        keys = {r.key for r in results}
+        assert keys == {"memory-actr", "memory-hebb"}
+
+    def test_query_empty_prefix(self, store):
+        store.write(_make_entry("a", "1"))
+        store.write(_make_entry("b", "2"))
+        results = store.query("")
+        assert len(results) == 2
+
+    def test_read_updates_access_count(self, store):
+        store.write(_make_entry("k", "v"))
+        store.read("k")
+        store.read("k")
+        # Query doesn't touch — use it to inspect
+        entries = store.query("k")
+        assert entries[0].access_count >= 2
+
+
+class TestTierIsolation:
+    """Stores for different tiers don't see each other's data."""
+
+    def test_tiers_isolated(self, conn):
+        sem = CognitiveMemoryStore(conn, MemoryTier.SEMANTIC)
+        epi = CognitiveMemoryStore(conn, MemoryTier.EPISODIC)
+        sem.write(_make_entry("k", "semantic", tier=MemoryTier.SEMANTIC))
+        epi.write(_make_entry("k", "episodic", tier=MemoryTier.EPISODIC))
+        assert sem.size() == 1
+        assert epi.size() == 1
+        sem_val = sem.read("k")
+        assert sem_val is not None
+        assert sem_val.value == "semantic"
+
+
+class TestSTMTTL:
+    """STM entries respect ttl_seconds."""
+
+    def test_expired_entry_not_returned(self, stm_store, conn):
+        entry = _make_entry("ephemeral", "gone soon", tier=MemoryTier.STM, ttl_seconds=1.0)
+        stm_store.write(entry)
+
+        # Force the created_at into the past
+        conn.execute(
+            "UPDATE engrams SET created_at = ? WHERE key = ?",
+            (time.time() - 100, "ephemeral"),
+        )
+        conn.commit()
+
+        assert stm_store.read("ephemeral") is None
+
+    def test_non_expired_entry_returned(self, stm_store):
+        entry = _make_entry(
+            "fresh", "still here", tier=MemoryTier.STM, ttl_seconds=9999.0,
+        )
+        stm_store.write(entry)
+        assert stm_store.read("fresh") is not None
+
+
+# ------------------------------------------------------------------
+# Cognitive retrieval
+# ------------------------------------------------------------------
+
+
+class TestActivate:
+    """activate() pipeline tests."""
+
+    def test_activate_returns_results(self, store):
+        store.write(_make_entry("tm", "temporal memory ACT-R scoring", context="temporal memory"))
+        results = store.activate("temporal memory")
+        assert len(results) >= 1
+        assert isinstance(results[0], ActivationResult)
+        assert results[0].entry.key == "tm"
+
+    def test_activate_returns_why(self, store):
+        store.write(_make_entry("tm", "temporal memory model", context="temporal"))
+        results = store.activate("temporal memory")
+        assert results
+        assert "BM25" in results[0].why
+        assert "act_r" in results[0].why
+
+    def test_frequent_beats_rare(self, store, conn):
+        """A frequently-accessed engram ranks above a rarely-accessed one
+        with identical content (AC from issue)."""
+        now = time.time()
+        store.write(_make_entry(
+            "freq", "temporal memory scoring system", context="temporal memory",
+        ))
+        store.write(_make_entry(
+            "rare", "temporal memory scoring system", context="temporal memory",
+        ))
+
+        # Simulate high access on 'freq'
+        conn.execute(
+            """UPDATE engrams SET access_count = 20, last_access_at = ?
+               WHERE key = 'freq'""",
+            (now,),
+        )
+        conn.execute(
+            """UPDATE engrams SET access_count = 1, last_access_at = ?
+               WHERE key = 'rare'""",
+            (now - 86400 * 30,),
+        )
+        conn.commit()
+
+        results = store.activate("temporal memory")
+        assert len(results) >= 2
+        keys = [r.entry.key for r in results]
+        assert keys.index("freq") < keys.index("rare")
+
+    def test_activate_empty_query(self, store):
+        store.write(_make_entry("k", "content"))
+        results = store.activate("")
+        # empty FTS match may return nothing — should not crash
+        assert isinstance(results, list)
+
+    def test_activate_no_matches(self, store):
+        store.write(_make_entry("k", "bananas"))
+        results = store.activate("xyzzy nonexistent topic")
+        assert results == []
+
+    def test_activate_respects_limit(self, store):
+        for i in range(20):
+            store.write(_make_entry(f"mem-{i}", f"temporal memory item {i}", context="temporal"))
+        results = store.activate("temporal memory", limit=5)
+        assert len(results) <= 5
+
+    def test_activate_expired_stm_excluded(self, conn):
+        stm = CognitiveMemoryStore(conn, MemoryTier.STM)
+        stm.write(_make_entry(
+            "exp", "temporal memory expired", tier=MemoryTier.STM,
+            ttl_seconds=1.0, context="temporal memory",
+        ))
+        # Force old created_at
+        conn.execute(
+            "UPDATE engrams SET created_at = ? WHERE key = 'exp'",
+            (time.time() - 100,),
+        )
+        conn.commit()
+        results = stm.activate("temporal memory")
+        assert all(r.entry.key != "exp" for r in results)
+
+
+class TestHebbianLearning:
+    """Hebbian weight evolution through co-activation."""
+
+    def test_co_activation_creates_associations(self, store, conn):
+        store.write(_make_entry("a", "temporal memory research", context="temporal memory"))
+        store.write(_make_entry("b", "temporal memory model", context="temporal memory"))
+        store.activate("temporal memory")
+
+        count = conn.execute(
+            "SELECT COUNT(*) FROM engram_associations"
+        ).fetchone()[0]
+        assert count >= 2  # bidirectional
+
+    def test_repeated_co_activation_strengthens(self, store, conn):
+        store.write(_make_entry("x", "temporal memory alpha", context="temporal memory"))
+        store.write(_make_entry("y", "temporal memory beta", context="temporal memory"))
+
+        # First activation
+        store.activate("temporal memory")
+        row1 = conn.execute(
+            "SELECT weight FROM engram_associations LIMIT 1"
+        ).fetchone()
+        w1 = row1["weight"]
+
+        # Second + third
+        store.activate("temporal memory")
+        store.activate("temporal memory")
+        row3 = conn.execute(
+            "SELECT weight FROM engram_associations LIMIT 1"
+        ).fetchone()
+        w3 = row3["weight"]
+
+        assert w3 > w1
+
+    def test_co_activation_count_increments(self, store, conn):
+        store.write(_make_entry("p", "temporal memory p", context="temporal memory"))
+        store.write(_make_entry("q", "temporal memory q", context="temporal memory"))
+        store.activate("temporal memory")
+        store.activate("temporal memory")
+
+        row = conn.execute(
+            "SELECT co_activation_count FROM engram_associations LIMIT 1"
+        ).fetchone()
+        assert row["co_activation_count"] >= 2
+
+
+class TestActivationLog:
+    """Activation log ring buffer."""
+
+    def test_activation_logged(self, store, conn):
+        store.write(_make_entry("k", "temporal memory activation", context="temporal memory"))
+        store.activate("temporal memory")
+
+        count = conn.execute(
+            "SELECT COUNT(*) FROM activation_log"
+        ).fetchone()[0]
+        assert count >= 1
+
+    def test_activation_log_query_context(self, store, conn):
+        store.write(_make_entry("k", "temporal memory ctx", context="temporal memory"))
+        store.activate("temporal memory")
+
+        row = conn.execute(
+            "SELECT query_context FROM activation_log ORDER BY log_id DESC LIMIT 1"
+        ).fetchone()
+        assert row["query_context"] == "temporal memory"


### PR DESCRIPTION
Closes #578

## Summary

Adds `CognitiveMemoryStore` — a `MemoryStore` ABC implementation backed by the SQLite engrams schema (#576) with cognitive scoring (#577).

### Key features:
- **Full MemoryStore ABC**: `write()`, `read()`, `delete()`, `query()`, `list_keys()`, `size()` — all operate against SQLite
- **`activate()` pipeline**: BM25 (FTS5) → ACT-R temporal scoring → Hebbian association boost → composite ranking
- **Learning on every read**: `read()` increments `access_count` and updates `last_access_at`
- **STM TTL enforcement**: Expired entries filtered on both `read()` and `activate()`
- **Hebbian co-activation**: `activate()` auto-strengthens associations between co-returned engrams
- **Activation log**: Ring buffer with per-tier pruning (last 50 entries)
- **Tier isolation**: Multiple `CognitiveMemoryStore` instances share one DB but filter by tier
- **Explainability**: `ActivationResult.why` shows score breakdown (BM25 + act_r + hebbian + confidence)

### `ActivationResult` dataclass:
```python
@dataclass
class ActivationResult:
    entry: MemoryEntry
    score: float
    why: str  # \"BM25(0.78) + act_r(0.94) + hebbian(0.16) confidence=0.95\"
```

## How to Test

```bash
.venv/bin/pytest tests/test_cognitive_store.py -v
```

25 tests covering CRUD, tier isolation, STM TTL, activation ranking (frequent beats rare), Hebbian weight evolution, activation log, and limit enforcement.