### PR TITLE
#579: Wire MemoryController to CognitiveMemoryStore backend

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -1,7 +1,7 @@
 memory:
   stm_max_tokens: 32768
   stm_ttl_seconds: 3600.0
-  ltm_backend: json
+  ltm_backend: sqlite
   ltm_storage_dir: data/memory
   pruning_interval_seconds: 3600.0
   forgetting_half_life_hours: 168.0

--- a/src/openbad/memory/controller.py
+++ b/src/openbad/memory/controller.py
@@ -7,18 +7,22 @@ STM to LTM, and exposes a unified query API across all memory tiers.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import sqlite3
 import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.memory.base import MemoryEntry, MemoryStore, MemoryTier
+from openbad.memory.cognitive_store import CognitiveMemoryStore
 from openbad.memory.config import MemoryConfig
 from openbad.memory.episodic import EpisodicMemory
 from openbad.memory.procedural import ProceduralMemory, Skill
 from openbad.memory.semantic import SemanticMemory, hash_embedding
 from openbad.memory.stm import ShortTermMemory
+from openbad.state.db import initialize_state_db
 
 logger = logging.getLogger(__name__)
 
@@ -86,16 +90,36 @@ class MemoryController:
             default_ttl=cfg.stm_ttl_seconds,
             publish_fn=publish_fn,
         )
-        self.episodic = EpisodicMemory(
-            storage_path=Path(storage_dir) / "episodic.json",
-        )
-        self.semantic = SemanticMemory(
-            embed_fn=embed_fn,
-            storage_path=Path(storage_dir) / "semantic.json",
-        )
-        self.procedural = ProceduralMemory(
-            storage_path=Path(storage_dir) / "procedural.json",
-        )
+
+        if cfg.ltm_backend == "sqlite":
+            db_path = Path(storage_dir) / ".." / "state.db"
+            conn = initialize_state_db(db_path)
+            self.episodic: MemoryStore = CognitiveMemoryStore(
+                conn, MemoryTier.EPISODIC,
+            )
+            self.semantic: MemoryStore = CognitiveMemoryStore(
+                conn, MemoryTier.SEMANTIC,
+            )
+            self.procedural: MemoryStore = CognitiveMemoryStore(
+                conn, MemoryTier.PROCEDURAL,
+            )
+            self._cognitive = True
+            self._db_conn: sqlite3.Connection | None = conn
+            _migrate_json_to_sqlite(storage_dir, conn)
+        else:
+            self.episodic = EpisodicMemory(
+                storage_path=Path(storage_dir) / "episodic.json",
+            )
+            self.semantic = SemanticMemory(
+                embed_fn=embed_fn,
+                storage_path=Path(storage_dir) / "semantic.json",
+            )
+            self.procedural = ProceduralMemory(
+                storage_path=Path(storage_dir) / "procedural.json",
+            )
+            self._cognitive = False
+            self._db_conn = None
+
         self._publish_fn = publish_fn
 
     # ------------------------------------------------------------------ #
@@ -190,10 +214,44 @@ class MemoryController:
     def recall(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
         """Recall memories ranked by relevance, with library ref annotations.
 
-        Searches semantic (scored) and episodic (recency) stores, then
-        annotates results whose ``metadata["library_refs"]`` contain book
-        IDs so the LLM knows exhaustive documentation is available.
+        When the cognitive backend is active, uses the ``activate()``
+        pipeline (BM25 + ACT-R + Hebbian).  Otherwise falls back to the
+        legacy cosine-similarity search.
         """
+        if self._cognitive:
+            return self._recall_cognitive(query, top_k)
+        return self._recall_legacy(query, top_k)
+
+    def _recall_cognitive(
+        self, query: str, top_k: int,
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+
+        for store_name in ("semantic", "episodic"):
+            store = getattr(self, store_name)
+            if not isinstance(store, CognitiveMemoryStore):
+                continue
+            try:
+                for ar in store.activate(query, limit=top_k):
+                    item: dict[str, Any] = {
+                        "key": ar.entry.key,
+                        "value": str(ar.entry.value),
+                        "tier": ar.entry.tier.value,
+                        "score": ar.score,
+                        "why": ar.why,
+                        "metadata": ar.entry.metadata,
+                    }
+                    _annotate_library_refs(item, ar.entry)
+                    results.append(item)
+            except Exception:
+                logger.exception("Cognitive recall failed for %s", store_name)
+
+        results.sort(key=lambda r: r["score"], reverse=True)
+        return results[:top_k]
+
+    def _recall_legacy(
+        self, query: str, top_k: int,
+    ) -> list[dict[str, Any]]:
         results: list[dict[str, Any]] = []
 
         # Semantic search — scored
@@ -266,3 +324,73 @@ def _annotate_library_refs(item: dict[str, Any], entry: MemoryEntry) -> None:
             f" Exhaustive documentation available in Library Book ID: {book_id}]"
         )
     item["library_annotations"] = annotations
+
+
+# ---------------------------------------------------------------------------
+# JSON → SQLite migration
+# ---------------------------------------------------------------------------
+
+_TIER_MAP = {
+    "episodic": MemoryTier.EPISODIC,
+    "semantic": MemoryTier.SEMANTIC,
+    "procedural": MemoryTier.PROCEDURAL,
+}
+
+
+def _migrate_json_to_sqlite(
+    storage_dir: Path,
+    conn: sqlite3.Connection,
+) -> None:
+    """One-time migration of JSON memory files into the engrams table.
+
+    Runs automatically on first startup when JSON files exist and the
+    engrams table is empty for that tier.  After successful migration
+    the JSON files are renamed to ``*.json.migrated``.
+    """
+    for name, tier in _TIER_MAP.items():
+        json_path = Path(storage_dir) / f"{name}.json"
+        if not json_path.exists():
+            continue
+
+        # Only migrate if the tier has no existing data
+        count = conn.execute(
+            "SELECT COUNT(*) FROM engrams WHERE tier = ?", (tier.value,),
+        ).fetchone()[0]
+        if count > 0:
+            continue
+
+        try:
+            raw = json.loads(json_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            logger.warning("Could not read %s for migration", json_path)
+            continue
+
+        entries: list[dict[str, Any]] = []
+        if isinstance(raw, dict):
+            # Typical format: { "entries": [...] } or bare { key: entry }
+            if "entries" in raw and isinstance(raw["entries"], list):
+                entries = raw["entries"]
+            else:
+                entries = list(raw.values())
+        elif isinstance(raw, list):
+            entries = raw
+
+        migrated = 0
+        store = CognitiveMemoryStore(conn, tier)
+        for data in entries:
+            if not isinstance(data, dict):
+                continue
+            try:
+                entry = MemoryEntry.from_dict(data)
+            except (KeyError, TypeError):
+                logger.debug("Skipping malformed entry during migration")
+                continue
+            store.write(entry)
+            migrated += 1
+
+        if migrated:
+            migrated_path = json_path.with_suffix(".json.migrated")
+            json_path.rename(migrated_path)
+            logger.info(
+                "Migrated %d %s entries from JSON to SQLite", migrated, name,
+            )

--- a/tests/test_memory_controller_sqlite.py
+++ b/tests/test_memory_controller_sqlite.py
@@ -1,0 +1,248 @@
+"""Tests for MemoryController wired to CognitiveMemoryStore backend."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from openbad.memory.cognitive_store import CognitiveMemoryStore
+from openbad.memory.config import MemoryConfig
+from openbad.memory.controller import MemoryController, _migrate_json_to_sqlite
+from openbad.memory.episodic import EpisodicMemory
+from openbad.state.db import initialize_state_db
+
+
+@pytest.fixture()
+def cfg(tmp_path):
+    """MemoryConfig pointed at a temp directory with sqlite backend."""
+    return MemoryConfig(
+        ltm_backend="sqlite",
+        ltm_storage_dir=tmp_path / "memory",
+    )
+
+
+@pytest.fixture()
+def ctrl(cfg, tmp_path):
+    """MemoryController with sqlite backend."""
+    # Ensure state.db parent exists
+    (cfg.ltm_storage_dir).mkdir(parents=True, exist_ok=True)
+    return MemoryController(config=cfg)
+
+
+class TestControllerSqliteInit:
+    """Controller initialises CognitiveMemoryStore when backend=sqlite."""
+
+    def test_stores_are_cognitive(self, ctrl):
+        assert isinstance(ctrl.episodic, CognitiveMemoryStore)
+        assert isinstance(ctrl.semantic, CognitiveMemoryStore)
+        assert isinstance(ctrl.procedural, CognitiveMemoryStore)
+
+    def test_cognitive_flag_set(self, ctrl):
+        assert ctrl._cognitive is True
+
+
+class TestControllerCRUD:
+    """Basic CRUD via the controller's convenience methods."""
+
+    def test_write_and_read_episodic(self, ctrl):
+        eid = ctrl.write_episodic("ep1", "an event happened")
+        assert eid
+        result = ctrl.read("ep1")
+        assert result is not None
+        assert result.value == "an event happened"
+
+    def test_write_and_read_semantic(self, ctrl):
+        ctrl.write_semantic("fact1", "the sky is blue")
+        result = ctrl.read("fact1")
+        assert result is not None
+        assert result.value == "the sky is blue"
+
+    def test_write_and_read_procedural(self, ctrl):
+        ctrl.write_procedural("skill1", "how to tie a knot")
+        result = ctrl.read("skill1")
+        assert result is not None
+
+    def test_write_stm_and_read(self, ctrl):
+        ctrl.write_stm("temp", "volatile data")
+        result = ctrl.read("temp")
+        assert result is not None
+        assert result.value == "volatile data"
+
+    def test_search_all(self, ctrl):
+        ctrl.write_episodic("mem-a", "event a")
+        ctrl.write_semantic("mem-b", "fact b")
+        results = ctrl.search_all("mem-")
+        assert len(results["episodic"]) == 1
+        assert len(results["semantic"]) == 1
+
+
+class TestPromotion:
+    """Tier promotion still works with cognitive backend."""
+
+    def test_promote_to_episodic(self, ctrl):
+        ctrl.write_stm("promo-ep", "event to promote")
+        eid = ctrl.promote_to_episodic("promo-ep")
+        assert eid is not None
+        # Should be in episodic now
+        assert ctrl.episodic.read("promo-ep") is not None
+        # Should be gone from STM
+        assert ctrl.stm.read("promo-ep") is None
+
+    def test_promote_to_semantic(self, ctrl):
+        ctrl.write_stm("promo-sem", "fact to promote")
+        eid = ctrl.promote_to_semantic("promo-sem")
+        assert eid is not None
+        assert ctrl.semantic.read("promo-sem") is not None
+        assert ctrl.stm.read("promo-sem") is None
+
+    def test_promote_nonexistent_returns_none(self, ctrl):
+        assert ctrl.promote_to_episodic("nope") is None
+
+
+class TestRecallCognitive:
+    """recall() uses activate() pipeline with cognitive backend."""
+
+    def test_recall_returns_results(self, ctrl):
+        ctrl.write_semantic(
+            "temporal-mem", "temporal memory scoring model",
+            context="temporal memory",
+        )
+        results = ctrl.recall("temporal memory")
+        assert len(results) >= 1
+        assert results[0]["key"] == "temporal-mem"
+
+    def test_recall_has_why(self, ctrl):
+        ctrl.write_semantic(
+            "scored", "temporal memory with ACT-R",
+            context="temporal memory",
+        )
+        results = ctrl.recall("temporal memory")
+        assert results
+        assert "why" in results[0]
+        assert "BM25" in results[0]["why"]
+
+    def test_recall_library_refs_annotated(self, ctrl):
+        ctrl.write_semantic(
+            "ref-entry", "temporal memory reference",
+            context="temporal memory",
+            metadata={"library_refs": ["book-123"]},
+        )
+        results = ctrl.recall("temporal memory")
+        assert results
+        # Find the entry with library refs
+        annotated = [r for r in results if "library_annotations" in r]
+        assert len(annotated) >= 1
+        assert "book-123" in annotated[0]["library_annotations"][0]
+
+    def test_recall_empty_query(self, ctrl):
+        results = ctrl.recall("")
+        assert isinstance(results, list)
+
+
+class TestStats:
+    """Stats still work."""
+
+    def test_stats_structure(self, ctrl):
+        s = ctrl.stats()
+        assert "stm" in s
+        assert "episodic" in s
+        assert "semantic" in s
+        assert "procedural" in s
+        assert "timestamp" in s
+
+
+# ------------------------------------------------------------------
+# JSON → SQLite migration
+# ------------------------------------------------------------------
+
+
+class TestJsonMigration:
+    """One-time JSON → SQLite data migration."""
+
+    def test_migrates_episodic_json(self, tmp_path):
+        # Create a JSON memory file
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        entries = [
+            {
+                "entry_id": "abc123",
+                "key": "event1",
+                "value": "something happened",
+                "tier": "episodic",
+                "created_at": time.time() - 3600,
+                "accessed_at": time.time(),
+                "access_count": 3,
+                "metadata": {},
+            },
+        ]
+        (mem_dir / "episodic.json").write_text(
+            json.dumps({"entries": entries}),
+        )
+
+        conn = initialize_state_db(tmp_path / "state.db")
+        _migrate_json_to_sqlite(mem_dir, conn)
+
+        # Data should be in SQLite
+        count = conn.execute(
+            "SELECT COUNT(*) FROM engrams WHERE tier = 'episodic'",
+        ).fetchone()[0]
+        assert count == 1
+
+        # JSON file should be renamed
+        assert not (mem_dir / "episodic.json").exists()
+        assert (mem_dir / "episodic.json.migrated").exists()
+        conn.close()
+
+    def test_skips_if_engrams_exist(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        entries = [
+            {
+                "entry_id": "old1",
+                "key": "old",
+                "value": "old data",
+                "tier": "semantic",
+                "metadata": {},
+            },
+        ]
+        (mem_dir / "semantic.json").write_text(json.dumps({"entries": entries}))
+
+        conn = initialize_state_db(tmp_path / "state.db")
+        # Pre-populate an engram
+        now = time.time()
+        conn.execute(
+            """INSERT INTO engrams (engram_id, tier, key, content,
+               created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)""",
+            ("existing", "semantic", "existing", "data", now, now),
+        )
+        conn.commit()
+
+        _migrate_json_to_sqlite(mem_dir, conn)
+
+        # JSON file should NOT be renamed (skipped)
+        assert (mem_dir / "semantic.json").exists()
+        conn.close()
+
+    def test_no_crash_on_missing_json(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        conn = initialize_state_db(tmp_path / "state.db")
+        # Should not crash even without any JSON files
+        _migrate_json_to_sqlite(mem_dir, conn)
+        conn.close()
+
+
+class TestLegacyBackend:
+    """json backend still works for backwards compatibility."""
+
+    def test_json_backend_creates_old_stores(self, tmp_path):
+        cfg = MemoryConfig(
+            ltm_backend="json",
+            ltm_storage_dir=tmp_path / "memory",
+        )
+        (tmp_path / "memory").mkdir()
+        ctrl = MemoryController(config=cfg)
+        assert not ctrl._cognitive
+        assert isinstance(ctrl.episodic, EpisodicMemory)


### PR DESCRIPTION
Closes #579

## Summary

Wires `MemoryController` to use `CognitiveMemoryStore` when `ltm_backend: sqlite` is set in config.

### Changes:
- **`controller.py`**: Dual-backend init — `sqlite` uses `CognitiveMemoryStore` for episodic/semantic/procedural; `json` preserves legacy `EpisodicMemory`/`SemanticMemory`/`ProceduralMemory`
- **`recall()`**: Routes to `_recall_cognitive()` (BM25+ACT-R+Hebbian via `activate()`) or `_recall_legacy()` based on backend
- **JSON → SQLite migration**: `_migrate_json_to_sqlite()` runs automatically on first startup; renames migrated files to `*.json.migrated`
- **`config/memory.yaml`**: Default backend changed to `sqlite`
- **Backwards compatible**: STM stays in-memory, `promote_to_*` methods work, `stats()` unchanged, callers don't need changes

## How to Test

```bash
.venv/bin/pytest tests/test_memory_controller_sqlite.py tests/test_memory_base.py -v
```

19 new tests + 20 existing base tests all pass.