### PR TITLE
#580: Sleep consolidation cognitive maintenance pipeline

### DIFF
--- a/src/openbad/memory/sleep/cognitive_maintenance.py
+++ b/src/openbad/memory/sleep/cognitive_maintenance.py
@@ -1,0 +1,318 @@
+"""Cognitive sleep maintenance — Hebbian decay, activation pruning, source linking.
+
+Runs as an optional post-pass after the existing STM → LTM consolidation
+and LLM-based orchestrator.  Operates directly on the SQLite engrams
+schema (migration 0007) to maintain cognitive health.
+
+Pipeline:
+1. Decay stale Hebbian association weights
+2. Prune activation log ring buffer
+3. Link new semantic engrams back to their episodic sources
+4. Purge soft-deleted engrams older than retention window
+5. Clean up expired STM entries
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from openbad.memory.cognitive import hebbian_decay
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CognitiveMaintenanceReport:
+    """Summary of cognitive maintenance work."""
+
+    associations_decayed: int = 0
+    associations_pruned: int = 0
+    activation_entries_pruned: int = 0
+    source_links_created: int = 0
+    soft_deleted_purged: int = 0
+    expired_stm_cleaned: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "associations_decayed": self.associations_decayed,
+            "associations_pruned": self.associations_pruned,
+            "activation_entries_pruned": self.activation_entries_pruned,
+            "source_links_created": self.source_links_created,
+            "soft_deleted_purged": self.soft_deleted_purged,
+            "expired_stm_cleaned": self.expired_stm_cleaned,
+            "errors": self.errors,
+        }
+
+
+def run_cognitive_maintenance(
+    conn: sqlite3.Connection,
+    *,
+    half_life_hours: float = 168.0,
+    decay_threshold: float = 0.01,
+    activation_log_limit: int = 500,
+    soft_delete_retention_days: float = 7.0,
+    publish_fn: Any | None = None,
+) -> CognitiveMaintenanceReport:
+    """Run the full cognitive maintenance pipeline.
+
+    Parameters
+    ----------
+    conn:
+        Open SQLite connection with the engrams schema.
+    half_life_hours:
+        Half-life for Hebbian decay (default: 1 week).
+    decay_threshold:
+        Associations below this weight after decay are pruned.
+    activation_log_limit:
+        Maximum activation log entries to retain.
+    soft_delete_retention_days:
+        Days before soft-deleted engrams are permanently purged.
+    publish_fn:
+        Optional ``(topic, payload)`` callback for MQTT events.
+    """
+    report = CognitiveMaintenanceReport()
+    now = time.time()
+
+    try:
+        _decay_hebbian_weights(conn, now, half_life_hours, decay_threshold, report)
+    except Exception as exc:
+        report.errors.append(f"hebbian_decay: {exc}")
+        logger.warning("Hebbian decay failed: %s", exc)
+
+    try:
+        _prune_activation_log(conn, activation_log_limit, report)
+    except Exception as exc:
+        report.errors.append(f"activation_prune: {exc}")
+        logger.warning("Activation log prune failed: %s", exc)
+
+    try:
+        _link_semantic_sources(conn, now, report)
+    except Exception as exc:
+        report.errors.append(f"source_linking: {exc}")
+        logger.warning("Source linking failed: %s", exc)
+
+    try:
+        _purge_soft_deleted(conn, now, soft_delete_retention_days, report)
+    except Exception as exc:
+        report.errors.append(f"soft_delete_purge: {exc}")
+        logger.warning("Soft-delete purge failed: %s", exc)
+
+    try:
+        _clean_expired_stm(conn, now, report)
+    except Exception as exc:
+        report.errors.append(f"stm_cleanup: {exc}")
+        logger.warning("STM cleanup failed: %s", exc)
+
+    if publish_fn is not None:
+        import json as _json
+
+        publish_fn(
+            "agent/sleep/consolidation",
+            _json.dumps(report.to_dict()).encode(),
+        )
+
+    logger.info(
+        "Cognitive maintenance: %d assoc decayed, %d pruned, "
+        "%d activation entries pruned, %d source links, "
+        "%d soft-deleted purged, %d expired STM cleaned",
+        report.associations_decayed,
+        report.associations_pruned,
+        report.activation_entries_pruned,
+        report.source_links_created,
+        report.soft_deleted_purged,
+        report.expired_stm_cleaned,
+    )
+    return report
+
+
+# ------------------------------------------------------------------
+# Hebbian decay
+# ------------------------------------------------------------------
+
+
+def _decay_hebbian_weights(
+    conn: sqlite3.Connection,
+    now: float,
+    half_life_hours: float,
+    threshold: float,
+    report: CognitiveMaintenanceReport,
+) -> None:
+    """Batch-decay all association weights; prune those below threshold."""
+    rows = conn.execute(
+        "SELECT source_id, target_id, weight, updated_at FROM engram_associations",
+    ).fetchall()
+
+    for row in rows:
+        hours_since = (now - row["updated_at"]) / 3600.0
+        if hours_since < 0.01:  # skip if updated less than ~36 seconds ago
+            continue
+
+        new_weight = hebbian_decay(row["weight"], hours_since, half_life_hours)
+
+        if new_weight < threshold:
+            conn.execute(
+                "DELETE FROM engram_associations WHERE source_id = ? AND target_id = ?",
+                (row["source_id"], row["target_id"]),
+            )
+            report.associations_pruned += 1
+        else:
+            conn.execute(
+                """UPDATE engram_associations
+                   SET weight = ?, updated_at = ?
+                   WHERE source_id = ? AND target_id = ?""",
+                (new_weight, now, row["source_id"], row["target_id"]),
+            )
+            report.associations_decayed += 1
+
+    conn.commit()
+
+
+# ------------------------------------------------------------------
+# Activation log pruning
+# ------------------------------------------------------------------
+
+
+def _prune_activation_log(
+    conn: sqlite3.Connection,
+    limit: int,
+    report: CognitiveMaintenanceReport,
+) -> None:
+    """Keep only the most recent *limit* activation entries."""
+    total = conn.execute("SELECT COUNT(*) FROM activation_log").fetchone()[0]
+    if total <= limit:
+        return
+
+    excess = total - limit
+    conn.execute(
+        """DELETE FROM activation_log
+           WHERE log_id IN (
+               SELECT log_id FROM activation_log
+               ORDER BY activated_at ASC
+               LIMIT ?
+           )""",
+        (excess,),
+    )
+    conn.commit()
+    report.activation_entries_pruned = excess
+
+
+# ------------------------------------------------------------------
+# Source linking
+# ------------------------------------------------------------------
+
+
+def _link_semantic_sources(
+    conn: sqlite3.Connection,
+    now: float,
+    report: CognitiveMaintenanceReport,
+) -> None:
+    """Create associations between semantic engrams and their episodic sources.
+
+    Looks for semantic engrams whose metadata contains
+    ``source_episodic_keys`` or ``promoted_from`` = ``"stm"`` with a
+    matching episodic key, and creates Hebbian links if none exist.
+    """
+    rows = conn.execute(
+        """SELECT engram_id, key, metadata FROM engrams
+           WHERE tier = 'semantic' AND state = 'active'
+             AND metadata LIKE '%source_episodic_keys%'""",
+    ).fetchall()
+
+    import json
+
+    for row in rows:
+        try:
+            meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+        source_keys = meta.get("source_episodic_keys", [])
+        if not source_keys:
+            continue
+
+        semantic_id = row["engram_id"]
+        for src_key in source_keys:
+            ep_row = conn.execute(
+                """SELECT engram_id FROM engrams
+                   WHERE key = ? AND tier = 'episodic'
+                     AND state = 'active'
+                   LIMIT 1""",
+                (src_key,),
+            ).fetchone()
+            if ep_row is None:
+                continue
+
+            episodic_id = ep_row["engram_id"]
+            # Only create if no link exists
+            existing = conn.execute(
+                """SELECT 1 FROM engram_associations
+                   WHERE source_id = ? AND target_id = ?""",
+                (semantic_id, episodic_id),
+            ).fetchone()
+            if existing:
+                continue
+
+            # Bidirectional link
+            for src, tgt in (
+                (semantic_id, episodic_id),
+                (episodic_id, semantic_id),
+            ):
+                conn.execute(
+                    """INSERT OR IGNORE INTO engram_associations
+                       (source_id, target_id, weight, co_activation_count,
+                        created_at, updated_at)
+                       VALUES (?, ?, 0.3, 1, ?, ?)""",
+                    (src, tgt, now, now),
+                )
+            report.source_links_created += 1
+
+    conn.commit()
+
+
+# ------------------------------------------------------------------
+# Soft-delete purge
+# ------------------------------------------------------------------
+
+
+def _purge_soft_deleted(
+    conn: sqlite3.Connection,
+    now: float,
+    retention_days: float,
+    report: CognitiveMaintenanceReport,
+) -> None:
+    """Permanently delete soft-deleted engrams older than retention window."""
+    cutoff = now - (retention_days * 86400.0)
+    cursor = conn.execute(
+        "DELETE FROM engrams WHERE state = 'soft_deleted' AND updated_at < ?",
+        (cutoff,),
+    )
+    conn.commit()
+    report.soft_deleted_purged = cursor.rowcount
+
+
+# ------------------------------------------------------------------
+# Expired STM cleanup
+# ------------------------------------------------------------------
+
+
+def _clean_expired_stm(
+    conn: sqlite3.Connection,
+    now: float,
+    report: CognitiveMaintenanceReport,
+) -> None:
+    """Remove STM entries whose TTL has expired."""
+    cursor = conn.execute(
+        """DELETE FROM engrams
+           WHERE tier = 'stm'
+             AND ttl_seconds IS NOT NULL
+             AND ttl_seconds > 0
+             AND (? - created_at) > ttl_seconds""",
+        (now,),
+    )
+    conn.commit()
+    report.expired_stm_cleaned = cursor.rowcount

--- a/tests/test_cognitive_maintenance.py
+++ b/tests/test_cognitive_maintenance.py
@@ -1,0 +1,298 @@
+"""Tests for cognitive sleep maintenance (Hebbian decay, activation pruning, etc.)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from openbad.memory.sleep.cognitive_maintenance import (
+    CognitiveMaintenanceReport,
+    run_cognitive_maintenance,
+)
+from openbad.state.db import initialize_state_db
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    db = initialize_state_db(tmp_path / "state.db")
+    yield db
+    db.close()
+
+
+def _insert_engram(conn, eid, tier="semantic", key=None, **kwargs):
+    now = kwargs.pop("now", time.time())
+    key = key or f"k-{eid}"
+    metadata = json.dumps(kwargs.pop("metadata", {}))
+    conn.execute(
+        """INSERT INTO engrams
+           (engram_id, tier, key, concept, content, created_at, updated_at,
+            metadata, state)
+           VALUES (?, ?, ?, '', '', ?, ?, ?, 'active')""",
+        (eid, tier, key, now, now, metadata),
+    )
+
+
+def _insert_assoc(conn, src, tgt, weight=0.5, updated_at=None):
+    now = updated_at or time.time()
+    conn.execute(
+        """INSERT INTO engram_associations
+           (source_id, target_id, weight, co_activation_count,
+            created_at, updated_at)
+           VALUES (?, ?, ?, 1, ?, ?)""",
+        (src, tgt, weight, now, now),
+    )
+
+
+# ------------------------------------------------------------------
+# Hebbian decay
+# ------------------------------------------------------------------
+
+
+class TestHebbianDecay:
+    """Association weights decay over time; weak ones get pruned."""
+
+    def test_weights_decay(self, conn):
+        _insert_engram(conn, "e1")
+        _insert_engram(conn, "e2")
+        # Association last updated 1 week ago
+        _insert_assoc(conn, "e1", "e2", weight=1.0, updated_at=time.time() - 168 * 3600)
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn, half_life_hours=168.0)
+        assert report.associations_decayed >= 1
+
+        row = conn.execute(
+            "SELECT weight FROM engram_associations WHERE source_id = 'e1'"
+        ).fetchone()
+        assert row is not None
+        assert row["weight"] < 1.0
+        # At exactly 1 half-life, weight ≈ 0.5
+        assert abs(row["weight"] - 0.5) < 0.05
+
+    def test_very_weak_associations_pruned(self, conn):
+        _insert_engram(conn, "e1")
+        _insert_engram(conn, "e2")
+        # Very old, will decay below threshold
+        _insert_assoc(
+            conn, "e1", "e2", weight=0.01,
+            updated_at=time.time() - 10000 * 3600,
+        )
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn, decay_threshold=0.01)
+        assert report.associations_pruned >= 1
+        count = conn.execute(
+            "SELECT COUNT(*) FROM engram_associations"
+        ).fetchone()[0]
+        assert count == 0
+
+    def test_fresh_associations_unchanged(self, conn):
+        _insert_engram(conn, "e1")
+        _insert_engram(conn, "e2")
+        _insert_assoc(conn, "e1", "e2", weight=0.5)  # just created
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn)
+        # Should not decay (updated_at == now)
+        assert report.associations_decayed == 0
+        assert report.associations_pruned == 0
+
+
+# ------------------------------------------------------------------
+# Activation log pruning
+# ------------------------------------------------------------------
+
+
+class TestActivationLogPruning:
+    """Ring buffer capped at configured limit."""
+
+    def test_prunes_excess(self, conn):
+        _insert_engram(conn, "e1")
+        now = time.time()
+        for i in range(20):
+            conn.execute(
+                "INSERT INTO activation_log (engram_id, activated_at) VALUES (?, ?)",
+                ("e1", now + i),
+            )
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn, activation_log_limit=10)
+        assert report.activation_entries_pruned == 10
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM activation_log"
+        ).fetchone()[0]
+        assert remaining == 10
+
+    def test_no_prune_under_limit(self, conn):
+        _insert_engram(conn, "e1")
+        conn.execute(
+            "INSERT INTO activation_log (engram_id, activated_at) VALUES (?, ?)",
+            ("e1", time.time()),
+        )
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn, activation_log_limit=500)
+        assert report.activation_entries_pruned == 0
+
+
+# ------------------------------------------------------------------
+# Source linking
+# ------------------------------------------------------------------
+
+
+class TestSourceLinking:
+    """Semantic → episodic associations from source_episodic_keys metadata."""
+
+    def test_creates_links(self, conn):
+        _insert_engram(conn, "ep1", tier="episodic", key="event-a")
+        _insert_engram(
+            conn, "sem1", tier="semantic",
+            metadata={"source_episodic_keys": ["event-a"]},
+        )
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn)
+        assert report.source_links_created == 1
+
+        # Bidirectional
+        count = conn.execute(
+            "SELECT COUNT(*) FROM engram_associations"
+        ).fetchone()[0]
+        assert count == 2
+
+    def test_no_duplicate_links(self, conn):
+        _insert_engram(conn, "ep1", tier="episodic", key="event-a")
+        _insert_engram(
+            conn, "sem1", tier="semantic",
+            metadata={"source_episodic_keys": ["event-a"]},
+        )
+        conn.commit()
+
+        # Run twice
+        run_cognitive_maintenance(conn)
+        report = run_cognitive_maintenance(conn)
+        assert report.source_links_created == 0
+
+    def test_skips_missing_episodic(self, conn):
+        _insert_engram(
+            conn, "sem1", tier="semantic",
+            metadata={"source_episodic_keys": ["nonexistent"]},
+        )
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn)
+        assert report.source_links_created == 0
+
+
+# ------------------------------------------------------------------
+# Soft-delete purge
+# ------------------------------------------------------------------
+
+
+class TestSoftDeletePurge:
+    """Permanently remove old soft-deleted engrams."""
+
+    def test_purges_old_soft_deleted(self, conn):
+        now = time.time()
+        old = now - 10 * 86400  # 10 days ago
+        conn.execute(
+            """INSERT INTO engrams
+               (engram_id, tier, key, created_at, updated_at, state)
+               VALUES (?, ?, ?, ?, ?, 'soft_deleted')""",
+            ("old1", "episodic", "k-old", old, old),
+        )
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn, soft_delete_retention_days=7.0)
+        assert report.soft_deleted_purged == 1
+
+    def test_keeps_recent_soft_deleted(self, conn):
+        now = time.time()
+        conn.execute(
+            """INSERT INTO engrams
+               (engram_id, tier, key, created_at, updated_at, state)
+               VALUES (?, ?, ?, ?, ?, 'soft_deleted')""",
+            ("new1", "episodic", "k-new", now, now),
+        )
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn, soft_delete_retention_days=7.0)
+        assert report.soft_deleted_purged == 0
+
+    def test_active_entries_untouched(self, conn):
+        _insert_engram(conn, "active1", now=time.time() - 30 * 86400)
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn)
+        assert report.soft_deleted_purged == 0
+        count = conn.execute(
+            "SELECT COUNT(*) FROM engrams WHERE state = 'active'"
+        ).fetchone()[0]
+        assert count == 1
+
+
+# ------------------------------------------------------------------
+# Expired STM cleanup
+# ------------------------------------------------------------------
+
+
+class TestExpiredSTMCleanup:
+    """STM entries with expired TTL are removed."""
+
+    def test_cleans_expired(self, conn):
+        old = time.time() - 7200  # 2 hours ago
+        conn.execute(
+            """INSERT INTO engrams
+               (engram_id, tier, key, created_at, updated_at, ttl_seconds, state)
+               VALUES (?, ?, ?, ?, ?, ?, 'active')""",
+            ("stm1", "stm", "temp", old, old, 3600.0),
+        )
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn)
+        assert report.expired_stm_cleaned == 1
+
+    def test_keeps_non_expired(self, conn):
+        now = time.time()
+        conn.execute(
+            """INSERT INTO engrams
+               (engram_id, tier, key, created_at, updated_at, ttl_seconds, state)
+               VALUES (?, ?, ?, ?, ?, ?, 'active')""",
+            ("stm1", "stm", "temp", now, now, 9999.0),
+        )
+        conn.commit()
+
+        report = run_cognitive_maintenance(conn)
+        assert report.expired_stm_cleaned == 0
+
+
+# ------------------------------------------------------------------
+# Report
+# ------------------------------------------------------------------
+
+
+class TestReport:
+    """Report dataclass serialisation."""
+
+    def test_to_dict(self):
+        r = CognitiveMaintenanceReport(
+            associations_decayed=5,
+            associations_pruned=2,
+            activation_entries_pruned=10,
+        )
+        d = r.to_dict()
+        assert d["associations_decayed"] == 5
+        assert d["associations_pruned"] == 2
+        assert d["activation_entries_pruned"] == 10
+
+    def test_publish_fn_called(self, conn):
+        published = []
+
+        def capture(topic, payload):
+            published.append((topic, payload))
+
+        run_cognitive_maintenance(conn, publish_fn=capture)
+        assert len(published) == 1
+        assert published[0][0] == "agent/sleep/consolidation"


### PR DESCRIPTION
Closes #580

## Summary

Adds `src/openbad/memory/sleep/cognitive_maintenance.py` — a post-pass pipeline that runs after existing STM→LTM consolidation to maintain cognitive health:

- **Hebbian decay worker**: Batch-decays all association weights using exponential decay with configurable half-life; prunes associations below threshold
- **Activation log pruner**: Caps the activation_log table to a configurable limit (default 500), removing oldest entries
- **Semantic → episodic source linking**: Creates bidirectional Hebbian associations between semantic engrams and their episodic sources (via `source_episodic_keys` metadata)
- **Soft-delete purge**: Permanently removes `soft_deleted` engrams older than retention window (default 7 days)
- **Expired STM cleanup**: Removes STM engrams with expired TTL directly from SQLite
- **MQTT publish**: Reports `CognitiveMaintenanceReport` to `agent/sleep/consolidation`

### What is NOT deleted
- Active episodic memories are never removed by consolidation (total recall)
- Only `soft_deleted` engrams past retention window and expired STM are cleaned

## How to Test

```bash
.venv/bin/pytest tests/test_cognitive_maintenance.py -v
```

15 tests covering all pipeline stages, edge cases (fresh associations untouched, no prune under limit, duplicate link prevention), and the report/publish interface.