### PR TITLE
#589: Add Corsair sidecar bootstrap — scaffold, config, systemd unit

### DIFF
--- a/12-OpenBaD Peripheral Transducers & Systemd.md
+++ b/12-OpenBaD Peripheral Transducers & Systemd.md
@@ -1,90 +1,150 @@
-# **Phase 12: Peripheral Transducers and Systemd Orchestration**
+# **Phase 12: Peripheral Transducers — Corsair Integration**
 
 ## **Purpose**
 
-To integrate persistent external communications (e.g., Discord, Slack, Webhooks) into OpenBaD without compromising the autonomic heartbeat loop. Rather than building blocking "Gateway" tools that starve the execution DAG, external integrations will be built as **Peripheral Transducers**—isolated, long-lived background microservices.
+Integrate persistent external communications (Discord, Slack, Gmail, GitHub, Telegram, etc.) into OpenBaD without compromising the autonomic heartbeat loop. Instead of building per-platform transducer microservices from scratch, leverage **Corsair** (Apache 2.0) — a TypeScript integration layer that exposes 40+ platform connectors behind a unified MCP interface.
 
-These transducers will be dynamically managed by the WUI as Linux systemd user services, ensuring high availability, crash recovery, and strict process isolation. They communicate with the core cognitive daemon exclusively via the MQTT nervous system.
+Corsair runs as a **single Node.js sidecar process** managed by systemd. The cognitive daemon talks to it through the existing `mcp_bridge()` tool for egress, while a thin **MQTT bridge** converts Corsair webhook callbacks into nervous-system events for ingress. The WUI provides an operator control surface for enabling plugins, storing credentials, and monitoring health.
+
+## **Architecture**
+
+```
+┌───────────────────────────────────────────────┐
+│  Corsair MCP Sidecar  (Node.js)               │
+│  openbad-corsair.service                       │
+│  ┌───────────────────────────────────────────┐ │
+│  │ Plugins: slack(), discord(), gmail(), ... │ │
+│  │ Auth / rate-limit / API versioning        │ │
+│  │ MCP stdio server (4 tools)                │ │
+│  │   corsair_setup                           │ │
+│  │   list_operations                         │ │
+│  │   get_schema                              │ │
+│  │   corsair_run                             │ │
+│  └───────────────────────────────────────────┘ │
+│  ┌───────────────────────────────────────────┐ │
+│  │ Webhook listener  (HTTP on 127.0.0.1)     │ │
+│  │ POST /webhook/{platform} → stdout JSON    │ │
+│  └───────────────────────────────────────────┘ │
+└────────────┬──────────────────────────────────┘
+             │ stdio / HTTP loopback
+┌────────────┴──────────────────────────────────┐
+│  OpenBaD Daemon  (Python)                      │
+│                                                │
+│  ┌──────────────────────────────────────────┐  │
+│  │ transmit_message  (Level 1 skill)        │  │
+│  │  → mcp_bridge("corsair", "corsair_run",  │  │
+│  │     {plugin, operation, params})          │  │
+│  └──────────────────────────────────────────┘  │
+│  ┌──────────────────────────────────────────┐  │
+│  │ Webhook → MQTT bridge                    │  │
+│  │  aiohttp route: POST /api/webhooks/corsair│ │
+│  │  → publish sensory/external/{plat}/inbound│ │
+│  └──────────────────────────────────────────┘  │
+│  ┌──────────────────────────────────────────┐  │
+│  │ Active inference ingress handler         │  │
+│  │  subscribe sensory/external/+/inbound    │  │
+│  │  → STM + surprise calc → optional task   │  │
+│  └──────────────────────────────────────────┘  │
+└────────────────────────────────────────────────┘
+```
 
 ## **Goals**
 
-1. Establish a native OS-level service manager within the WUI to generate and control systemd services dynamically.  
-2. Implement a base Transducer architecture for persistent external connections.  
-3. Build a universal Level 1 egress tool (transmit\_message) allowing the cognitive engine to route outbound messages via MQTT without knowing specific API protocols.  
-4. Create a comprehensive WUI frontend (/transducers) for operators to configure, enable, and monitor active sensory peripherals.
+1. Install and configure Corsair as a systemd sidecar service with declarative plugin config.
+2. Build a `transmit_message` Level 1 skill that routes outbound messages through Corsair's MCP interface.
+3. Bridge Corsair webhook events into the MQTT nervous system for autonomic ingress.
+4. Wire the active-inference engine to react to external inbound signals.
+5. Provide a WUI frontend (`/transducers`) for operators to enable plugins, manage credentials, and monitor health.
 
-## ---
+---
 
-**Task 1: The WUI Systemd Manager**
+## **Task 1: Corsair Sidecar Bootstrap**
 
-**Objective:** Grant the WUI server the ability to securely manage Linux user services for dynamic peripherals.
+**Objective:** Install Corsair and run it as a managed systemd service alongside the daemon.
 
-* \[ \] **1.1: Create SystemManager Module**  
-  * Create src/openbad/wui/system\_manager.py.  
-  * Implement an asynchronous class utilizing subprocess to execute systemctl \--user commands.  
-  * Required methods: enable\_service(name, config), disable\_service(name), get\_status(name), and stream\_logs(name).  
-* \[ \] **1.2: Dynamic Unit File Generation**  
-  * Implement a template engine within system\_manager.py that writes .service files directly to \~/.config/systemd/user/.  
-  * Ensure the templates include After=openbad-broker.service and Restart=always to guarantee resilience.  
-* \[ \] **1.3: Expose API Endpoints**  
-  * In src/openbad/wui/server.py, expose REST/WebSocket endpoints for the Svelte frontend to interface with the SystemManager (e.g., POST /api/transducers/enable, GET /api/transducers/status).
+- **1.1: Create Corsair project scaffold**
+  - Create `src/openbad/peripherals/corsair/` directory.
+  - Add `package.json` with `corsair` and `@corsair-dev/mcp` dependencies.
+  - Create `corsair.ts` entry point that reads plugin config from `config/peripherals.yaml` and starts the MCP stdio server.
+- **1.2: Plugin configuration file**
+  - Create `config/peripherals.yaml` with a `corsair.plugins` list (each entry: plugin name, enabled flag, credential reference).
+  - Credentials stored separately in `data/config/peripherals/` (file-per-plugin, `0600` permissions).
+- **1.3: Systemd unit file**
+  - Create `config/openbad-corsair.service` — runs as the `openbad` user, `After=openbad-broker.service`, `Restart=always`.
+  - `ExecStart` invokes `node` on the compiled Corsair entry point.
+- **1.4: Install script integration**
+  - Extend `scripts/install.sh` to `npm install` the Corsair sidecar and install the systemd unit.
 
-## **Task 2: Transducer Base Architecture & Implementations**
+## **Task 2: `transmit_message` Egress Skill**
 
-**Objective:** Create the isolated microservices that translate external protocols into OpenBaD's internal MQTT events.
+**Objective:** Give the cognitive engine a single, abstract capability to speak to external platforms.
 
-* \[ \] **2.1: Establish the Peripherals Directory**  
-  * Create the src/openbad/peripherals/ namespace.  
-  * Create base\_transducer.py. This class must inherit or utilize src/openbad/nervous\_system/client.py to establish a persistent MQTT connection on boot.  
-* \[ \] **2.2: Implement Liveness & Health Pings**  
-  * Ensure base\_transducer.py publishes a retained {"status": "online"} payload to system/transducers/{platform}/health upon successful external connection.  
-  * Establish a graceful shutdown hook that publishes {"status": "offline"} upon exit.  
-* \[ \] **2.3: Build the First Transducer (Discord/Slack Example)**  
-  * Create src/openbad/peripherals/discord\_transducer.py (or target platform).  
-  * **Ingress:** Listen to the external WebSocket. On new message, format to OpenBaD Protobuf schema and publish to sensory/external/discord/inbound.  
-  * **Egress:** Subscribe to motor/external/discord/outbound. Upon receiving an MQTT payload, transmit it over the external WebSocket.
+- **2.1: Create `transmit_message` skill**
+  - Add `transmit_message(platform, operation, target, content)` to `src/openbad/skills/server.py` as a `@skill_server.tool()`.
+  - Implementation: call `mcp_bridge("corsair", "corsair_run", {plugin: platform, operation: operation, params: {target, content}})`.
+  - Return the Corsair response (success/error) to the LLM.
+- **2.2: Register in capability catalog**
+  - Add `transmit_message` to the Level 1 capability registry in `src/openbad/wui/server.py` so it appears in the toolbelt.
+  - Assign `ToolRole.COMMUNICATION` in the proprioception registry.
 
-## **Task 3: Universal Level 1 Egress Tool**
+## **Task 3: Webhook Ingress Bridge**
 
-**Objective:** Give the core daemon a single, abstract capability to speak to the outside world without context window bloat.
+**Objective:** Route inbound Corsair webhook events into the MQTT nervous system.
 
-* \[ \] **3.1: Create transmit\_message.py**  
-  * Create src/openbad/toolbelt/transmit\_message.py.  
-  * Define the schema for the cognitive router: transmit\_message(platform: str, target\_id: str, content: str).  
-* \[ \] **3.2: Heartbeat Execution Logic**  
-  * Ensure this tool operates on a standard heartbeat lease.  
-  * The tool logic simply formats the payload and publishes it to the MQTT broker at motor/external/{platform}/outbound. It does not handle HTTP requests or external API limits.  
-* \[ \] **3.3: Register as Trusted Capability**  
-  * Add transmit\_message to the default Level 1 capability registry so it is always available to the CognitiveEventLoop.
+- **3.1: Add webhook endpoint**
+  - In `src/openbad/wui/server.py`, add `POST /api/webhooks/corsair` handler.
+  - Validate HMAC signature (Corsair webhook secret from config).
+  - Parse platform and event type from the payload.
+- **3.2: Publish to MQTT**
+  - Publish parsed event to `sensory/external/{platform}/inbound` as a JSON-encoded MQTT message.
+  - Add topic constants to `src/openbad/nervous_system/topics.py`:
+    - `EXTERNAL_INBOUND = "sensory/external/{platform}/inbound"`
+    - `EXTERNAL_OUTBOUND = "motor/external/{platform}/outbound"`
+- **3.3: Health topic**
+  - On Corsair sidecar startup, publish retained `{"status": "online"}` to `system/peripherals/corsair/health`.
+  - On graceful shutdown, publish `{"status": "offline"}`.
+  - Add a proprioception health check that monitors this retained message.
 
 ## **Task 4: Autonomic Ingress Routing**
 
-**Objective:** Ensure the core daemon reacts to incoming peripheral signals correctly.
+**Objective:** Ensure the daemon reacts to incoming external signals correctly.
 
-* \[ \] **4.1: Extend Active Inference Hooks**  
-  * Modify src/openbad/active\_inference/engine.py or the FSM (src/openbad/reflex\_arc/fsm.py) to subscribe to sensory/external/+/inbound.  
-  * When an external payload arrives, push it to Short-Term Memory (stm.py) and trigger a surprise/interest calculation to determine if a reactive TaskNode should be generated.
+- **4.1: Subscribe to external inbound**
+  - In `src/openbad/daemon.py`, subscribe to `sensory/external/+/inbound`.
+  - On message: push to Short-Term Memory via `CognitiveMemoryStore.write()` with tier `stm`.
+- **4.2: Surprise calculation**
+  - Add `ExternalSignalPlugin` to `src/openbad/active_inference/engine.py` as an `ObservationPlugin`.
+  - Default prediction: 0 external messages per interval.
+  - When inbound messages arrive, prediction error triggers surprise → potential task generation.
 
-## **Task 5: WUI Frontend Surface (/transducers)**
+## **Task 5: WUI Frontend (`/transducers`)**
 
-**Objective:** Provide a visual catalog and control panel for the operator.
+**Objective:** Operator control panel for peripheral integrations.
 
-* \[ \] **5.1: Create the Transducers Route**  
-  * Generate wui-svelte/src/routes/transducers/+page.svelte.  
-* \[ \] **5.2: Build the Catalog Component**  
-  * Create a grid UI displaying available/supported peripherals (dynamically pulled from the src/openbad/peripherals/ directory manifests).  
-* \[ \] **5.3: Configuration Modal**  
-  * Implement a modal that prompts for necessary API tokens/keys when activating a peripheral.  
-  * Ensure the submitted configuration is saved securely to data/config/peripherals/ before the systemctl launch command is issued.  
-* \[ \] **5.4: Live Status & Log Streaming**  
-  * Bind the UI to the MQTT system/transducers/+/health topics to display glowing green/red status dots in real-time.  
-  * Add a "View Logs" button that streams the journalctl \--user \-u openbad-peripheral-{name} output directly into a Svelte terminal component for easy debugging.
+- **5.1: Backend API endpoints**
+  - `GET /api/transducers` — list available plugins with enabled/disabled status.
+  - `PUT /api/transducers/{plugin}` — enable/disable a plugin and save credentials.
+  - `GET /api/transducers/{plugin}/health` — return Corsair health for this plugin.
+  - `POST /api/transducers/{plugin}/test` — send a test message via `corsair_run`.
+- **5.2: Create the Transducers route**
+  - Create `wui-svelte/src/routes/transducers/+page.svelte`.
+  - Grid layout showing available plugins with enable/disable toggles and status indicators.
+- **5.3: Configuration modal**
+  - Modal for entering API tokens/keys when enabling a plugin.
+  - Tokens sent to the backend for secure storage (never stored in the frontend).
+- **5.4: Live health indicators**
+  - Subscribe to MQTT `system/peripherals/corsair/health` via the existing WUI WebSocket bridge.
+  - Green/red status dots per plugin. "View Logs" button streams `journalctl -u openbad-corsair` output.
+
+---
 
 ## **Definition of Done**
 
-Phase 11 is complete when:
+Phase 12 is complete when:
 
-1. A user can input a bot token in the WUI, resulting in a live, OS-managed background process.  
-2. An external message to that bot appears seamlessly on the OpenBaD internal MQTT bus.  
-3. The OpenBaD daemon can use the transmit\_message Level 1 tool to successfully reply to the external platform.  
-4. Restarting the WUI or the core daemon does not cause the external transducer process to disconnect or drop messages.
+1. An operator can enable a Corsair plugin (e.g., Discord) in the WUI by entering credentials.
+2. The `transmit_message` skill successfully sends a message to an external platform via Corsair.
+3. An inbound webhook event from an external platform appears on the MQTT bus at `sensory/external/{platform}/inbound`.
+4. The active-inference engine detects the inbound signal and creates an STM entry (with optional task generation on surprise).
+5. Restarting the WUI or the core daemon does not crash the Corsair sidecar (independent systemd lifecycle).
+6. All new code has unit tests. Integration tests verify the egress skill and webhook bridge end-to-end.

--- a/config/openbad-corsair.service
+++ b/config/openbad-corsair.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=OpenBaD Corsair MCP Sidecar
+Documentation=https://github.com/bruceamoser/OpenBaD
+After=openbad-broker.service network-online.target
+Wants=network-online.target
+Wants=openbad-broker.service
+
+[Service]
+Type=simple
+User=openbad
+Group=openbad
+ExecStart=/usr/bin/node /opt/openbad/peripherals/corsair/dist/corsair.js
+ExecStop=/bin/kill -TERM $MAINPID
+Restart=always
+RestartSec=5s
+TimeoutStopSec=15s
+
+# Environment
+Environment=OPENBAD_PERIPHERALS_CONFIG=/etc/openbad/peripherals.yaml
+Environment=NODE_ENV=production
+WorkingDirectory=/opt/openbad/peripherals/corsair
+
+# Security hardening (match openbad.service)
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/lib/openbad /var/log/openbad
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+# Resource limits
+LimitNOFILE=4096
+MemoryMax=256M
+
+[Install]
+WantedBy=multi-user.target

--- a/config/peripherals.yaml
+++ b/config/peripherals.yaml
@@ -1,0 +1,27 @@
+# Peripheral Transducers — Corsair Integration
+# See: 12-OpenBaD Peripheral Transducers & Systemd.md
+
+corsair:
+  # Path to the compiled Corsair MCP entry point.
+  entry_point: /opt/openbad/peripherals/corsair/dist/corsair.js
+  # HMAC secret for validating inbound webhook payloads.
+  # Override in /etc/openbad/peripherals.yaml for production.
+  webhook_secret: ""
+
+  plugins:
+    # Each plugin maps to a Corsair integration package.
+    # enabled: whether the sidecar should load this plugin on startup.
+    # credentials_file: path (relative to data/config/peripherals/) where
+    #   the plugin's API tokens are stored (0600 permissions).
+    #
+    # Example:
+    # - name: discord
+    #   enabled: false
+    #   credentials_file: discord.json
+    # - name: slack
+    #   enabled: false
+    #   credentials_file: slack.json
+    # - name: gmail
+    #   enabled: false
+    #   credentials_file: gmail.json
+    []

--- a/src/openbad/peripherals/__init__.py
+++ b/src/openbad/peripherals/__init__.py
@@ -1,0 +1,1 @@
+"""Peripheral transducers — external integration subsystem."""

--- a/src/openbad/peripherals/config.py
+++ b/src/openbad/peripherals/config.py
@@ -1,0 +1,133 @@
+"""Configuration loader for the Corsair peripheral transducer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# Default config search paths (production → repo fallback).
+_DEFAULT_SEARCH_PATHS: list[Path] = [
+    Path("/etc/openbad/peripherals.yaml"),
+    Path("config/peripherals.yaml"),
+]
+
+# Where per-plugin credential files live.
+_DEFAULT_CREDENTIALS_DIR = Path("data/config/peripherals")
+
+
+@dataclass(frozen=True)
+class PluginConfig:
+    """A single Corsair plugin entry."""
+
+    name: str
+    enabled: bool = False
+    credentials_file: str = ""
+
+
+@dataclass(frozen=True)
+class CorsairConfig:
+    """Top-level Corsair sidecar configuration."""
+
+    entry_point: str = ""
+    webhook_secret: str = ""
+    plugins: list[PluginConfig] = field(default_factory=list)
+
+
+def _resolve_config_path(
+    explicit: Path | None = None,
+    search_paths: list[Path] | None = None,
+) -> Path | None:
+    """Return the first existing config file from *search_paths*."""
+    if explicit is not None:
+        return explicit if explicit.is_file() else None
+    for candidate in search_paths or _DEFAULT_SEARCH_PATHS:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def load_peripherals_config(
+    path: Path | None = None,
+) -> CorsairConfig:
+    """Load and validate the peripherals YAML config.
+
+    Parameters
+    ----------
+    path:
+        Explicit path to the YAML file.  When *None* the standard
+        search order is used (``/etc/openbad`` → ``config/``).
+
+    Returns
+    -------
+    CorsairConfig
+        Parsed, validated configuration.  Returns a default (empty) config
+        when no file is found.
+    """
+    resolved = _resolve_config_path(path)
+    if resolved is None:
+        return CorsairConfig()
+
+    raw = yaml.safe_load(resolved.read_text(encoding="utf-8")) or {}
+    corsair_raw = raw.get("corsair", {})
+    if not isinstance(corsair_raw, dict):
+        return CorsairConfig()
+
+    plugins: list[PluginConfig] = []
+    for entry in corsair_raw.get("plugins", []) or []:
+        if isinstance(entry, dict) and "name" in entry:
+            plugins.append(
+                PluginConfig(
+                    name=entry["name"],
+                    enabled=bool(entry.get("enabled", False)),
+                    credentials_file=str(entry.get("credentials_file", "")),
+                )
+            )
+
+    return CorsairConfig(
+        entry_point=str(corsair_raw.get("entry_point", "")),
+        webhook_secret=str(corsair_raw.get("webhook_secret", "")),
+        plugins=plugins,
+    )
+
+
+def resolve_credentials_path(
+    plugin: PluginConfig,
+    credentials_dir: Path | None = None,
+) -> Path | None:
+    """Return the absolute path to a plugin's credentials file.
+
+    Returns *None* when:
+    - ``plugin.credentials_file`` is empty, or
+    - the resolved file does not exist.
+    """
+    if not plugin.credentials_file:
+        return None
+
+    base = credentials_dir or _DEFAULT_CREDENTIALS_DIR
+    candidate = base / plugin.credentials_file
+
+    if not candidate.is_file():
+        return None
+
+    # Warn (but don't block) if permissions are too open.
+    try:
+        mode = candidate.stat().st_mode & 0o777
+        if mode & 0o077:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Credentials file %s has mode %04o — expected 0600.",
+                candidate,
+                mode,
+            )
+    except OSError:
+        pass
+
+    return candidate
+
+
+def enabled_plugin_names(cfg: CorsairConfig) -> list[str]:
+    """Return the names of all enabled plugins."""
+    return [p.name for p in cfg.plugins if p.enabled]

--- a/src/openbad/peripherals/corsair/corsair.ts
+++ b/src/openbad/peripherals/corsair/corsair.ts
@@ -1,0 +1,120 @@
+/**
+ * OpenBaD Corsair MCP Sidecar
+ *
+ * Reads plugin configuration from peripherals.yaml and starts a Corsair
+ * MCP stdio server.  The OpenBaD daemon communicates with this process
+ * via stdio (mcp_bridge) for egress and HTTP webhooks for ingress.
+ *
+ * Usage:
+ *   OPENBAD_PERIPHERALS_CONFIG=/etc/openbad/peripherals.yaml node dist/corsair.js
+ */
+
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+
+// Corsair imports — resolved after `npm install`.
+// @ts-ignore — packages may not be installed in the dev environment yet.
+import { createCorsair } from "corsair";
+// @ts-ignore
+import { runStdioMcpServer } from "@corsair-dev/mcp";
+
+/* ------------------------------------------------------------------ */
+/*  Configuration                                                      */
+/* ------------------------------------------------------------------ */
+
+interface PluginEntry {
+  name: string;
+  enabled: boolean;
+  credentials_file?: string;
+}
+
+interface PeripheralsConfig {
+  corsair?: {
+    entry_point?: string;
+    webhook_secret?: string;
+    plugins?: PluginEntry[];
+  };
+}
+
+function loadConfig(): PeripheralsConfig {
+  const configPath =
+    process.env.OPENBAD_PERIPHERALS_CONFIG ??
+    "/etc/openbad/peripherals.yaml";
+  const raw = readFileSync(configPath, "utf-8");
+  return (parse(raw) as PeripheralsConfig) ?? {};
+}
+
+/* ------------------------------------------------------------------ */
+/*  Dynamic plugin loader                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Dynamically import Corsair plugin functions by name.
+ *
+ * Each enabled plugin (e.g. "discord") is expected to be importable as
+ * `@corsair-dev/discord` and to export a default factory function.
+ */
+async function loadPlugins(entries: PluginEntry[]): Promise<any[]> {
+  const loaded: any[] = [];
+  for (const entry of entries) {
+    if (!entry.enabled) continue;
+    try {
+      // Corsair packages follow @corsair-dev/{name} or corsair-{name}
+      // Try the scoped package first, then the unscoped variant.
+      let mod: any;
+      try {
+        mod = await import(`@corsair-dev/${entry.name}`);
+      } catch {
+        mod = await import(`corsair-${entry.name}`);
+      }
+      const factory = mod.default ?? mod[entry.name];
+      if (typeof factory === "function") {
+        loaded.push(factory());
+        console.error(`[corsair] Loaded plugin: ${entry.name}`);
+      } else {
+        console.error(`[corsair] Plugin ${entry.name}: no factory export found`);
+      }
+    } catch (err) {
+      console.error(`[corsair] Failed to load plugin ${entry.name}:`, err);
+    }
+  }
+  return loaded;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                               */
+/* ------------------------------------------------------------------ */
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const pluginEntries = config.corsair?.plugins ?? [];
+
+  const enabledPlugins = await loadPlugins(pluginEntries);
+
+  if (enabledPlugins.length === 0) {
+    console.error(
+      "[corsair] No plugins enabled.  " +
+        "Enable at least one plugin in peripherals.yaml.",
+    );
+    // Still start the server so health checks pass — just with no plugins.
+  }
+
+  const corsair = createCorsair({ plugins: enabledPlugins });
+  const server = runStdioMcpServer({ corsair });
+
+  console.error(
+    `[corsair] MCP sidecar running with ${enabledPlugins.length} plugin(s).`,
+  );
+
+  // Keep the process alive until stdin closes (daemon shuts down).
+  process.stdin.resume();
+  process.stdin.on("end", () => {
+    console.error("[corsair] stdin closed — shutting down.");
+    process.exit(0);
+  });
+}
+
+main().catch((err) => {
+  console.error("[corsair] Fatal:", err);
+  process.exit(1);
+});

--- a/src/openbad/peripherals/corsair/package.json
+++ b/src/openbad/peripherals/corsair/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "openbad-corsair",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "OpenBaD Corsair MCP sidecar — external integration layer",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/corsair.js"
+  },
+  "dependencies": {
+    "corsair": "^1.0.0",
+    "@corsair-dev/mcp": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/src/openbad/peripherals/corsair/tsconfig.json
+++ b/src/openbad/peripherals/corsair/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["corsair.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/test_peripherals_config.py
+++ b/tests/test_peripherals_config.py
@@ -1,0 +1,207 @@
+"""Tests for the Corsair peripherals configuration loader."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from openbad.peripherals.config import (
+    CorsairConfig,
+    PluginConfig,
+    enabled_plugin_names,
+    load_peripherals_config,
+    resolve_credentials_path,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────── #
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path) -> Path:
+    """Return a temp directory pre-populated with a peripherals.yaml."""
+    cfg = tmp_path / "peripherals.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+        corsair:
+          entry_point: /opt/openbad/peripherals/corsair/dist/corsair.js
+          webhook_secret: test-secret-123
+          plugins:
+            - name: discord
+              enabled: true
+              credentials_file: discord.json
+            - name: slack
+              enabled: false
+              credentials_file: slack.json
+            - name: gmail
+              enabled: true
+              credentials_file: gmail.json
+        """),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def creds_dir(tmp_path: Path) -> Path:
+    """Return a temp directory with sample credential files."""
+    d = tmp_path / "creds"
+    d.mkdir()
+    discord_creds = d / "discord.json"
+    discord_creds.write_text(
+        json.dumps({"token": "fake-bot-token"}), encoding="utf-8",
+    )
+    discord_creds.chmod(0o600)
+
+    slack_creds = d / "slack.json"
+    slack_creds.write_text(
+        json.dumps({"token": "fake-slack-token"}), encoding="utf-8",
+    )
+    slack_creds.chmod(0o644)  # intentionally too open
+    return d
+
+
+# ── load_peripherals_config ──────────────────────────────────────── #
+
+
+class TestLoadConfig:
+    """Tests for load_peripherals_config()."""
+
+    def test_loads_from_explicit_path(self, config_dir: Path) -> None:
+        cfg = load_peripherals_config(config_dir / "peripherals.yaml")
+        assert cfg.entry_point == "/opt/openbad/peripherals/corsair/dist/corsair.js"
+        assert cfg.webhook_secret == "test-secret-123"  # noqa: S105
+        assert len(cfg.plugins) == 3
+
+    def test_parses_plugin_entries(self, config_dir: Path) -> None:
+        cfg = load_peripherals_config(config_dir / "peripherals.yaml")
+        names = [p.name for p in cfg.plugins]
+        assert names == ["discord", "slack", "gmail"]
+
+    def test_plugin_enabled_flags(self, config_dir: Path) -> None:
+        cfg = load_peripherals_config(config_dir / "peripherals.yaml")
+        by_name = {p.name: p for p in cfg.plugins}
+        assert by_name["discord"].enabled is True
+        assert by_name["slack"].enabled is False
+        assert by_name["gmail"].enabled is True
+
+    def test_plugin_credentials_files(self, config_dir: Path) -> None:
+        cfg = load_peripherals_config(config_dir / "peripherals.yaml")
+        by_name = {p.name: p for p in cfg.plugins}
+        assert by_name["discord"].credentials_file == "discord.json"
+
+    def test_returns_default_when_no_file(self, tmp_path: Path) -> None:
+        cfg = load_peripherals_config(tmp_path / "missing.yaml")
+        assert cfg == CorsairConfig()
+        assert cfg.plugins == []
+
+    def test_returns_default_for_empty_yaml(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty.yaml"
+        empty.write_text("", encoding="utf-8")
+        cfg = load_peripherals_config(empty)
+        assert cfg == CorsairConfig()
+
+    def test_returns_default_for_no_corsair_key(self, tmp_path: Path) -> None:
+        nope = tmp_path / "no_corsair.yaml"
+        nope.write_text("other_stuff:\n  key: value\n", encoding="utf-8")
+        cfg = load_peripherals_config(nope)
+        assert cfg == CorsairConfig()
+
+    def test_empty_plugins_list(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "peripherals.yaml"
+        cfg_file.write_text(
+            textwrap.dedent("""\
+            corsair:
+              entry_point: /opt/openbad/peripherals/corsair/dist/corsair.js
+              plugins: []
+            """),
+            encoding="utf-8",
+        )
+        cfg = load_peripherals_config(cfg_file)
+        assert cfg.plugins == []
+
+    def test_skips_malformed_plugin_entries(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "peripherals.yaml"
+        cfg_file.write_text(
+            textwrap.dedent("""\
+            corsair:
+              plugins:
+                - name: good
+                  enabled: true
+                - not_a_dict
+                - enabled: true
+            """),
+            encoding="utf-8",
+        )
+        cfg = load_peripherals_config(cfg_file)
+        # Only the entry with "name" is kept.
+        assert len(cfg.plugins) == 1
+        assert cfg.plugins[0].name == "good"
+
+
+# ── resolve_credentials_path ─────────────────────────────────────── #
+
+
+class TestResolveCredentials:
+    """Tests for resolve_credentials_path()."""
+
+    def test_returns_path_for_existing_file(self, creds_dir: Path) -> None:
+        plugin = PluginConfig(name="discord", credentials_file="discord.json")
+        result = resolve_credentials_path(plugin, creds_dir)
+        assert result is not None
+        assert result == creds_dir / "discord.json"
+
+    def test_returns_none_for_missing_file(self, creds_dir: Path) -> None:
+        plugin = PluginConfig(name="telegram", credentials_file="telegram.json")
+        result = resolve_credentials_path(plugin, creds_dir)
+        assert result is None
+
+    def test_returns_none_for_empty_credentials_file(
+        self, creds_dir: Path,
+    ) -> None:
+        plugin = PluginConfig(name="discord", credentials_file="")
+        result = resolve_credentials_path(plugin, creds_dir)
+        assert result is None
+
+    def test_warns_on_open_permissions(
+        self, creds_dir: Path, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plugin = PluginConfig(name="slack", credentials_file="slack.json")
+        with caplog.at_level("WARNING"):
+            result = resolve_credentials_path(plugin, creds_dir)
+        assert result is not None
+        assert "0644" in caplog.text or "mode" in caplog.text.lower()
+
+    def test_no_warning_on_correct_permissions(
+        self, creds_dir: Path, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        plugin = PluginConfig(name="discord", credentials_file="discord.json")
+        with caplog.at_level("WARNING"):
+            resolve_credentials_path(plugin, creds_dir)
+        assert "mode" not in caplog.text.lower()
+
+
+# ── enabled_plugin_names ─────────────────────────────────────────── #
+
+
+class TestEnabledPluginNames:
+    """Tests for enabled_plugin_names()."""
+
+    def test_returns_only_enabled(self, config_dir: Path) -> None:
+        cfg = load_peripherals_config(config_dir / "peripherals.yaml")
+        names = enabled_plugin_names(cfg)
+        assert names == ["discord", "gmail"]
+
+    def test_empty_when_none_enabled(self) -> None:
+        cfg = CorsairConfig(
+            plugins=[
+                PluginConfig(name="a", enabled=False),
+                PluginConfig(name="b", enabled=False),
+            ],
+        )
+        assert enabled_plugin_names(cfg) == []
+
+    def test_empty_for_default_config(self) -> None:
+        assert enabled_plugin_names(CorsairConfig()) == []


### PR DESCRIPTION
Closes #589

## Summary

- **Rewritten Phase 12 spec** (`12-OpenBaD Peripheral Transducers & Systemd.md`) — replaces per-platform transducer microservices with Corsair MCP sidecar architecture.
- **Corsair TypeScript scaffold** (`src/openbad/peripherals/corsair/`) — `corsair.ts` entry point, `package.json`, `tsconfig.json`. Reads `peripherals.yaml` and dynamically loads enabled plugins.
- **Python config loader** (`src/openbad/peripherals/config.py`) — `CorsairConfig`/`PluginConfig` dataclasses, YAML loader with standard search paths, credential file resolver with permission warnings.
- **Systemd unit** (`config/openbad-corsair.service`) — runs as `openbad` user, `After=openbad-broker.service`, `Restart=always`, security-hardened to match `openbad.service`.
- **Config file** (`config/peripherals.yaml`) — declarative plugin list with credential references.

## Tests

17 unit tests covering:
- Config loading from explicit path, missing file, empty YAML, no `corsair` key
- Plugin entry parsing, enabled/disabled flags, credentials file references
- Malformed entries skipped gracefully
- Credential resolution: existing files, missing files, empty refs
- Permission warnings on `0644` creds, no warning on `0600`
- `enabled_plugin_names()` filtering

## How to Test

```bash
.venv/bin/pytest tests/test_peripherals_config.py -v
.venv/bin/ruff check src/openbad/peripherals/ tests/test_peripherals_config.py
```