### PR TITLE
#591: Add webhook ingress bridge — Corsair webhooks to MQTT

### DIFF
--- a/src/openbad/nervous_system/topics.py
+++ b/src/openbad/nervous_system/topics.py
@@ -199,6 +199,15 @@ AGENT_ESCALATION = "agent/escalation"
 
 
 # ---------------------------------------------------------------------------
+# External peripherals (Phase 12 — Corsair integration)
+# ---------------------------------------------------------------------------
+EXTERNAL_INBOUND = "sensory/external/{platform}/inbound"
+EXTERNAL_OUTBOUND = "motor/external/{platform}/outbound"
+EXTERNAL_INBOUND_ALL = "sensory/external/+/inbound"
+PERIPHERALS_HEALTH = "system/peripherals/{name}/health"
+
+
+# ---------------------------------------------------------------------------
 # Helper: resolve topic templates
 # ---------------------------------------------------------------------------
 def topic_for(template: str, /, **kwargs: str) -> str:

--- a/src/openbad/peripherals/webhook.py
+++ b/src/openbad/peripherals/webhook.py
@@ -1,0 +1,122 @@
+"""Corsair webhook ingress bridge.
+
+Receives HTTP webhook callbacks from the Corsair sidecar and publishes
+them to the MQTT nervous system at ``sensory/external/{platform}/inbound``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+from typing import Any
+
+from aiohttp import web
+
+from openbad.nervous_system import topics
+from openbad.peripherals.config import load_peripherals_config
+
+log = logging.getLogger(__name__)
+
+
+def _verify_hmac(
+    body: bytes,
+    signature: str,
+    secret: str,
+) -> bool:
+    """Validate an HMAC-SHA256 signature header.
+
+    The expected format of *signature* is ``sha256=<hex-digest>``.
+    Returns ``True`` when the signature is valid.
+    """
+    if not secret:
+        # No secret configured — skip validation (dev mode).
+        return True
+    if not signature.startswith("sha256="):
+        return False
+    expected = hmac.new(
+        secret.encode(), body, hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature[7:])
+
+
+async def post_webhook_corsair(request: web.Request) -> web.Response:
+    """Handle ``POST /api/webhooks/corsair``.
+
+    Expected JSON body::
+
+        {
+            "platform": "discord",
+            "event": "message.created",
+            "data": { ... platform-specific payload ... }
+        }
+
+    Validated via HMAC-SHA256 if ``corsair.webhook_secret`` is set.
+    """
+    # --- Signature validation ------------------------------------------------
+    cfg = load_peripherals_config()
+    body = await request.read()
+    signature = request.headers.get("X-Corsair-Signature", "")
+
+    if not _verify_hmac(body, signature, cfg.webhook_secret):
+        log.warning("Webhook signature mismatch from %s", request.remote)
+        return web.json_response(
+            {"error": "Invalid signature"}, status=401,
+        )
+
+    # --- Parse payload -------------------------------------------------------
+    try:
+        payload: dict[str, Any] = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return web.json_response(
+            {"error": "Malformed JSON body"}, status=400,
+        )
+
+    platform = payload.get("platform", "")
+    if not platform or not isinstance(platform, str):
+        return web.json_response(
+            {"error": "Missing or invalid 'platform' field"}, status=400,
+        )
+
+    # --- Publish to MQTT -----------------------------------------------------
+    mqtt = request.app.get("bridge")
+    if mqtt is None:
+        log.error("MQTT bridge not available in app context")
+        return web.json_response(
+            {"error": "MQTT bridge unavailable"}, status=503,
+        )
+
+    topic = topics.topic_for(
+        topics.EXTERNAL_INBOUND, platform=platform,
+    )
+    mqtt_payload = json.dumps({
+        "platform": platform,
+        "event": payload.get("event", "unknown"),
+        "data": payload.get("data", {}),
+        "received_at": time.time(),
+    }).encode()
+
+    try:
+        mqtt.publish_raw(topic, mqtt_payload, qos=1)
+    except Exception:
+        # Fallback: some bridge impls use a different method name.
+        try:
+            from openbad.nervous_system.client import NervousSystemClient
+
+            client = NervousSystemClient.get_instance()
+            client._mqtt.publish(topic, mqtt_payload, qos=1)
+        except Exception as exc:
+            log.exception("Failed to publish webhook to MQTT: %s", exc)
+            return web.json_response(
+                {"error": "Failed to publish to MQTT"}, status=503,
+            )
+
+    log.info("Webhook published: %s → %s", platform, topic)
+    return web.json_response({"ok": True, "topic": topic})
+
+
+def setup_webhook_routes(app: web.Application) -> None:
+    """Register webhook routes on the aiohttp application."""
+    app.router.add_post("/api/webhooks/corsair", post_webhook_corsair)

--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -3602,6 +3602,11 @@ def create_app(
     app.router.add_get("/api/events", _get_system_events)
     app.router.add_get("/api/capabilities", _get_capabilities)
 
+    # Corsair webhook ingress bridge
+    from openbad.peripherals.webhook import setup_webhook_routes  # noqa: PLC0415
+
+    setup_webhook_routes(app)
+
     # Library API (backed by state.db)
     from openbad.state.db import initialize_state_db  # noqa: PLC0415
     from openbad.wui.library_api import setup_library_routes  # noqa: PLC0415

--- a/tests/test_webhook_ingress.py
+++ b/tests/test_webhook_ingress.py
@@ -1,0 +1,255 @@
+"""Tests for the Corsair webhook ingress bridge."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+from openbad.peripherals.webhook import (
+    _verify_hmac,
+    setup_webhook_routes,
+)
+
+# ── HMAC verification ────────────────────────────────────────────── #
+
+
+class TestVerifyHmac:
+    """Tests for _verify_hmac()."""
+
+    def test_valid_signature(self) -> None:
+        body = b'{"platform":"discord"}'
+        secret = "test-secret"  # noqa: S105
+        digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        sig = f"sha256={digest}"
+        assert _verify_hmac(body, sig, secret) is True
+
+    def test_invalid_signature(self) -> None:
+        body = b'{"platform":"discord"}'
+        secret = "test-secret"  # noqa: S105
+        assert _verify_hmac(body, "sha256=bad", secret) is False
+
+    def test_missing_prefix(self) -> None:
+        body = b'{"platform":"discord"}'
+        secret = "test-secret"  # noqa: S105
+        digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        assert _verify_hmac(body, digest, secret) is False
+
+    def test_empty_secret_skips_validation(self) -> None:
+        assert _verify_hmac(b"anything", "whatever", "") is True
+
+    def test_empty_signature_with_secret(self) -> None:
+        assert _verify_hmac(b"body", "", "secret") is False
+
+
+# ── Topic constants ──────────────────────────────────────────────── #
+
+
+class TestTopicConstants:
+    """Verify external topic templates exist in topics.py."""
+
+    def test_external_inbound_exists(self) -> None:
+        from openbad.nervous_system import topics
+
+        assert hasattr(topics, "EXTERNAL_INBOUND")
+        assert "{platform}" in topics.EXTERNAL_INBOUND
+
+    def test_external_outbound_exists(self) -> None:
+        from openbad.nervous_system import topics
+
+        assert hasattr(topics, "EXTERNAL_OUTBOUND")
+        assert "{platform}" in topics.EXTERNAL_OUTBOUND
+
+    def test_external_inbound_all_wildcard(self) -> None:
+        from openbad.nervous_system import topics
+
+        assert hasattr(topics, "EXTERNAL_INBOUND_ALL")
+        assert "+" in topics.EXTERNAL_INBOUND_ALL
+
+    def test_peripherals_health_exists(self) -> None:
+        from openbad.nervous_system import topics
+
+        assert hasattr(topics, "PERIPHERALS_HEALTH")
+        assert "{name}" in topics.PERIPHERALS_HEALTH
+
+    def test_topic_for_resolves_inbound(self) -> None:
+        from openbad.nervous_system.topics import (
+            EXTERNAL_INBOUND,
+            topic_for,
+        )
+
+        assert (
+            topic_for(EXTERNAL_INBOUND, platform="discord")
+            == "sensory/external/discord/inbound"
+        )
+
+
+# ── Webhook endpoint (aiohttp integration) ──────────────────────── #
+
+
+@pytest.fixture()
+def _no_peripherals_config(tmp_path: Path) -> Any:
+    """Patch config loader to return empty (no webhook secret)."""
+    from openbad.peripherals.config import CorsairConfig
+
+    with patch(
+        "openbad.peripherals.webhook.load_peripherals_config",
+        return_value=CorsairConfig(),
+    ):
+        yield
+
+
+@pytest.fixture()
+def _secret_config() -> Any:
+    """Patch config loader to require a specific webhook secret."""
+    from openbad.peripherals.config import CorsairConfig
+
+    with patch(
+        "openbad.peripherals.webhook.load_peripherals_config",
+        return_value=CorsairConfig(webhook_secret="test-secret"),  # noqa: S106
+    ):
+        yield
+
+
+def _make_app(bridge: Any = None) -> web.Application:
+    """Build a minimal aiohttp app with webhook routes."""
+    app = web.Application()
+    if bridge is not None:
+        app["bridge"] = bridge
+    setup_webhook_routes(app)
+    return app
+
+
+def _sign(body: bytes, secret: str) -> str:
+    """Compute the HMAC-SHA256 signature header value."""
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+class TestWebhookEndpoint:
+    """Integration tests for POST /api/webhooks/corsair."""
+
+    @pytest.mark.asyncio
+    async def test_valid_payload_publishes(
+        self, _no_peripherals_config: Any, aiohttp_client: Any,
+    ) -> None:
+        bridge = MagicMock()
+        bridge.publish_raw = MagicMock()
+        app = _make_app(bridge)
+        client = await aiohttp_client(app)
+
+        payload = {"platform": "discord", "event": "message", "data": {}}
+        resp = await client.post(
+            "/api/webhooks/corsair",
+            json=payload,
+        )
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["ok"] is True
+        assert "sensory/external/discord/inbound" in body["topic"]
+        bridge.publish_raw.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_platform_returns_400(
+        self, _no_peripherals_config: Any, aiohttp_client: Any,
+    ) -> None:
+        bridge = MagicMock()
+        app = _make_app(bridge)
+        client = await aiohttp_client(app)
+
+        resp = await client.post(
+            "/api/webhooks/corsair",
+            json={"event": "test"},
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_400(
+        self, _no_peripherals_config: Any, aiohttp_client: Any,
+    ) -> None:
+        bridge = MagicMock()
+        app = _make_app(bridge)
+        client = await aiohttp_client(app)
+
+        resp = await client.post(
+            "/api/webhooks/corsair",
+            data=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_signature_returns_401(
+        self, _secret_config: Any, aiohttp_client: Any,
+    ) -> None:
+        bridge = MagicMock()
+        app = _make_app(bridge)
+        client = await aiohttp_client(app)
+
+        resp = await client.post(
+            "/api/webhooks/corsair",
+            json={"platform": "discord", "event": "test"},
+            headers={"X-Corsair-Signature": "sha256=bad"},
+        )
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_valid_signature_passes(
+        self, _secret_config: Any, aiohttp_client: Any,
+    ) -> None:
+        bridge = MagicMock()
+        bridge.publish_raw = MagicMock()
+        app = _make_app(bridge)
+        client = await aiohttp_client(app)
+
+        body = json.dumps(
+            {"platform": "slack", "event": "msg", "data": {}},
+        ).encode()
+        sig = _sign(body, "test-secret")
+
+        resp = await client.post(
+            "/api/webhooks/corsair",
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-Corsair-Signature": sig,
+            },
+        )
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_no_bridge_returns_503(
+        self, _no_peripherals_config: Any, aiohttp_client: Any,
+    ) -> None:
+        app = _make_app(bridge=None)  # No MQTT bridge
+        client = await aiohttp_client(app)
+
+        resp = await client.post(
+            "/api/webhooks/corsair",
+            json={"platform": "discord", "event": "test"},
+        )
+        assert resp.status == 503
+
+    @pytest.mark.asyncio
+    async def test_published_topic_matches_platform(
+        self, _no_peripherals_config: Any, aiohttp_client: Any,
+    ) -> None:
+        bridge = MagicMock()
+        bridge.publish_raw = MagicMock()
+        app = _make_app(bridge)
+        client = await aiohttp_client(app)
+
+        await client.post(
+            "/api/webhooks/corsair",
+            json={"platform": "telegram", "event": "msg", "data": {}},
+        )
+
+        call_args = bridge.publish_raw.call_args
+        topic = call_args[0][0]
+        assert topic == "sensory/external/telegram/inbound"


### PR DESCRIPTION
Closes #591

## Summary

- **Webhook endpoint** `POST /api/webhooks/corsair` in `src/openbad/peripherals/webhook.py`
  - HMAC-SHA256 signature validation (skipped when no secret configured)
  - Parses `platform`, `event`, `data` from JSON body
  - Publishes to MQTT `sensory/external/{platform}/inbound`
  - Returns 401 on sig mismatch, 400 on malformed payload, 503 on MQTT unavailable
- **Topic constants** in `src/openbad/nervous_system/topics.py`:
  - `EXTERNAL_INBOUND`, `EXTERNAL_OUTBOUND`, `EXTERNAL_INBOUND_ALL`, `PERIPHERALS_HEALTH`
- **Route wiring** in `src/openbad/wui/server.py` via `setup_webhook_routes(app)`

## Tests

17 unit tests covering:
- HMAC verification: valid, invalid, missing prefix, empty secret, empty signature
- Topic constants: existence, templates, wildcard, `topic_for()` resolution
- Webhook endpoint: valid publish, missing platform (400), malformed JSON (400), bad signature (401), valid signature, no bridge (503), correct topic per platform

## How to Test

```bash
.venv/bin/pytest tests/test_webhook_ingress.py -v
```