### PR TITLE
#592: Add autonomic ingress routing — external signals to STM + active inference

### DIFF
--- a/src/openbad/daemon.py
+++ b/src/openbad/daemon.py
@@ -16,12 +16,14 @@ from openbad.endocrine.controller import EndocrineController
 from openbad.frameworks.crew_mqtt_bridge import CrewMQTTBridge
 from openbad.interoception.disk_network import DiskNetworkMonitor
 from openbad.interoception.monitor import TelemetryMonitor
+from openbad.memory.base import MemoryEntry, MemoryTier
 from openbad.nervous_system import topics
 from openbad.nervous_system.client import NervousSystemClient
 from openbad.nervous_system.schemas.cognitive_pb2 import ModelHealthStatus
 from openbad.nervous_system.schemas.common_pb2 import Header
 from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
 from openbad.nervous_system.schemas.telemetry_pb2 import TokenTelemetry
+from openbad.plugins.observations.external_signals import ExternalSignalPlugin
 from openbad.reflex_arc.fsm import AgentFSM
 
 logger = logging.getLogger(__name__)
@@ -63,6 +65,7 @@ class Daemon:
         self._disk_network: DiskNetworkMonitor | None = None
         self._stop_event: asyncio.Event | None = None
         self._crew_bridge: CrewMQTTBridge | None = None
+        self._external_signal_plugin: ExternalSignalPlugin | None = None
 
     # -- public --------------------------------------------------------- #
 
@@ -100,6 +103,12 @@ class Daemon:
         self._client.subscribe(topics.TASK_WORK_REQUEST, bytes, self._on_task_work_request)
         self._client.subscribe(topics.RESEARCH_WORK_REQUEST, bytes, self._on_research_work_request)
         self._client.subscribe(topics.DOCTOR_CALL, bytes, self._on_doctor_call)
+        self._client.subscribe(
+            topics.EXTERNAL_INBOUND_ALL, bytes, self._on_external_inbound,
+        )
+
+        # External signal observation plugin (records inbound messages)
+        self._external_signal_plugin = ExternalSignalPlugin()
 
         # 2. Finite state machine
         self._fsm = AgentFSM(client=self._client)
@@ -325,3 +334,49 @@ class Daemon:
         finally:
             if self._fsm is not None:
                 self._fsm.finish_work()
+
+    def _on_external_inbound(self, topic: str, payload: bytes) -> None:
+        """Handle an inbound external message from the Corsair webhook bridge.
+
+        Writes the message to STM and increments the external-signal counter
+        so the active inference engine can compute surprise.
+        """
+        try:
+            data = json.loads(payload.decode("utf-8"))
+        except Exception:
+            logger.exception("Invalid external inbound payload")
+            return
+
+        # Extract platform from topic: sensory/external/{platform}/inbound
+        parts = topic.split("/")
+        platform = parts[2] if len(parts) >= 4 else "unknown"
+
+        # Record observation for active inference
+        if self._external_signal_plugin is not None:
+            self._external_signal_plugin.record()
+
+        # Write to Short-Term Memory
+        try:
+            from openbad.memory.cognitive_store import CognitiveMemoryStore
+            from openbad.state.db import initialize_state_db
+
+            conn = initialize_state_db()
+            stm = CognitiveMemoryStore(conn, MemoryTier.STM)
+            stm.write(
+                MemoryEntry(
+                    key=f"external:{platform}:{time.time():.0f}",
+                    value=json.dumps(data),
+                    tier=MemoryTier.STM,
+                    ttl_seconds=300.0,
+                    context=f"External inbound from {platform}",
+                    metadata={
+                        "platform": platform,
+                        "sender": data.get("sender", ""),
+                        "timestamp": data.get("timestamp", time.time()),
+                        "content_summary": str(data.get("data", ""))[:200],
+                        "event": data.get("event", ""),
+                    },
+                ),
+            )
+        except Exception:
+            logger.exception("Failed to write external signal to STM")

--- a/src/openbad/plugins/observations/external_signals.py
+++ b/src/openbad/plugins/observations/external_signals.py
@@ -1,0 +1,47 @@
+"""Observation plugin for external inbound signals (Corsair webhooks)."""
+
+from __future__ import annotations
+
+import threading
+
+from openbad.active_inference.plugin_interface import ObservationPlugin, ObservationResult
+
+
+class ExternalSignalPlugin(ObservationPlugin):
+    """Tracks inbound external messages from Corsair webhook bridge.
+
+    The daemon's ``_on_external_inbound`` handler calls :meth:`record` for
+    every message received on ``sensory/external/+/inbound``.  Each
+    :meth:`observe` call returns the count accumulated since the last
+    observation and resets the counter.
+
+    Default prediction is **0 messages per poll interval** so any inbound
+    traffic produces surprise, which feeds the explore pipeline.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._count: int = 0
+
+    # -- recording (called from daemon MQTT handler) -------------------- #
+
+    def record(self) -> None:
+        """Increment the inbound message counter (thread-safe)."""
+        with self._lock:
+            self._count += 1
+
+    # -- ObservationPlugin ABC ------------------------------------------ #
+
+    @property
+    def source_id(self) -> str:
+        return "external_signals"
+
+    async def observe(self) -> ObservationResult:
+        """Return message count since last observation, then reset."""
+        with self._lock:
+            count = self._count
+            self._count = 0
+        return ObservationResult(metrics={"message_count": count})
+
+    def default_predictions(self) -> dict[str, dict[str, float]]:
+        return {"message_count": {"expected": 0.0, "tolerance": 1.0}}

--- a/tests/test_autonomic_ingress.py
+++ b/tests/test_autonomic_ingress.py
@@ -1,0 +1,225 @@
+"""Tests for autonomic ingress routing — external signals to STM + active inference."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openbad.memory.base import MemoryEntry, MemoryTier
+from openbad.plugins.observations.external_signals import ExternalSignalPlugin
+
+# ── ExternalSignalPlugin ─────────────────────────────────────────── #
+
+
+class TestExternalSignalPlugin:
+    """Tests for the observation plugin counter logic."""
+
+    def test_source_id(self) -> None:
+        plugin = ExternalSignalPlugin()
+        assert plugin.source_id == "external_signals"
+
+    def test_default_predictions(self) -> None:
+        plugin = ExternalSignalPlugin()
+        preds = plugin.default_predictions()
+        assert "message_count" in preds
+        assert preds["message_count"]["expected"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_observe_returns_zero_initially(self) -> None:
+        plugin = ExternalSignalPlugin()
+        result = await plugin.observe()
+        assert result.metrics["message_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_observe_returns_recorded_count(self) -> None:
+        plugin = ExternalSignalPlugin()
+        plugin.record()
+        plugin.record()
+        plugin.record()
+        result = await plugin.observe()
+        assert result.metrics["message_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_observe_resets_counter(self) -> None:
+        plugin = ExternalSignalPlugin()
+        plugin.record()
+        plugin.record()
+        await plugin.observe()
+        result = await plugin.observe()
+        assert result.metrics["message_count"] == 0
+
+    def test_record_is_thread_safe(self) -> None:
+        """Smoke test that record doesn't raise under concurrent calls."""
+        import threading
+
+        plugin = ExternalSignalPlugin()
+        threads = [threading.Thread(target=plugin.record) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # All 50 records should be captured
+        assert plugin._count == 50  # noqa: SLF001
+
+    def test_poll_interval_default(self) -> None:
+        plugin = ExternalSignalPlugin()
+        assert plugin.poll_interval_seconds == 60
+
+
+# ── ExternalSignalPlugin with surprise ──────────────────────────── #
+
+
+class TestExternalSignalSurprise:
+    """Tests that unexpected messages produce surprise in the engine."""
+
+    @pytest.mark.asyncio
+    async def test_surprise_on_unexpected_messages(self) -> None:
+        """Non-zero messages when prediction is 0 → positive surprise."""
+        from openbad.active_inference.surprise import aggregate_surprise
+        from openbad.active_inference.world_model import WorldModel
+
+        wm = WorldModel()
+        plugin = ExternalSignalPlugin()
+        wm.register_source(plugin.source_id, plugin.default_predictions())
+
+        # Record some inbound messages
+        plugin.record()
+        plugin.record()
+        result = await plugin.observe()
+
+        errors = wm.update(plugin.source_id, result.metrics)
+        surprise = aggregate_surprise(errors)
+        assert surprise > 0.0
+
+    @pytest.mark.asyncio
+    async def test_no_surprise_when_zero_messages(self) -> None:
+        """Zero messages matches prediction of 0 → zero surprise."""
+        from openbad.active_inference.surprise import aggregate_surprise
+        from openbad.active_inference.world_model import WorldModel
+
+        wm = WorldModel()
+        plugin = ExternalSignalPlugin()
+        wm.register_source(plugin.source_id, plugin.default_predictions())
+
+        result = await plugin.observe()
+        errors = wm.update(plugin.source_id, result.metrics)
+        surprise = aggregate_surprise(errors)
+        assert surprise == 0.0
+
+
+# ── Daemon handler ───────────────────────────────────────────────── #
+
+
+class TestDaemonExternalInbound:
+    """Tests for the daemon's _on_external_inbound handler."""
+
+    def _make_daemon(self) -> MagicMock:
+        """Construct a daemon-like object with patched dependencies."""
+        from openbad.daemon import Daemon
+
+        d = Daemon.__new__(Daemon)
+        d._external_signal_plugin = ExternalSignalPlugin()  # noqa: SLF001
+        d._fsm = None  # noqa: SLF001
+        d._client = None  # noqa: SLF001
+        return d
+
+    def test_handler_records_to_plugin(self) -> None:
+        d = self._make_daemon()
+        payload = json.dumps({
+            "platform": "discord",
+            "event": "message",
+            "data": {"text": "hello"},
+        }).encode()
+
+        with patch(
+            "openbad.memory.cognitive_store.CognitiveMemoryStore"
+        ) as mock_store_cls, patch(
+            "openbad.state.db.initialize_state_db",
+            return_value=MagicMock(),
+        ):
+            mock_store = MagicMock()
+            mock_store_cls.return_value = mock_store
+            d._on_external_inbound(  # noqa: SLF001
+                "sensory/external/discord/inbound", payload,
+            )
+
+        assert d._external_signal_plugin._count == 1  # noqa: SLF001
+
+    def test_handler_writes_stm_entry(self) -> None:
+        d = self._make_daemon()
+        payload = json.dumps({
+            "platform": "slack",
+            "event": "message",
+            "data": {"text": "hi there"},
+            "sender": "user42",
+        }).encode()
+
+        with patch(
+            "openbad.memory.cognitive_store.CognitiveMemoryStore"
+        ) as mock_store_cls, patch(
+            "openbad.state.db.initialize_state_db",
+            return_value=MagicMock(),
+        ):
+            mock_store = MagicMock()
+            mock_store_cls.return_value = mock_store
+            d._on_external_inbound(  # noqa: SLF001
+                "sensory/external/slack/inbound", payload,
+            )
+
+        mock_store.write.assert_called_once()
+        entry: MemoryEntry = mock_store.write.call_args[0][0]
+        assert entry.tier == MemoryTier.STM
+        assert entry.metadata["platform"] == "slack"
+        assert entry.metadata["sender"] == "user42"
+        assert entry.ttl_seconds == 300.0
+        assert "slack" in entry.key
+
+    def test_handler_extracts_platform_from_topic(self) -> None:
+        d = self._make_daemon()
+        payload = json.dumps({
+            "platform": "gmail",
+            "event": "new_email",
+            "data": {},
+        }).encode()
+
+        with patch(
+            "openbad.memory.cognitive_store.CognitiveMemoryStore"
+        ) as mock_store_cls, patch(
+            "openbad.state.db.initialize_state_db",
+            return_value=MagicMock(),
+        ):
+            mock_store = MagicMock()
+            mock_store_cls.return_value = mock_store
+            d._on_external_inbound(  # noqa: SLF001
+                "sensory/external/gmail/inbound", payload,
+            )
+
+        entry: MemoryEntry = mock_store.write.call_args[0][0]
+        assert entry.metadata["platform"] == "gmail"
+        assert "gmail" in entry.context
+
+    def test_handler_survives_bad_payload(self) -> None:
+        d = self._make_daemon()
+        # Invalid JSON should not raise
+        d._on_external_inbound(  # noqa: SLF001
+            "sensory/external/discord/inbound", b"not json",
+        )
+        # Plugin count should stay at 0 (handler bails before record)
+        assert d._external_signal_plugin._count == 0  # noqa: SLF001
+
+    def test_handler_survives_stm_failure(self) -> None:
+        d = self._make_daemon()
+        payload = json.dumps({"platform": "discord", "event": "msg", "data": {}}).encode()
+
+        with patch(
+            "openbad.state.db.initialize_state_db",
+            side_effect=RuntimeError("db error"),
+        ):
+            # Should not raise
+            d._on_external_inbound(  # noqa: SLF001
+                "sensory/external/discord/inbound", payload,
+            )
+        # Plugin still recorded despite STM failure
+        assert d._external_signal_plugin._count == 1  # noqa: SLF001


### PR DESCRIPTION
Closes #592

## Summary

- **ExternalSignalPlugin** (`src/openbad/plugins/observations/external_signals.py`)
  - Implements `ObservationPlugin` with `source_id="external_signals"`
  - Thread-safe counter: `record()` increments, `observe()` returns count and resets
  - Default prediction: 0 messages → any inbound traffic produces surprise
- **Daemon subscription** (`src/openbad/daemon.py`)
  - Subscribes to `sensory/external/+/inbound` wildcard topic
  - `_on_external_inbound` handler: parses JSON, extracts platform from topic, records to plugin, writes STM entry with metadata (platform, sender, timestamp, content_summary, event)
  - STM entries get 300s TTL

## Tests (14 total)

- **Plugin**: source_id, default predictions, observe zero, observe count, reset, thread safety, poll interval
- **Surprise**: positive surprise on messages, zero surprise when empty
- **Daemon handler**: records to plugin, writes STM entry with metadata, extracts platform from topic, survives bad JSON, survives STM failure

## How to Test

```bash
.venv/bin/pytest tests/test_autonomic_ingress.py -v
```