### PR TITLE
#593: Add WUI transducers frontend — plugin catalog, config, health

### DIFF
--- a/src/openbad/wui/server.py
+++ b/src/openbad/wui/server.py
@@ -3607,6 +3607,11 @@ def create_app(
 
     setup_webhook_routes(app)
 
+    # Transducer management API (plugin catalog, config, health)
+    from openbad.wui.transducer_api import setup_transducer_routes  # noqa: PLC0415
+
+    setup_transducer_routes(app)
+
     # Library API (backed by state.db)
     from openbad.state.db import initialize_state_db  # noqa: PLC0415
     from openbad.wui.library_api import setup_library_routes  # noqa: PLC0415

--- a/src/openbad/wui/transducer_api.py
+++ b/src/openbad/wui/transducer_api.py
@@ -1,0 +1,182 @@
+"""WUI API routes for the Transducers panel (Corsair peripheral plugins)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from pathlib import Path
+
+from aiohttp import web
+
+from openbad.peripherals.config import (
+    CorsairConfig,
+    PluginConfig,
+    load_peripherals_config,
+)
+
+logger = logging.getLogger(__name__)
+
+_CREDS_DIR = Path("data/config/peripherals")
+
+
+def _read_config() -> CorsairConfig:
+    """Load the current peripherals configuration."""
+    return load_peripherals_config()
+
+
+def _plugin_dict(p: PluginConfig, health_cache: dict[str, str]) -> dict:
+    return {
+        "name": p.name,
+        "enabled": p.enabled,
+        "has_credentials": p.credentials_file is not None,
+        "health": health_cache.get(p.name, "unknown"),
+    }
+
+
+# ── Handlers ─────────────────────────────────────────────────────── #
+
+
+async def _get_transducers(_request: web.Request) -> web.Response:
+    """GET /api/transducers — list available plugins with status."""
+    cfg = _read_config()
+    health_cache: dict[str, str] = _request.app.get("_transducers_health", {})
+    plugins = [_plugin_dict(p, health_cache) for p in cfg.plugins]
+    return web.json_response({"plugins": plugins})
+
+
+async def _put_transducer(request: web.Request) -> web.Response:
+    """PUT /api/transducers/{plugin} — enable/disable + save credentials."""
+    plugin_name = request.match_info["plugin"]
+    cfg = _read_config()
+
+    # Find the plugin in config
+    target: PluginConfig | None = None
+    for p in cfg.plugins:
+        if p.name == plugin_name:
+            target = p
+            break
+    if target is None:
+        raise web.HTTPNotFound(text=f"plugin not found: {plugin_name}")
+
+    try:
+        payload = await request.json()
+    except Exception:
+        raise web.HTTPBadRequest(text="invalid JSON body")  # noqa: B904
+
+    if not isinstance(payload, dict):
+        raise web.HTTPBadRequest(text="request body must be an object")
+
+    # Handle enable/disable
+    enabled = payload.get("enabled")
+    credentials = payload.get("credentials")
+
+    # Save credentials securely if provided
+    if credentials and isinstance(credentials, dict):
+        _CREDS_DIR.mkdir(parents=True, exist_ok=True)
+        creds_path = _CREDS_DIR / f"{plugin_name}.json"
+        creds_path.write_text(json.dumps(credentials, indent=2))
+        # Set file permissions to 0600 (owner read/write only)
+        os.chmod(creds_path, stat.S_IRUSR | stat.S_IWUSR)
+
+    # Update the YAML config for enabled state
+    if enabled is not None:
+        _update_plugin_enabled(plugin_name, bool(enabled))
+
+    # Re-read config after update
+    cfg = _read_config()
+    for p in cfg.plugins:
+        if p.name == plugin_name:
+            health_cache: dict[str, str] = request.app.get("_transducers_health", {})
+            return web.json_response(_plugin_dict(p, health_cache))
+
+    return web.json_response({"name": plugin_name, "enabled": bool(enabled)})
+
+
+async def _get_transducer_health(request: web.Request) -> web.Response:
+    """GET /api/transducers/{plugin}/health — return health status."""
+    plugin_name = request.match_info["plugin"]
+    health_cache: dict[str, str] = request.app.get("_transducers_health", {})
+    status = health_cache.get(plugin_name, "unknown")
+    return web.json_response({"plugin": plugin_name, "status": status})
+
+
+async def _post_transducer_test(request: web.Request) -> web.Response:
+    """POST /api/transducers/{plugin}/test — send a test message."""
+    plugin_name = request.match_info["plugin"]
+
+    try:
+        payload = await request.json()
+    except Exception:
+        payload = {}
+
+    target = payload.get("target", "test")
+    content = payload.get("content", f"Test message from OpenBaD to {plugin_name}")
+
+    try:
+        from openbad.skills.server import skill_server  # noqa: PLC0415
+
+        tools = {t.name: t for t in skill_server.list_tools()}
+        if "transmit_message" not in tools:
+            raise web.HTTPServiceUnavailable(text="transmit_message skill not available")
+
+        # Call the transmit_message skill
+        result = await tools["transmit_message"].run(
+            platform=plugin_name,
+            operation="sendMessage",
+            target=target,
+            content=content,
+        )
+        return web.json_response({"ok": True, "result": str(result)})
+    except web.HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Test message to %s failed", plugin_name)
+        return web.json_response(
+            {"ok": False, "error": str(exc)}, status=500,
+        )
+
+
+# ── Config mutation helper ────────────────────────────────────────── #
+
+
+def _update_plugin_enabled(plugin_name: str, enabled: bool) -> None:
+    """Toggle the enabled flag for a plugin in peripherals.yaml."""
+    import yaml  # noqa: PLC0415
+
+    # Find the config file
+    for candidate in [
+        Path("/etc/openbad/peripherals.yaml"),
+        Path("config/peripherals.yaml"),
+    ]:
+        if candidate.exists():
+            config_path = candidate
+            break
+    else:
+        config_path = Path("config/peripherals.yaml")
+
+    raw = (yaml.safe_load(config_path.read_text()) or {}) if config_path.exists() else {}
+
+    corsair = raw.setdefault("corsair", {})
+    plugins = corsair.setdefault("plugins", [])
+
+    for p in plugins:
+        if isinstance(p, dict) and p.get("name") == plugin_name:
+            p["enabled"] = enabled
+            break
+    else:
+        plugins.append({"name": plugin_name, "enabled": enabled})
+
+    config_path.write_text(yaml.dump(raw, default_flow_style=False))
+
+
+# ── Route registration ────────────────────────────────────────────── #
+
+
+def setup_transducer_routes(app: web.Application) -> None:
+    """Register transducer API routes on the aiohttp app."""
+    app.router.add_get("/api/transducers", _get_transducers)
+    app.router.add_put("/api/transducers/{plugin}", _put_transducer)
+    app.router.add_get("/api/transducers/{plugin}/health", _get_transducer_health)
+    app.router.add_post("/api/transducers/{plugin}/test", _post_transducer_test)

--- a/tests/test_transducer_api.py
+++ b/tests/test_transducer_api.py
@@ -1,0 +1,185 @@
+"""Tests for the transducer API endpoints."""
+
+from __future__ import annotations
+
+import json
+import stat
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+from openbad.peripherals.config import CorsairConfig, PluginConfig
+from openbad.wui.transducer_api import setup_transducer_routes
+
+
+def _sample_config() -> CorsairConfig:
+    return CorsairConfig(
+        plugins=[
+            PluginConfig(name="discord", enabled=True, credentials_file="discord.json"),
+            PluginConfig(name="slack", enabled=False),
+            PluginConfig(name="gmail", enabled=True),
+        ],
+    )
+
+
+def _make_app() -> web.Application:
+    app = web.Application()
+    setup_transducer_routes(app)
+    return app
+
+
+# ── GET /api/transducers ────────────────────────────────────────── #
+
+
+class TestGetTransducers:
+    @pytest.fixture(autouse=True)
+    def _patch_config(self):
+        with patch(
+            "openbad.wui.transducer_api.load_peripherals_config",
+            return_value=_sample_config(),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_returns_plugin_list(self, aiohttp_client) -> None:
+        client = await aiohttp_client(_make_app())
+        resp = await client.get("/api/transducers")
+        assert resp.status == 200
+        data = await resp.json()
+        assert "plugins" in data
+        assert len(data["plugins"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_plugin_shape(self, aiohttp_client) -> None:
+        client = await aiohttp_client(_make_app())
+        resp = await client.get("/api/transducers")
+        data = await resp.json()
+        p = data["plugins"][0]
+        assert p["name"] == "discord"
+        assert p["enabled"] is True
+        assert "health" in p
+        assert "has_credentials" in p
+
+    @pytest.mark.asyncio
+    async def test_disabled_plugin(self, aiohttp_client) -> None:
+        client = await aiohttp_client(_make_app())
+        resp = await client.get("/api/transducers")
+        data = await resp.json()
+        slack = next(p for p in data["plugins"] if p["name"] == "slack")
+        assert slack["enabled"] is False
+
+
+# ── PUT /api/transducers/{plugin} ───────────────────────────────── #
+
+
+class TestPutTransducer:
+    @pytest.fixture(autouse=True)
+    def _patch_config(self):
+        with patch(
+            "openbad.wui.transducer_api.load_peripherals_config",
+            return_value=_sample_config(),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, aiohttp_client) -> None:
+        client = await aiohttp_client(_make_app())
+        resp = await client.put(
+            "/api/transducers/nonexistent",
+            json={"enabled": True},
+        )
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_saves_credentials(self, aiohttp_client, tmp_path) -> None:
+        with patch(
+            "openbad.wui.transducer_api._CREDS_DIR", tmp_path,
+        ), patch(
+            "openbad.wui.transducer_api._update_plugin_enabled",
+        ):
+            client = await aiohttp_client(_make_app())
+            resp = await client.put(
+                "/api/transducers/discord",
+                json={"credentials": {"api_key": "test-key-123"}},  # noqa: S106
+            )
+            assert resp.status == 200
+
+            creds_file = tmp_path / "discord.json"
+            assert creds_file.exists()
+            creds = json.loads(creds_file.read_text())
+            assert creds["api_key"] == "test-key-123"
+
+            # Verify 0600 permissions
+            mode = creds_file.stat().st_mode
+            assert mode & stat.S_IRUSR  # owner read
+            assert mode & stat.S_IWUSR  # owner write
+            assert not mode & stat.S_IRGRP  # no group read
+            assert not mode & stat.S_IROTH  # no other read
+
+    @pytest.mark.asyncio
+    async def test_toggle_enabled(self, aiohttp_client) -> None:
+        with patch(
+            "openbad.wui.transducer_api._update_plugin_enabled",
+        ) as mock_update:
+            client = await aiohttp_client(_make_app())
+            resp = await client.put(
+                "/api/transducers/slack",
+                json={"enabled": True},
+            )
+            assert resp.status == 200
+            mock_update.assert_called_once_with("slack", True)
+
+
+# ── GET /api/transducers/{plugin}/health ────────────────────────── #
+
+
+class TestGetTransducerHealth:
+    @pytest.mark.asyncio
+    async def test_unknown_health(self, aiohttp_client) -> None:
+        client = await aiohttp_client(_make_app())
+        resp = await client.get("/api/transducers/discord/health")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["plugin"] == "discord"
+        assert data["status"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_cached_health(self, aiohttp_client) -> None:
+        app = _make_app()
+        app["_transducers_health"] = {"discord": "healthy"}
+        client = await aiohttp_client(app)
+        resp = await client.get("/api/transducers/discord/health")
+        data = await resp.json()
+        assert data["status"] == "healthy"
+
+
+# ── POST /api/transducers/{plugin}/test ─────────────────────────── #
+
+
+class TestPostTransducerTest:
+    @pytest.mark.asyncio
+    async def test_test_message(self, aiohttp_client) -> None:
+        mock_tool = MagicMock()
+        mock_tool.name = "transmit_message"
+
+        async def mock_run(**kwargs):
+            return "sent"
+
+        mock_tool.run = mock_run
+
+        mock_server = MagicMock()
+        mock_server.list_tools.return_value = [mock_tool]
+
+        with patch(
+            "openbad.skills.server.skill_server",
+            mock_server,
+        ):
+            client = await aiohttp_client(_make_app())
+            resp = await client.post(
+                "/api/transducers/discord/test",
+                json={"target": "general", "content": "hello"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["ok"] is True

--- a/wui-svelte/src/routes/+layout.svelte
+++ b/wui-svelte/src/routes/+layout.svelte
@@ -24,8 +24,9 @@
     { href: '/senses',    label: 'Senses',    icon: '👁' },
     { href: '/toolbelt',  label: 'Toolbelt',  icon: '🔧' },
     { href: '/immune',    label: 'Immune',    icon: '🛡' },
-    { href: '/skills',     label: 'Skills',     icon: '🛠' },
-    { href: '/scheduling', label: 'Scheduling', icon: '⏰' },
+    { href: '/skills',       label: 'Skills',       icon: '🛠' },
+    { href: '/transducers', label: 'Transducers', icon: '🔌' },
+    { href: '/scheduling',  label: 'Scheduling',  icon: '⏰' },
     { href: '/entity',     label: 'Entity',     icon: '👤' },
     { href: '/debug',      label: 'Debug',      icon: '🐛' },
   ];

--- a/wui-svelte/src/routes/transducers/+page.svelte
+++ b/wui-svelte/src/routes/transducers/+page.svelte
@@ -1,0 +1,451 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { get as apiGet, put as apiPut, post as apiPost } from '$lib/api/client';
+
+  // ── Types ──────────────────────────────────────────────── //
+  interface Plugin {
+    name: string;
+    enabled: boolean;
+    has_credentials: boolean;
+    health: 'healthy' | 'unhealthy' | 'unknown';
+  }
+
+  // ── State ──────────────────────────────────────────────── //
+  let plugins: Plugin[] = $state([]);
+  let loading = $state(true);
+  let error = $state('');
+
+  // Modal state
+  let configPlugin: Plugin | null = $state(null);
+  let configCredentials = $state('');
+  let configSaving = $state(false);
+  let configMsg = $state('');
+
+  // Test state
+  let testPlugin: string | null = $state(null);
+  let testResult = $state('');
+  let testLoading = $state(false);
+
+  let pollTimer: ReturnType<typeof setInterval> | undefined;
+
+  // ── Data loading ───────────────────────────────────────── //
+  async function loadPlugins(): Promise<void> {
+    try {
+      const resp = await apiGet<{ plugins: Plugin[] }>('/api/transducers');
+      plugins = resp.plugins ?? [];
+      error = '';
+    } catch (err) {
+      error = String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function togglePlugin(p: Plugin): Promise<void> {
+    try {
+      const updated = await apiPut<Plugin>(`/api/transducers/${p.name}`, {
+        enabled: !p.enabled,
+      });
+      plugins = plugins.map(pl => pl.name === p.name ? { ...pl, ...updated } : pl);
+    } catch (err) {
+      error = String(err);
+    }
+  }
+
+  function openConfig(p: Plugin): void {
+    configPlugin = p;
+    configCredentials = '';
+    configMsg = '';
+  }
+
+  function closeConfig(): void {
+    configPlugin = null;
+    configCredentials = '';
+    configMsg = '';
+  }
+
+  async function saveCredentials(): Promise<void> {
+    if (!configPlugin) return;
+    configSaving = true;
+    configMsg = '';
+    try {
+      let creds: Record<string, string>;
+      try {
+        creds = JSON.parse(configCredentials);
+      } catch {
+        configMsg = 'Invalid JSON — enter {"api_key": "..."}';
+        configSaving = false;
+        return;
+      }
+      await apiPut(`/api/transducers/${configPlugin.name}`, { credentials: creds });
+      configMsg = 'Credentials saved.';
+      await loadPlugins();
+    } catch (err) {
+      configMsg = `Error: ${err}`;
+    } finally {
+      configSaving = false;
+    }
+  }
+
+  async function testPlugin_(name: string): Promise<void> {
+    testPlugin = name;
+    testLoading = true;
+    testResult = '';
+    try {
+      const resp = await apiPost<{ ok: boolean; result?: string; error?: string }>(
+        `/api/transducers/${name}/test`,
+        { target: 'test', content: `Test from OpenBaD at ${new Date().toLocaleTimeString()}` }
+      );
+      testResult = resp.ok ? `✓ ${resp.result ?? 'Sent'}` : `✗ ${resp.error ?? 'Failed'}`;
+    } catch (err) {
+      testResult = `✗ ${err}`;
+    } finally {
+      testLoading = false;
+    }
+  }
+
+  function healthDot(status: string): string {
+    if (status === 'healthy') return 'dot-green';
+    if (status === 'unhealthy') return 'dot-red';
+    return 'dot-grey';
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') closeConfig();
+  }
+
+  onMount(() => {
+    loadPlugins();
+    pollTimer = setInterval(loadPlugins, 15_000);
+  });
+
+  onDestroy(() => { if (pollTimer) clearInterval(pollTimer); });
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div class="page-header">
+  <h2>Transducers</h2>
+  <span class="page-sub">Peripheral integrations — Corsair plugins</span>
+</div>
+
+{#if loading}
+  <p class="loading">Loading plugins…</p>
+{:else if error}
+  <p class="error">{error}</p>
+{:else if plugins.length === 0}
+  <p class="empty">No plugins configured. Edit <code>config/peripherals.yaml</code> to add plugins.</p>
+{:else}
+  <div class="plugin-grid">
+    {#each plugins as p}
+      <div class="plugin-card" class:enabled={p.enabled}>
+        <div class="card-top">
+          <span class="plugin-icon">🔌</span>
+          <div class="plugin-meta">
+            <span class="plugin-name">{p.name}</span>
+            <span class="plugin-status">
+              <span class="dot {healthDot(p.health)}"></span>
+              {p.health}
+            </span>
+          </div>
+          <label class="toggle-wrap">
+            <input
+              type="checkbox"
+              checked={p.enabled}
+              onchange={() => togglePlugin(p)}
+            />
+            <span class="toggle-track"></span>
+          </label>
+        </div>
+
+        <div class="card-actions">
+          <button class="btn-sm btn-config" onclick={() => openConfig(p)}>
+            Configure
+          </button>
+          <button
+            class="btn-sm btn-test"
+            onclick={() => testPlugin_(p.name)}
+            disabled={!p.enabled || testLoading}
+          >
+            {testLoading && testPlugin === p.name ? 'Testing…' : 'Test'}
+          </button>
+        </div>
+
+        {#if testPlugin === p.name && testResult}
+          <div class="test-result" class:ok={testResult.startsWith('✓')}>
+            {testResult}
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<!-- Configuration modal -->
+{#if configPlugin}
+  <div class="modal-backdrop" onclick={closeConfig} role="presentation">
+    <div class="modal" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+      <div class="modal-header">
+        <h3>Configure {configPlugin.name}</h3>
+        <button class="modal-close" onclick={closeConfig}>✕</button>
+      </div>
+
+      <p class="modal-desc">
+        Enter API credentials as JSON. Tokens are stored server-side with restricted permissions (0600).
+      </p>
+
+      <label class="field-label" for="creds-input">Credentials JSON</label>
+      <textarea
+        id="creds-input"
+        class="creds-textarea"
+        bind:value={configCredentials}
+        placeholder={'{"api_key": "your-key-here"}'}
+        rows="5"
+      ></textarea>
+
+      {#if configMsg}
+        <p class="config-msg" class:ok={configMsg.startsWith('Credentials')}>
+          {configMsg}
+        </p>
+      {/if}
+
+      <div class="modal-actions">
+        <button class="btn btn-secondary" onclick={closeConfig}>Cancel</button>
+        <button class="btn btn-primary" onclick={saveCredentials} disabled={configSaving}>
+          {configSaving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .page-header { margin-bottom: 1.5rem; }
+  .page-header h2 { font-size: 1.5rem; color: var(--text); margin: 0; }
+  .page-sub { color: var(--text-dim); font-size: 0.9rem; }
+
+  .loading, .error, .empty {
+    color: var(--text-dim);
+    text-align: center;
+    padding: 2rem;
+  }
+  .error { color: var(--red); }
+
+  /* ── Plugin grid ── */
+  .plugin-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1rem;
+  }
+
+  .plugin-card {
+    background: var(--bg-surface1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md, 8px);
+    padding: 1rem;
+    transition: all 0.15s ease;
+  }
+  .plugin-card:hover {
+    background: var(--bg-surface2);
+    border-color: var(--blue);
+  }
+  .plugin-card.enabled { border-left: 3px solid var(--green); }
+
+  .card-top {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .plugin-icon { font-size: 1.6rem; }
+  .plugin-meta { flex: 1; }
+  .plugin-name { display: block; font-weight: 600; color: var(--text); }
+  .plugin-status {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+  }
+
+  /* ── Health dots ── */
+  .dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+  .dot-green { background: var(--green); }
+  .dot-red { background: var(--red); }
+  .dot-grey { background: var(--text-dim); }
+
+  /* ── Toggle switch ── */
+  .toggle-wrap {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 22px;
+    cursor: pointer;
+  }
+  .toggle-wrap input { opacity: 0; width: 0; height: 0; }
+  .toggle-track {
+    position: absolute;
+    inset: 0;
+    background: var(--bg-surface0);
+    border-radius: 11px;
+    transition: background 0.2s;
+  }
+  .toggle-track::after {
+    content: '';
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    left: 3px;
+    top: 3px;
+    background: var(--text-dim);
+    border-radius: 50%;
+    transition: transform 0.2s, background 0.2s;
+  }
+  .toggle-wrap input:checked + .toggle-track {
+    background: var(--green);
+  }
+  .toggle-wrap input:checked + .toggle-track::after {
+    transform: translateX(18px);
+    background: var(--bg-base);
+  }
+
+  /* ── Card actions ── */
+  .card-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .btn-sm {
+    padding: 0.35rem 0.75rem;
+    border-radius: var(--radius-sm, 4px);
+    border: 1px solid var(--border);
+    background: var(--bg-surface0);
+    color: var(--text);
+    cursor: pointer;
+    font-size: 0.8rem;
+    transition: all 0.15s ease;
+  }
+  .btn-sm:hover:not(:disabled) { background: var(--bg-surface2); }
+  .btn-sm:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-config { color: var(--blue); border-color: var(--blue); }
+  .btn-test { color: var(--teal); border-color: var(--teal); }
+
+  /* ── Test result ── */
+  .test-result {
+    margin-top: 0.5rem;
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    color: var(--red);
+    background: rgba(243, 139, 168, 0.1);
+  }
+  .test-result.ok {
+    color: var(--green);
+    background: rgba(166, 227, 161, 0.1);
+  }
+
+  /* ── Modal ── */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    padding: 1rem;
+  }
+  .modal {
+    background: var(--bg-surface1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius, 6px);
+    padding: 1.5rem;
+    max-width: 500px;
+    width: 100%;
+    max-height: 80vh;
+    overflow-y: auto;
+  }
+  .modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+  .modal-header h3 { margin: 0; color: var(--text); }
+  .modal-close {
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 1.2rem;
+  }
+  .modal-close:hover { color: var(--text); }
+  .modal-desc {
+    color: var(--text-dim);
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+
+  .field-label {
+    display: block;
+    color: var(--text-sub);
+    font-size: 0.8rem;
+    margin-bottom: 0.35rem;
+    font-weight: 600;
+  }
+  .creds-textarea {
+    width: 100%;
+    background: var(--bg-surface0);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    padding: 0.6rem;
+    font-family: monospace;
+    font-size: 0.85rem;
+    resize: vertical;
+  }
+  .creds-textarea:focus {
+    outline: none;
+    border-color: var(--blue);
+  }
+
+  .config-msg {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--red);
+  }
+  .config-msg.ok { color: var(--green); }
+
+  .modal-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 1rem;
+  }
+  .btn {
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius-sm, 4px);
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+    transition: all 0.15s ease;
+  }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-secondary {
+    background: var(--bg-surface0);
+    color: var(--text);
+    border: 1px solid var(--border);
+  }
+  .btn-secondary:hover:not(:disabled) { background: var(--bg-surface2); }
+  .btn-primary {
+    background: var(--blue);
+    color: var(--bg-base);
+  }
+  .btn-primary:hover:not(:disabled) { opacity: 0.85; }
+</style>


### PR DESCRIPTION
Closes #593

## Summary

### Backend API (`src/openbad/wui/transducer_api.py`)
- `GET /api/transducers` — list all Corsair plugins with enabled/disabled status and health
- `PUT /api/transducers/{plugin}` — enable/disable plugin, save credentials to `data/config/peripherals/{plugin}.json` with `0600` permissions
- `GET /api/transducers/{plugin}/health` — return cached health status
- `POST /api/transducers/{plugin}/test` — send a test message via `transmit_message` skill

### Frontend (`wui-svelte/src/routes/transducers/+page.svelte`)
- Grid layout with Catppuccin Mocha styled plugin cards
- Each card: plugin name, enable/disable toggle switch, green/red/grey health dot, Configure + Test buttons
- Configuration modal: JSON credential entry, server-side storage with restricted permissions
- Test messaging with success/failure feedback
- 15-second polling for status updates
- Added "Transducers" nav item (🔌) to sidebar

### Route wiring
- `setup_transducer_routes(app)` called from `create_app()` in server.py

## Tests (9 total)
- GET: returns plugin list, correct shape, disabled plugin status
- PUT: 404 for unknown plugin, saves credentials with 0600 permissions, toggle enabled
- Health: unknown default, cached health
- Test: sends test message via skill server

## How to Test

```bash
# Backend tests
.venv/bin/pytest tests/test_transducer_api.py -v

# Svelte build
cd wui-svelte && npm run build

# Lint
.venv/bin/ruff check src/openbad/wui/transducer_api.py
```