### PR TITLE
#602: Peripheral chat router

### DIFF
--- a/src/openbad/peripherals/chat_router.py
+++ b/src/openbad/peripherals/chat_router.py
@@ -1,0 +1,154 @@
+"""Peripheral chat router — bridges inbound peripheral messages to the chat pipeline.
+
+Subscribes to ``sensory/external/+/inbound``, feeds each message through
+:func:`~openbad.wui.chat_pipeline.stream_chat`, and publishes the
+assembled reply to ``motor/external/{platform}/outbound``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from openbad.nervous_system import topics
+from openbad.nervous_system.client import NervousSystemClient
+from openbad.wui.chat_pipeline import stream_chat
+
+logger = logging.getLogger(__name__)
+
+
+class PeripheralChatRouter:
+    """Route messages from external peripherals through the chat pipeline."""
+
+    def __init__(
+        self,
+        mqtt_client: NervousSystemClient,
+        model_resolver: Callable[[], tuple[Any, str, str]],
+    ) -> None:
+        """Initialise the router.
+
+        Parameters
+        ----------
+        mqtt_client:
+            The shared MQTT client for pub/sub.
+        model_resolver:
+            A callable returning ``(chat_model, model_id, provider_name)``
+            for the current default provider.  This is called per-message
+            so the router always uses the latest configuration.
+        """
+        self._mqtt = mqtt_client
+        self._resolve_model = model_resolver
+        self._running = False
+
+    # ── Lifecycle ─────────────────────────────────────────── #
+
+    def start(self) -> None:
+        """Subscribe to the external inbound wildcard topic."""
+        if self._running:
+            return
+        self._running = True
+        self._mqtt.subscribe(
+            topics.EXTERNAL_INBOUND_ALL,
+            bytes,
+            self._on_inbound,
+        )
+        logger.info("PeripheralChatRouter started")
+
+    def stop(self) -> None:
+        """Unsubscribe from inbound messages."""
+        self._running = False
+        self._mqtt.unsubscribe(topics.EXTERNAL_INBOUND_ALL)
+        logger.info("PeripheralChatRouter stopped")
+
+    # ── Inbound handler ──────────────────────────────────── #
+
+    def _on_inbound(self, topic: str, payload: bytes) -> None:
+        """Dispatch inbound MQTT messages to the async handler."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            logger.error("No event loop — cannot handle inbound message")
+            return
+        loop.create_task(self._handle_inbound(topic, payload))
+
+    async def _handle_inbound(self, topic: str, payload: bytes) -> None:
+        """Parse the inbound message, run through chat, and reply."""
+        try:
+            data = json.loads(payload.decode("utf-8"))
+        except Exception:
+            logger.exception("Invalid inbound payload on %s", topic)
+            return
+
+        platform = data.get("platform", "")
+        event = data.get("event", "")
+        msg_data = data.get("data", {})
+        content = msg_data.get("content", "")
+        sender = msg_data.get("sender", "")
+        sender_name = msg_data.get("sender_name", "")
+
+        if not content or event != "message":
+            return
+
+        session_id = f"peripheral:{platform}:{sender}"
+        logger.info(
+            "Peripheral message from %s/%s (%s): %s",
+            platform, sender_name, sender, content[:80],
+        )
+
+        # Resolve the current model
+        try:
+            chat_model, model_id, provider_name = self._resolve_model()
+        except Exception:
+            logger.exception("Failed to resolve chat model")
+            return
+
+        if chat_model is None:
+            logger.warning("No chat model configured — skipping peripheral message")
+            return
+
+        # Collect the streamed response
+        reply_parts: list[str] = []
+        try:
+            async for chunk in stream_chat(
+                chat_model,
+                model_id,
+                content,
+                session_id,
+                provider_name=provider_name,
+                nervous_system_client=self._mqtt,
+            ):
+                if chunk.error:
+                    logger.error("Chat pipeline error: %s", chunk.error)
+                    reply_parts.append(f"[Error: {chunk.error}]")
+                    break
+                if chunk.token:
+                    reply_parts.append(chunk.token)
+                if chunk.done:
+                    break
+        except Exception:
+            logger.exception("Chat pipeline failed for %s/%s", platform, sender)
+            return
+
+        reply_text = "".join(reply_parts).strip()
+        if not reply_text:
+            logger.warning("Empty reply for %s/%s — not sending", platform, sender)
+            return
+
+        # Publish reply to the outbound topic
+        outbound_topic = topics.topic_for(
+            topics.EXTERNAL_OUTBOUND, platform=platform,
+        )
+        outbound_payload = json.dumps({
+            "chat_id": sender,
+            "text": reply_text,
+        }).encode()
+
+        self._mqtt.publish_bytes(outbound_topic, outbound_payload, qos=1)
+        logger.info(
+            "Reply sent to %s/%s (%d chars)",
+            platform, sender, len(reply_text),
+        )

--- a/tests/test_peripheral_chat_router.py
+++ b/tests/test_peripheral_chat_router.py
@@ -1,0 +1,242 @@
+"""Tests for the peripheral chat router."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openbad.peripherals.chat_router import PeripheralChatRouter
+from openbad.wui.chat_pipeline import StreamChunk
+
+
+def _make_mqtt() -> MagicMock:
+    client = MagicMock()
+    client.publish_bytes = MagicMock()
+    client.subscribe = MagicMock()
+    client.unsubscribe = MagicMock()
+    return client
+
+
+def _resolver(model=None, model_id="test/model", provider="test"):
+    if model is None:
+        model = MagicMock()
+    return lambda: (model, model_id, provider)
+
+
+class TestPeripheralChatRouter:
+
+    def test_start_subscribes(self) -> None:
+        mqtt = _make_mqtt()
+        router = PeripheralChatRouter(mqtt, _resolver())
+        router.start()
+        mqtt.subscribe.assert_called_once()
+        assert router._running is True
+
+    def test_stop_unsubscribes(self) -> None:
+        mqtt = _make_mqtt()
+        router = PeripheralChatRouter(mqtt, _resolver())
+        router.start()
+        router.stop()
+        mqtt.unsubscribe.assert_called_once()
+        assert router._running is False
+
+    def test_start_idempotent(self) -> None:
+        mqtt = _make_mqtt()
+        router = PeripheralChatRouter(mqtt, _resolver())
+        router.start()
+        router.start()
+        assert mqtt.subscribe.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_inbound_routes_and_replies(self) -> None:
+        mqtt = _make_mqtt()
+        model = MagicMock()
+
+        async def fake_stream(*args, **kwargs):
+            yield StreamChunk(token="Hello ")  # noqa: S106
+            yield StreamChunk(token="World")  # noqa: S106
+            yield StreamChunk(done=True)
+
+        router = PeripheralChatRouter(mqtt, _resolver(model))
+
+        payload = json.dumps({
+            "platform": "telegram",
+            "event": "message",
+            "data": {
+                "sender": "42",
+                "content": "hi there",
+                "sender_name": "Bruce",
+            },
+        }).encode()
+
+        with patch(
+            "openbad.peripherals.chat_router.stream_chat",
+            side_effect=fake_stream,
+        ):
+            await router._handle_inbound(
+                "sensory/external/telegram/inbound", payload,
+            )
+
+        mqtt.publish_bytes.assert_called_once()
+        topic, reply_bytes = mqtt.publish_bytes.call_args[0][:2]
+        assert topic == "motor/external/telegram/outbound"
+        reply = json.loads(reply_bytes)
+        assert reply["chat_id"] == "42"
+        assert reply["text"] == "Hello World"
+
+    @pytest.mark.asyncio
+    async def test_handle_inbound_error_chunk(self) -> None:
+        mqtt = _make_mqtt()
+
+        async def error_stream(*args, **kwargs):
+            yield StreamChunk(error="boom", done=True)
+
+        router = PeripheralChatRouter(mqtt, _resolver())
+
+        payload = json.dumps({
+            "platform": "telegram",
+            "event": "message",
+            "data": {"sender": "1", "content": "test", "sender_name": "X"},
+        }).encode()
+
+        with patch(
+            "openbad.peripherals.chat_router.stream_chat",
+            side_effect=error_stream,
+        ):
+            await router._handle_inbound(
+                "sensory/external/telegram/inbound", payload,
+            )
+
+        mqtt.publish_bytes.assert_called_once()
+        reply = json.loads(mqtt.publish_bytes.call_args[0][1])
+        assert "[Error: boom]" in reply["text"]
+
+    @pytest.mark.asyncio
+    async def test_handle_inbound_no_model(self) -> None:
+        mqtt = _make_mqtt()
+        router = PeripheralChatRouter(
+            mqtt, lambda: (None, None, ""),
+        )
+
+        payload = json.dumps({
+            "platform": "telegram",
+            "event": "message",
+            "data": {"sender": "1", "content": "hi", "sender_name": "X"},
+        }).encode()
+
+        await router._handle_inbound(
+            "sensory/external/telegram/inbound", payload,
+        )
+        mqtt.publish_bytes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_inbound_skips_non_message_event(self) -> None:
+        mqtt = _make_mqtt()
+        router = PeripheralChatRouter(mqtt, _resolver())
+
+        payload = json.dumps({
+            "platform": "telegram",
+            "event": "typing",
+            "data": {"sender": "1", "content": "hi"},
+        }).encode()
+
+        await router._handle_inbound(
+            "sensory/external/telegram/inbound", payload,
+        )
+        mqtt.publish_bytes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_inbound_skips_empty_content(self) -> None:
+        mqtt = _make_mqtt()
+        router = PeripheralChatRouter(mqtt, _resolver())
+
+        payload = json.dumps({
+            "platform": "telegram",
+            "event": "message",
+            "data": {"sender": "1", "content": ""},
+        }).encode()
+
+        await router._handle_inbound(
+            "sensory/external/telegram/inbound", payload,
+        )
+        mqtt.publish_bytes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_inbound_empty_reply_not_sent(self) -> None:
+        mqtt = _make_mqtt()
+
+        async def empty_stream(*args, **kwargs):
+            yield StreamChunk(done=True)
+
+        router = PeripheralChatRouter(mqtt, _resolver())
+
+        payload = json.dumps({
+            "platform": "telegram",
+            "event": "message",
+            "data": {"sender": "1", "content": "test", "sender_name": "X"},
+        }).encode()
+
+        with patch(
+            "openbad.peripherals.chat_router.stream_chat",
+            side_effect=empty_stream,
+        ):
+            await router._handle_inbound(
+                "sensory/external/telegram/inbound", payload,
+            )
+
+        mqtt.publish_bytes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_inbound_invalid_json(self) -> None:
+        mqtt = _make_mqtt()
+        router = PeripheralChatRouter(mqtt, _resolver())
+
+        await router._handle_inbound("topic", b"not-json")
+        mqtt.publish_bytes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_session_id_format(self) -> None:
+        mqtt = _make_mqtt()
+        model = MagicMock()
+        calls = []
+
+        async def capture_stream(*args, **kwargs):
+            calls.append(kwargs.get("session_id") or args[3])
+            yield StreamChunk(token="ok", done=True)  # noqa: S106
+
+        router = PeripheralChatRouter(mqtt, _resolver(model))
+
+        payload = json.dumps({
+            "platform": "discord",
+            "event": "message",
+            "data": {"sender": "99", "content": "test"},
+        }).encode()
+
+        with patch(
+            "openbad.peripherals.chat_router.stream_chat",
+            side_effect=capture_stream,
+        ):
+            await router._handle_inbound(
+                "sensory/external/discord/inbound", payload,
+            )
+
+        # stream_chat is called with positional args: model, model_id, msg, session_id
+        # session_id is the 4th positional arg
+        assert calls[0] == "peripheral:discord:99"
+
+    def test_on_inbound_dispatches_to_loop(self) -> None:
+        mqtt = _make_mqtt()
+        router = PeripheralChatRouter(mqtt, _resolver())
+
+        mock_loop = MagicMock()
+        with patch("asyncio.get_event_loop", return_value=mock_loop):
+            router._on_inbound(
+                "topic",
+                json.dumps(
+                    {"platform": "t", "event": "message",
+                     "data": {"content": "hi", "sender": "1"}},
+                ).encode(),
+            )
+            mock_loop.create_task.assert_called_once()


### PR DESCRIPTION
Closes #602

## Summary
Adds `PeripheralChatRouter` — subscribes to `sensory/external/+/inbound`, feeds each message through the full `stream_chat()` pipeline, and publishes the assembled reply to `motor/external/{platform}/outbound`.

### Key features:
- **Model resolution**: Uses a callable `model_resolver` so the daemon can inject the current provider config
- **Session isolation**: Each peripheral sender gets a unique session ID (`peripheral:{platform}:{sender}`)
- **Error handling**: Logs and sends error text if the pipeline fails; skips empty replies
- **Platform-agnostic**: Works for any platform (telegram, discord, slack, etc.)

### Files:
- `src/openbad/peripherals/chat_router.py` — Router implementation
- `tests/test_peripheral_chat_router.py` — 12 unit tests

## How to test
```bash
.venv/bin/pytest tests/test_peripheral_chat_router.py -v
```