### PR TITLE
#603: Wire peripheral transducers into daemon lifecycle

### DIFF
--- a/src/openbad/daemon.py
+++ b/src/openbad/daemon.py
@@ -23,6 +23,9 @@ from openbad.nervous_system.schemas.cognitive_pb2 import ModelHealthStatus
 from openbad.nervous_system.schemas.common_pb2 import Header
 from openbad.nervous_system.schemas.endocrine_pb2 import EndocrineEvent
 from openbad.nervous_system.schemas.telemetry_pb2 import TokenTelemetry
+from openbad.peripherals.chat_router import PeripheralChatRouter
+from openbad.peripherals.config import load_peripherals_config
+from openbad.peripherals.telegram_bridge import TelegramBridge
 from openbad.plugins.observations.external_signals import ExternalSignalPlugin
 from openbad.reflex_arc.fsm import AgentFSM
 
@@ -66,6 +69,8 @@ class Daemon:
         self._stop_event: asyncio.Event | None = None
         self._crew_bridge: CrewMQTTBridge | None = None
         self._external_signal_plugin: ExternalSignalPlugin | None = None
+        self._telegram_bridge: TelegramBridge | None = None
+        self._chat_router: PeripheralChatRouter | None = None
 
     # -- public --------------------------------------------------------- #
 
@@ -123,6 +128,9 @@ class Daemon:
         )
         self._crew_bridge.subscribe()
 
+        # 4b. Peripheral transducers (Telegram, etc.)
+        await self._start_peripherals()
+
         # 5. Interoception publishers for vitals panels and dashboards
         telemetry_interval_s = _load_hardware_telemetry_interval()
         self._telemetry = TelemetryMonitor(self._client, interval=telemetry_interval_s)
@@ -166,6 +174,9 @@ class Daemon:
         if self._telemetry is not None:
             self._telemetry.stop()
             self._telemetry = None
+
+        # Peripheral transducers
+        await self._stop_peripherals()
 
         self._crew_bridge = None
         self._endocrine = None
@@ -334,6 +345,55 @@ class Daemon:
         finally:
             if self._fsm is not None:
                 self._fsm.finish_work()
+
+    # -- peripheral transducers ----------------------------------------- #
+
+    async def _start_peripherals(self) -> None:
+        """Start enabled peripheral bridges (Telegram, etc.)."""
+        if self._client is None:
+            return
+
+        cfg = load_peripherals_config()
+        enabled_plugins = {p.name for p in cfg.plugins if p.enabled}
+
+        if "telegram" in enabled_plugins:
+            bridge = TelegramBridge.from_credentials(self._client)
+            if bridge is not None:
+                await bridge.start()
+                self._telegram_bridge = bridge
+                logger.info("Telegram bridge activated")
+            else:
+                logger.warning("Telegram enabled but credentials missing")
+
+        if enabled_plugins:
+            self._chat_router = PeripheralChatRouter(
+                self._client, self._resolve_chat_model,
+            )
+            self._chat_router.start()
+
+    async def _stop_peripherals(self) -> None:
+        """Stop peripheral bridges."""
+        if self._chat_router is not None:
+            self._chat_router.stop()
+            self._chat_router = None
+
+        if self._telegram_bridge is not None:
+            await self._telegram_bridge.stop()
+            self._telegram_bridge = None
+
+    def _resolve_chat_model(self) -> tuple[object | None, str | None, str]:
+        """Return ``(chat_model, model_id, provider_name)`` for the default provider."""
+        try:
+            from openbad.wui.server import _read_providers_config, _resolve_chat_adapter
+
+            _path, config = _read_providers_config()
+            chat_model, model_id, provider_name, *_ = _resolve_chat_adapter(
+                config, "chat",
+            )
+            return chat_model, model_id, provider_name
+        except Exception:
+            logger.exception("Failed to resolve chat model for peripheral router")
+            return None, None, ""
 
     def _on_external_inbound(self, topic: str, payload: bytes) -> None:
         """Handle an inbound external message from the Corsair webhook bridge.

--- a/tests/test_daemon_peripherals.py
+++ b/tests/test_daemon_peripherals.py
@@ -1,0 +1,133 @@
+"""Tests for daemon peripheral wiring (#603)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openbad.daemon import Daemon
+
+
+@pytest.fixture
+def daemon() -> Daemon:
+    return Daemon(mqtt_host="localhost", mqtt_port=1883, dry_run=True)
+
+
+class TestDaemonPeripherals:
+
+    def test_init_has_peripheral_attrs(self, daemon: Daemon) -> None:
+        assert daemon._telegram_bridge is None
+        assert daemon._chat_router is None
+
+    @pytest.mark.asyncio
+    async def test_start_peripherals_no_plugins(self, daemon: Daemon) -> None:
+        daemon._client = MagicMock()
+        with patch(
+            "openbad.daemon.load_peripherals_config",
+        ) as mock_cfg:
+            from openbad.peripherals.config import CorsairConfig
+            mock_cfg.return_value = CorsairConfig(plugins=[])
+            await daemon._start_peripherals()
+
+        assert daemon._telegram_bridge is None
+        assert daemon._chat_router is None
+
+    @pytest.mark.asyncio
+    async def test_start_peripherals_telegram_enabled(
+        self, daemon: Daemon,
+    ) -> None:
+        daemon._client = MagicMock()
+
+        from openbad.peripherals.config import CorsairConfig, PluginConfig
+
+        cfg = CorsairConfig(plugins=[
+            PluginConfig(name="telegram", enabled=True),
+        ])
+        mock_bridge = MagicMock()
+        mock_bridge.start = AsyncMock()
+
+        with (
+            patch("openbad.daemon.load_peripherals_config", return_value=cfg),
+            patch(
+                "openbad.daemon.TelegramBridge.from_credentials",
+                return_value=mock_bridge,
+            ),
+        ):
+            await daemon._start_peripherals()
+
+        mock_bridge.start.assert_awaited_once()
+        assert daemon._telegram_bridge is mock_bridge
+        assert daemon._chat_router is not None
+
+    @pytest.mark.asyncio
+    async def test_start_peripherals_telegram_no_creds(
+        self, daemon: Daemon,
+    ) -> None:
+        daemon._client = MagicMock()
+
+        from openbad.peripherals.config import CorsairConfig, PluginConfig
+
+        cfg = CorsairConfig(plugins=[
+            PluginConfig(name="telegram", enabled=True),
+        ])
+
+        with (
+            patch("openbad.daemon.load_peripherals_config", return_value=cfg),
+            patch(
+                "openbad.daemon.TelegramBridge.from_credentials",
+                return_value=None,
+            ),
+        ):
+            await daemon._start_peripherals()
+
+        assert daemon._telegram_bridge is None
+        # Chat router still created because plugin is enabled
+        assert daemon._chat_router is not None
+
+    @pytest.mark.asyncio
+    async def test_stop_peripherals(self, daemon: Daemon) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.stop = AsyncMock()
+        mock_router = MagicMock()
+
+        daemon._telegram_bridge = mock_bridge
+        daemon._chat_router = mock_router
+
+        await daemon._stop_peripherals()
+
+        mock_bridge.stop.assert_awaited_once()
+        mock_router.stop.assert_called_once()
+        assert daemon._telegram_bridge is None
+        assert daemon._chat_router is None
+
+    @pytest.mark.asyncio
+    async def test_stop_peripherals_noop_when_none(
+        self, daemon: Daemon,
+    ) -> None:
+        await daemon._stop_peripherals()
+        assert daemon._telegram_bridge is None
+        assert daemon._chat_router is None
+
+    def test_resolve_chat_model_success(self, daemon: Daemon) -> None:
+        mock_model = MagicMock()
+        with patch("openbad.wui.server._read_providers_config") as mock_read, \
+             patch("openbad.wui.server._resolve_chat_adapter") as mock_resolve:
+            mock_read.return_value = (MagicMock(), MagicMock())
+            mock_resolve.return_value = (
+                mock_model, "test/model", "test-provider", False, None, None,
+            )
+            result = daemon._resolve_chat_model()
+
+        assert result[0] is mock_model
+        assert result[1] == "test/model"
+        assert result[2] == "test-provider"
+
+    def test_resolve_chat_model_failure(self, daemon: Daemon) -> None:
+        with patch(
+            "openbad.wui.server._read_providers_config",
+            side_effect=Exception("no config"),
+        ):
+            result = daemon._resolve_chat_model()
+
+        assert result == (None, None, "")


### PR DESCRIPTION
Closes #603

## Summary
Wires `TelegramBridge` and `PeripheralChatRouter` into the daemon's `start()`/`stop()` lifecycle.

### Changes in `src/openbad/daemon.py`:
- Imports TelegramBridge, PeripheralChatRouter, and load_peripherals_config
- New instance vars `_telegram_bridge` and `_chat_router`
- `_start_peripherals()`: checks peripherals config, creates TelegramBridge from credentials if telegram is enabled, creates PeripheralChatRouter with model resolver
- `_stop_peripherals()`: graceful async teardown in reverse order
- `_resolve_chat_model()`: lazy import from server.py to resolve the current default LLM provider

### Tests (8):
- Init attrs present
- No plugins → no bridge/router created
- Telegram enabled → bridge + router started
- Telegram enabled but no creds → router only
- Stop lifecycle
- Model resolver success/failure

## How to test
```bash
.venv/bin/pytest tests/test_daemon_peripherals.py -v
```