### PR TITLE
Centralize peripheral config paths — wizard writes directly to production paths

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -455,6 +455,13 @@ create_dirs() {
     mkdir -p "$DATA_DIR" "$LOG_DIR"
     chown "$OPENBAD_USER:$OPENBAD_GROUP" "$DATA_DIR" "$LOG_DIR"
     chmod 750 "$DATA_DIR" "$LOG_DIR"
+
+    # Peripheral transducer credentials directory
+    local creds_dir="$DATA_DIR/data/config/peripherals"
+    mkdir -p "$creds_dir"
+    chown "$OPENBAD_USER:$OPENBAD_GROUP" "$creds_dir"
+    chmod 700 "$creds_dir"
+    info "  Created $creds_dir"
 }
 
 # ------------------------------------------------------------------

--- a/src/openbad/peripherals/config.py
+++ b/src/openbad/peripherals/config.py
@@ -13,8 +13,11 @@ _DEFAULT_SEARCH_PATHS: list[Path] = [
     Path("config/peripherals.yaml"),
 ]
 
-# Where per-plugin credential files live.
-_DEFAULT_CREDENTIALS_DIR = Path("data/config/peripherals")
+# Credentials dir search order (production → repo fallback).
+_CREDENTIALS_DIR_CANDIDATES: list[Path] = [
+    Path("/var/lib/openbad/data/config/peripherals"),
+    Path("data/config/peripherals"),
+]
 
 
 @dataclass(frozen=True)
@@ -33,6 +36,54 @@ class CorsairConfig:
     entry_point: str = ""
     webhook_secret: str = ""
     plugins: list[PluginConfig] = field(default_factory=list)
+
+
+def resolve_credentials_dir() -> Path:
+    """Return the credentials directory, preferring the production path.
+
+    Creates the directory if it doesn't exist at the selected location.
+    Falls back to ``data/config/peripherals`` (relative to CWD) for dev.
+    """
+    for candidate in _CREDENTIALS_DIR_CANDIDATES:
+        if candidate.is_dir():
+            return candidate
+        # If the parent exists and is writable, use this candidate
+        if candidate.parent.exists():
+            try:
+                candidate.mkdir(parents=True, exist_ok=True)
+                return candidate
+            except OSError:
+                continue
+    # Final fallback: relative path
+    fallback = _CREDENTIALS_DIR_CANDIDATES[-1]
+    fallback.mkdir(parents=True, exist_ok=True)
+    return fallback
+
+
+def resolve_config_write_path() -> Path:
+    """Return the path to write ``peripherals.yaml``.
+
+    Prefers ``/etc/openbad/peripherals.yaml`` when writable, otherwise
+    falls back to the repo-local ``config/peripherals.yaml``.
+    """
+    for candidate in _DEFAULT_SEARCH_PATHS:
+        if candidate.exists():
+            try:
+                # Check if writable
+                candidate.open("a").close()
+                return candidate
+            except OSError:
+                continue
+        elif candidate.parent.is_dir():
+            try:
+                candidate.parent.mkdir(parents=True, exist_ok=True)
+                return candidate
+            except OSError:
+                continue
+    # Fallback
+    fallback = _DEFAULT_SEARCH_PATHS[-1]
+    fallback.parent.mkdir(parents=True, exist_ok=True)
+    return fallback
 
 
 def _resolve_config_path(
@@ -105,7 +156,7 @@ def resolve_credentials_path(
     if not plugin.credentials_file:
         return None
 
-    base = credentials_dir or _DEFAULT_CREDENTIALS_DIR
+    base = credentials_dir or resolve_credentials_dir()
     candidate = base / plugin.credentials_file
 
     if not candidate.is_file():

--- a/src/openbad/peripherals/telegram_bridge.py
+++ b/src/openbad/peripherals/telegram_bridge.py
@@ -19,11 +19,11 @@ import aiohttp
 
 from openbad.nervous_system import topics
 from openbad.nervous_system.client import NervousSystemClient
+from openbad.peripherals.config import resolve_credentials_dir
 
 logger = logging.getLogger(__name__)
 
 _TELEGRAM_API = "https://api.telegram.org/bot{token}"
-_CREDS_DIR = Path("data/config/peripherals")
 _POLL_TIMEOUT = 30  # Telegram long-poll timeout (seconds)
 _MAX_BACKOFF = 60  # Max retry backoff on API errors
 
@@ -223,7 +223,7 @@ class TelegramBridge:
         credentials_dir: Path | None = None,
     ) -> TelegramBridge | None:
         """Create a bridge from stored credentials, or None if unavailable."""
-        creds_dir = credentials_dir or _CREDS_DIR
+        creds_dir = credentials_dir or resolve_credentials_dir()
         creds_path = creds_dir / "telegram.json"
         if not creds_path.exists():
             logger.warning("No Telegram credentials at %s", creds_path)

--- a/src/openbad/wui/transducer_api.py
+++ b/src/openbad/wui/transducer_api.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import stat
-from pathlib import Path
 
 from aiohttp import web
 
@@ -14,11 +13,11 @@ from openbad.peripherals.config import (
     CorsairConfig,
     PluginConfig,
     load_peripherals_config,
+    resolve_config_write_path,
+    resolve_credentials_dir,
 )
 
 logger = logging.getLogger(__name__)
-
-_CREDS_DIR = Path("data/config/peripherals")
 
 # Available Corsair plugin catalog — integrations users can add.
 # Each entry describes the plugin, required credential fields, and a hint.
@@ -157,8 +156,8 @@ async def _put_transducer(request: web.Request) -> web.Response:
 
     # Save credentials securely if provided
     if credentials and isinstance(credentials, dict):
-        _CREDS_DIR.mkdir(parents=True, exist_ok=True)
-        creds_path = _CREDS_DIR / f"{plugin_name}.json"
+        creds_dir = resolve_credentials_dir()
+        creds_path = creds_dir / f"{plugin_name}.json"
         creds_path.write_text(json.dumps(credentials, indent=2))
         # Set file permissions to 0600 (owner read/write only)
         os.chmod(creds_path, stat.S_IRUSR | stat.S_IWUSR)
@@ -206,8 +205,8 @@ async def _post_transducer(request: web.Request) -> web.Response:
 
     # Save credentials if provided
     if credentials and isinstance(credentials, dict):
-        _CREDS_DIR.mkdir(parents=True, exist_ok=True)
-        creds_path = _CREDS_DIR / f"{name}.json"
+        creds_dir = resolve_credentials_dir()
+        creds_path = creds_dir / f"{name}.json"
         creds_path.write_text(json.dumps(credentials, indent=2))
         os.chmod(creds_path, stat.S_IRUSR | stat.S_IWUSR)
 
@@ -280,7 +279,8 @@ async def _verify_credentials(plugin_name: str) -> web.Response:
     """Verify credentials by calling the platform's API directly."""
     import aiohttp as _aiohttp  # noqa: PLC0415
 
-    creds_path = _CREDS_DIR / f"{plugin_name}.json"
+    creds_dir = resolve_credentials_dir()
+    creds_path = creds_dir / f"{plugin_name}.json"
     if not creds_path.exists():
         return web.json_response(
             {"ok": False, "error": "No credentials file found"}, status=400,
@@ -371,19 +371,17 @@ async def _verify_credentials(plugin_name: str) -> web.Response:
 
 
 def _update_plugin_enabled(plugin_name: str, enabled: bool) -> None:
-    """Toggle the enabled flag for a plugin in peripherals.yaml."""
+    """Toggle the enabled flag for a plugin in peripherals.yaml.
+
+    Writes to the first writable config path (``/etc/openbad`` in
+    production, ``config/`` in dev) so the daemon picks up changes
+    without manual file copying.
+    """
     import yaml  # noqa: PLC0415
 
-    # Read from /etc first (production overlay), but always write to
-    # the local config dir (writable by the service user).
-    write_path = Path("config/peripherals.yaml")
-    read_path = write_path
+    write_path = resolve_config_write_path()
 
-    etc_path = Path("/etc/openbad/peripherals.yaml")
-    if etc_path.exists():
-        read_path = etc_path
-
-    raw = (yaml.safe_load(read_path.read_text()) or {}) if read_path.exists() else {}
+    raw = (yaml.safe_load(write_path.read_text()) or {}) if write_path.exists() else {}
 
     corsair = raw.setdefault("corsair", {})
     plugins = corsair.setdefault("plugins", [])
@@ -391,9 +389,16 @@ def _update_plugin_enabled(plugin_name: str, enabled: bool) -> None:
     for p in plugins:
         if isinstance(p, dict) and p.get("name") == plugin_name:
             p["enabled"] = enabled
+            # Ensure credentials_file is set
+            if not p.get("credentials_file"):
+                p["credentials_file"] = f"{plugin_name}.json"
             break
     else:
-        plugins.append({"name": plugin_name, "enabled": enabled})
+        plugins.append({
+            "name": plugin_name,
+            "enabled": enabled,
+            "credentials_file": f"{plugin_name}.json",
+        })
 
     write_path.parent.mkdir(parents=True, exist_ok=True)
     write_path.write_text(yaml.dump(raw, default_flow_style=False))

--- a/tests/test_peripherals_config.py
+++ b/tests/test_peripherals_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import textwrap
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -13,6 +14,8 @@ from openbad.peripherals.config import (
     PluginConfig,
     enabled_plugin_names,
     load_peripherals_config,
+    resolve_config_write_path,
+    resolve_credentials_dir,
     resolve_credentials_path,
 )
 
@@ -205,3 +208,65 @@ class TestEnabledPluginNames:
 
     def test_empty_for_default_config(self) -> None:
         assert enabled_plugin_names(CorsairConfig()) == []
+
+
+# ── resolve_credentials_dir tests ─────────────────────────────────── #
+
+
+class TestResolveCredentialsDir:
+
+    def test_returns_existing_dir(self, tmp_path: Path) -> None:
+        with patch(
+            "openbad.peripherals.config._CREDENTIALS_DIR_CANDIDATES",
+            [tmp_path / "prod", tmp_path / "dev"],
+        ):
+            prod = tmp_path / "prod"
+            prod.mkdir()
+            result = resolve_credentials_dir()
+            assert result == prod
+
+    def test_creates_dir_if_parent_exists(self, tmp_path: Path) -> None:
+        with patch(
+            "openbad.peripherals.config._CREDENTIALS_DIR_CANDIDATES",
+            [tmp_path / "prod" / "creds", tmp_path / "dev"],
+        ):
+            (tmp_path / "prod").mkdir()
+            result = resolve_credentials_dir()
+            assert result == tmp_path / "prod" / "creds"
+            assert result.is_dir()
+
+    def test_falls_back_to_last_candidate(self, tmp_path: Path) -> None:
+        with patch(
+            "openbad.peripherals.config._CREDENTIALS_DIR_CANDIDATES",
+            [tmp_path / "nonexistent" / "prod", tmp_path / "dev"],
+        ):
+            result = resolve_credentials_dir()
+            assert result == tmp_path / "dev"
+            assert result.is_dir()
+
+
+# ── resolve_config_write_path tests ───────────────────────────────── #
+
+
+class TestResolveConfigWritePath:
+
+    def test_returns_existing_writable_file(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "peripherals.yaml"
+        cfg.write_text("corsair: {}")
+        with patch(
+            "openbad.peripherals.config._DEFAULT_SEARCH_PATHS",
+            [cfg, tmp_path / "fallback.yaml"],
+        ):
+            result = resolve_config_write_path()
+            assert result == cfg
+
+    def test_falls_back_when_not_writable(self, tmp_path: Path) -> None:
+        read_only = tmp_path / "ro" / "peripherals.yaml"
+        fallback = tmp_path / "fb" / "peripherals.yaml"
+        (tmp_path / "fb").mkdir()
+        with patch(
+            "openbad.peripherals.config._DEFAULT_SEARCH_PATHS",
+            [read_only, fallback],
+        ):
+            result = resolve_config_write_path()
+            assert result == fallback

--- a/tests/test_transducer_api.py
+++ b/tests/test_transducer_api.py
@@ -94,7 +94,8 @@ class TestPutTransducer:
     @pytest.mark.asyncio
     async def test_saves_credentials(self, aiohttp_client, tmp_path) -> None:
         with patch(
-            "openbad.wui.transducer_api._CREDS_DIR", tmp_path,
+            "openbad.wui.transducer_api.resolve_credentials_dir",
+            return_value=tmp_path,
         ), patch(
             "openbad.wui.transducer_api._update_plugin_enabled",
         ):
@@ -246,7 +247,8 @@ class TestPostTransducer:
     @pytest.mark.asyncio
     async def test_creates_plugin(self, aiohttp_client, tmp_path) -> None:
         with patch(
-            "openbad.wui.transducer_api._CREDS_DIR", tmp_path,
+            "openbad.wui.transducer_api.resolve_credentials_dir",
+            return_value=tmp_path,
         ), patch(
             "openbad.wui.transducer_api._update_plugin_enabled",
         ):
@@ -335,7 +337,8 @@ class TestCredentialVerification:
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
-            "openbad.wui.transducer_api._CREDS_DIR", tmp_path,
+            "openbad.wui.transducer_api.resolve_credentials_dir",
+            return_value=tmp_path,
         ), patch(
             "aiohttp.ClientSession", return_value=mock_session,
         ):
@@ -361,7 +364,8 @@ class TestCredentialVerification:
     async def test_missing_credentials(self, aiohttp_client, tmp_path) -> None:
         """Test returns error when no credentials file exists."""
         with patch(
-            "openbad.wui.transducer_api._CREDS_DIR", tmp_path,
+            "openbad.wui.transducer_api.resolve_credentials_dir",
+            return_value=tmp_path,
         ):
             mock_server = MagicMock()
             mock_server.list_tools = MagicMock(return_value=[])


### PR DESCRIPTION
## Summary
The WUI wizard was writing credentials and config to relative paths that didn't match where the daemon reads from in production. This meant users had to manually copy files and run CLI commands after adding a plugin through the UI.

### Root cause
- `transducer_api.py` wrote creds to `data/config/peripherals/` (relative) and config to `config/peripherals.yaml` (relative)
- In production (WorkingDirectory=/var/lib/openbad), these become `/var/lib/openbad/data/config/peripherals/` and `/var/lib/openbad/config/peripherals.yaml`
- But the daemon reads config from `/etc/openbad/peripherals.yaml` via `load_peripherals_config()`
- The WUI service already has `ReadWritePaths=/var/lib/openbad /var/log/openbad /etc/openbad`

### Fix
- **`peripherals/config.py`**: New `resolve_credentials_dir()` and `resolve_config_write_path()` functions with production → dev fallback
- **`transducer_api.py`**: Uses centralized path helpers — wizard now writes directly to `/etc/openbad/peripherals.yaml` and `/var/lib/openbad/data/config/peripherals/` in production
- **`telegram_bridge.py`**: Uses centralized credentials dir
- **`install.sh`**: Creates `$DATA_DIR/data/config/peripherals/` with correct ownership/permissions (700)
- `_update_plugin_enabled` now automatically sets `credentials_file` on new entries

### Now the flow is:
1. User clicks "+ Add Plugin" in WUI → enters bot token → clicks Finish
2. Wizard writes creds to `/var/lib/openbad/data/config/peripherals/telegram.json` (0600)
3. Wizard writes plugin entry to `/etc/openbad/peripherals.yaml` (with `enabled: true`)
4. `sudo systemctl restart openbad` — daemon reads config, finds telegram enabled, starts bridge
5. Messages flow: Telegram → Bridge → MQTT → ChatRouter → Pipeline → MQTT → Bridge → Telegram

## How to test
```bash
.venv/bin/pytest tests/test_transducer_api.py tests/test_peripherals_config.py tests/test_telegram_bridge.py -v
```