### PR TITLE
Fix PeripheralChatRouter event loop dispatch for MQTT thread

### DIFF
--- a/src/openbad/peripherals/chat_router.py
+++ b/src/openbad/peripherals/chat_router.py
@@ -7,6 +7,7 @@ assembled reply to ``motor/external/{platform}/outbound``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections.abc import Callable
@@ -41,6 +42,7 @@ class PeripheralChatRouter:
         self._mqtt = mqtt_client
         self._resolve_model = model_resolver
         self._running = False
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     # ── Lifecycle ─────────────────────────────────────────── #
 
@@ -49,6 +51,10 @@ class PeripheralChatRouter:
         if self._running:
             return
         self._running = True
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = asyncio.get_event_loop()
         self._mqtt.subscribe(
             topics.EXTERNAL_INBOUND_ALL,
             bytes,
@@ -66,14 +72,12 @@ class PeripheralChatRouter:
 
     def _on_inbound(self, topic: str, payload: bytes) -> None:
         """Dispatch inbound MQTT messages to the async handler."""
-        import asyncio
-
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
+        if self._loop is None or self._loop.is_closed():
             logger.error("No event loop — cannot handle inbound message")
             return
-        loop.create_task(self._handle_inbound(topic, payload))
+        self._loop.call_soon_threadsafe(
+            self._loop.create_task, self._handle_inbound(topic, payload),
+        )
 
     async def _handle_inbound(self, topic: str, payload: bytes) -> None:
         """Parse the inbound message, run through chat, and reply."""

--- a/tests/test_peripheral_chat_router.py
+++ b/tests/test_peripheral_chat_router.py
@@ -231,12 +231,13 @@ class TestPeripheralChatRouter:
         router = PeripheralChatRouter(mqtt, _resolver())
 
         mock_loop = MagicMock()
-        with patch("asyncio.get_event_loop", return_value=mock_loop):
-            router._on_inbound(
-                "topic",
-                json.dumps(
-                    {"platform": "t", "event": "message",
-                     "data": {"content": "hi", "sender": "1"}},
-                ).encode(),
-            )
-            mock_loop.create_task.assert_called_once()
+        mock_loop.is_closed.return_value = False
+        router._loop = mock_loop
+        router._on_inbound(
+            "topic",
+            json.dumps(
+                {"platform": "t", "event": "message",
+                 "data": {"content": "hi", "sender": "1"}},
+            ).encode(),
+        )
+        mock_loop.call_soon_threadsafe.assert_called_once()


### PR DESCRIPTION
## Summary

`PeripheralChatRouter._on_inbound()` was calling `asyncio.get_event_loop()` from the MQTT network thread, which has no event loop. This caused every inbound Telegram message to log `No event loop — cannot handle inbound message` and get dropped.

### Fix
- Capture the asyncio event loop reference in `start()` (called from the daemon's async context)
- Use `loop.call_soon_threadsafe(loop.create_task, coro)` in `_on_inbound()` to safely schedule the coroutine from the MQTT thread

### How to test
```bash
.venv/bin/pytest tests/test_peripheral_chat_router.py tests/test_daemon_peripherals.py -v
```