### PR TITLE
Fix TelegramBridge outbound event loop dispatch

### DIFF
--- a/src/openbad/peripherals/telegram_bridge.py
+++ b/src/openbad/peripherals/telegram_bridge.py
@@ -46,6 +46,7 @@ class TelegramBridge:
         self._session: aiohttp.ClientSession | None = None
         self._task: asyncio.Task[None] | None = None
         self._running = False
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     # ── Lifecycle ─────────────────────────────────────────── #
 
@@ -54,6 +55,7 @@ class TelegramBridge:
         if self._running:
             return
         self._running = True
+        self._loop = asyncio.get_running_loop()
         self._session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=_POLL_TIMEOUT + 10),
         )
@@ -188,8 +190,12 @@ class TelegramBridge:
             return
 
         # Schedule the async send on the event loop
-        loop = asyncio.get_event_loop()
-        loop.create_task(self.send_message(int(chat_id), text))
+        if self._loop is None or self._loop.is_closed():
+            logger.error("No event loop — cannot send outbound message")
+            return
+        self._loop.call_soon_threadsafe(
+            self._loop.create_task, self.send_message(int(chat_id), text),
+        )
 
     async def send_message(self, chat_id: int, text: str) -> bool:
         """Send a message via Telegram Bot API."""

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -185,18 +185,21 @@ class TestTelegramBridge:
         payload = json.dumps({"chat_id": 42, "text": "reply"}).encode()
 
         mock_loop = MagicMock()
-        with patch("asyncio.get_event_loop", return_value=mock_loop):
-            bridge._on_outbound("motor/external/telegram/outbound", payload)
-            mock_loop.create_task.assert_called_once()
+        mock_loop.is_closed.return_value = False
+        bridge._loop = mock_loop
+        bridge._on_outbound("motor/external/telegram/outbound", payload)
+        mock_loop.call_soon_threadsafe.assert_called_once()
 
     def test_on_outbound_missing_fields(self) -> None:
         mqtt = _make_mqtt()
         bridge = TelegramBridge("tok", mqtt)  # noqa: S106
 
         payload = json.dumps({"chat_id": 42}).encode()
-        with patch("asyncio.get_event_loop") as mock_loop:
-            bridge._on_outbound("topic", payload)
-            mock_loop.return_value.create_task.assert_not_called()
+        mock_loop = MagicMock()
+        mock_loop.is_closed.return_value = False
+        bridge._loop = mock_loop
+        bridge._on_outbound("topic", payload)
+        mock_loop.call_soon_threadsafe.assert_not_called()
 
     def test_from_credentials(self, tmp_path) -> None:
         creds = tmp_path / "telegram.json"


### PR DESCRIPTION
## Summary

`TelegramBridge._on_outbound()` called `asyncio.get_event_loop()` from the paho-mqtt network thread, which has no event loop. This caused replies to fail with `RuntimeError: There is no current event loop in thread 'paho-mqtt-client-'` — the chat router generated replies successfully but they never reached Telegram.

Same root cause as #612 (PeripheralChatRouter), now fixed in the bridge too.

### Fix
- Capture `asyncio.get_running_loop()` in `start()` (called from async context)
- Store as `self._loop`
- Use `self._loop.call_soon_threadsafe(self._loop.create_task, coro)` in `_on_outbound()`

## How to test
```bash
.venv/bin/pytest tests/test_telegram_bridge.py -v
```