### PR TITLE
Fix personality_modulator import and transducer test dispatch

### DIFF
--- a/src/openbad/daemon.py
+++ b/src/openbad/daemon.py
@@ -357,7 +357,7 @@ class Daemon:
         """Load identity persistence for peripheral chat context."""
         try:
             from openbad.identity.persistence import IdentityPersistence
-            from openbad.identity.personality import PersonalityModulator
+            from openbad.identity.personality_modulator import PersonalityModulator
             from openbad.memory.base import EpisodicMemory
             from openbad.wui.server import _resolve_identity_config_path
 

--- a/src/openbad/skills/server.py
+++ b/src/openbad/skills/server.py
@@ -812,7 +812,7 @@ def _get_identity_persistence() -> Any:
         from pathlib import Path
 
         from openbad.identity.persistence import IdentityPersistence
-        from openbad.identity.personality import PersonalityModulator
+        from openbad.identity.personality_modulator import PersonalityModulator
         from openbad.memory.base import EpisodicMemory
         from openbad.wui.server import _resolve_identity_config_path
 

--- a/src/openbad/wui/transducer_api.py
+++ b/src/openbad/wui/transducer_api.py
@@ -254,13 +254,15 @@ async def _post_transducer_test(request: web.Request) -> web.Response:
             # Fall back to credential verification
             return await _verify_credentials(plugin_name)
 
-        # Call the transmit_message skill
-        result = await tools["transmit_message"].run(
-            platform=plugin_name,
-            operation="sendMessage",
-            target=target,
-            content=content,
-        )
+        # Call the transmit_message skill via call_skill
+        from openbad.skills.server import call_skill  # noqa: PLC0415
+
+        result = await call_skill("transmit_message", {
+            "platform": plugin_name,
+            "operation": "sendMessage",
+            "target": target,
+            "content": content,
+        })
         return web.json_response({"ok": True, "result": str(result)})
     except web.HTTPException:
         raise


### PR DESCRIPTION
## Fixes

1. **`ModuleNotFoundError: No module named 'openbad.identity.personality'`** — The correct module is `openbad.identity.personality_modulator`. Fixed in both `skills/server.py` and `daemon.py`.

2. **`AttributeError: 'Tool' object has no attribute 'run'`** — MCP `Tool` objects don't have a `.run()` method. Changed `transducer_api.py` to use `call_skill()` instead.

### How to test
```bash
.venv/bin/pytest tests/test_peripheral_sessions.py tests/test_daemon_peripherals.py tests/test_langchain_tools.py -q
```