### PR TITLE
Fix EpisodicMemory import path

### DIFF
--- a/src/openbad/daemon.py
+++ b/src/openbad/daemon.py
@@ -358,7 +358,7 @@ class Daemon:
         try:
             from openbad.identity.persistence import IdentityPersistence
             from openbad.identity.personality_modulator import PersonalityModulator
-            from openbad.memory.base import EpisodicMemory
+            from openbad.memory.episodic import EpisodicMemory
             from openbad.wui.server import _resolve_identity_config_path
 
             config_path = _resolve_identity_config_path()

--- a/src/openbad/skills/server.py
+++ b/src/openbad/skills/server.py
@@ -813,7 +813,7 @@ def _get_identity_persistence() -> Any:
 
         from openbad.identity.persistence import IdentityPersistence
         from openbad.identity.personality_modulator import PersonalityModulator
-        from openbad.memory.base import EpisodicMemory
+        from openbad.memory.episodic import EpisodicMemory
         from openbad.wui.server import _resolve_identity_config_path
 
         config_path = _resolve_identity_config_path()


### PR DESCRIPTION
Fix `ImportError: cannot import name 'EpisodicMemory' from 'openbad.memory.base'`

`EpisodicMemory` lives in `openbad.memory.episodic`, not `openbad.memory.base`. Fixed in both `skills/server.py` and `daemon.py`.