### PR TITLE
Increase LiteLLM request timeout to 90s

### DIFF
--- a/src/openbad/cognitive/providers/litellm_adapter.py
+++ b/src/openbad/cognitive/providers/litellm_adapter.py
@@ -105,7 +105,7 @@ class LiteLLMAdapter(ProviderAdapter):
         default_model: str = "",
         api_key: str = "",
         api_base: str = "",
-        timeout_s: float = 30,
+        timeout_s: float = 90,
         max_retries: int = 2,
         extra_kwargs: dict[str, Any] | None = None,
     ) -> None:


### PR DESCRIPTION
Increase default LiteLLM request timeout from 30s to 90s. Local models with large tool schemas and identity prompts need more time to generate responses.