### PR TITLE
#619: Add hierarchical tool routing to fix context overflow

### DIFF
--- a/src/openbad/frameworks/langchain_tools.py
+++ b/src/openbad/frameworks/langchain_tools.py
@@ -4,6 +4,14 @@ Reads tool definitions from the FastMCP ``skill_server`` and produces
 LangChain-compatible tools that preserve immune gating, access control,
 and result truncation.
 
+Hierarchical tool routing
+~~~~~~~~~~~~~~~~~~~~~~~~~
+When a role defines ``_DIRECT_TOOLS`` (a small set always bound to the
+model) vs the full ``_ROLE_TOOLS`` allow-list, the extra tools are made
+available through two meta-tools: ``list_tools`` and ``use_tool``.  This
+keeps the tool-schema token footprint small enough for context-limited
+models while preserving access to the full capability set.
+
 Public API
 ----------
 ``get_openbad_tools()``
@@ -15,6 +23,7 @@ Public API
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from typing import Any
 
@@ -135,6 +144,26 @@ _ROLE_TOOLS: dict[str, set[str]] = {
     },
 }
 
+# ── Direct (always-bound) tools per role ──────────────────────────────── #
+#
+# Roles listed here expose only these tools directly to the model.
+# All remaining tools in ``_ROLE_TOOLS[role]`` are accessible via the
+# auto-generated ``list_tools`` and ``use_tool`` meta-tools.
+# Roles NOT listed here bind all their tools directly (no meta-tools).
+
+_DIRECT_TOOLS: dict[str, set[str]] = {
+    "chat": {
+        "ask_user",
+        "web_search",
+        "web_fetch",
+        "read_memory",
+        "write_memory",
+        "query_semantic",
+        "get_entity_info",
+        "read_events",
+    },
+}
+
 
 # ── Internal helpers ──────────────────────────────────────────────────── #
 
@@ -210,6 +239,108 @@ def _mcp_tool_to_langchain(mcp_tool: Any) -> StructuredTool:
     )
 
 
+# ── Meta-tool builders (hierarchical tool routing) ────────────────────── #
+
+
+def _build_meta_tools(
+    role: str,
+    discoverable: list[BaseTool],
+) -> list[BaseTool]:
+    """Build ``list_tools`` and ``use_tool`` meta-tools.
+
+    *discoverable* is the list of tools accessible only through these
+    meta-tools (i.e. those in ``_ROLE_TOOLS[role]`` but not in
+    ``_DIRECT_TOOLS[role]``).
+    """
+    from pydantic import BaseModel, Field
+
+    # Build a lookup for fast dispatch
+    _by_name: dict[str, BaseTool] = {t.name: t for t in discoverable}
+
+    # Pre-build the catalogue string once
+    _catalogue = "\n".join(
+        f"- {t.name}: {(t.description or '')[:120]}"
+        for t in discoverable
+    )
+
+    class ListToolsInput(BaseModel):
+        query: str = Field(
+            default="",
+            description="Optional keyword to filter tools by name or description.",
+        )
+
+    async def _list_tools(query: str = "") -> str:
+        if not query:
+            return (
+                f"Available tools ({len(_by_name)}):\n{_catalogue}\n\n"
+                "Call use_tool with the tool name and a JSON arguments object."
+            )
+        q = query.lower()
+        matches = [
+            f"- {t.name}: {(t.description or '')[:120]}"
+            for t in discoverable
+            if q in t.name.lower() or q in (t.description or "").lower()
+        ]
+        if not matches:
+            return f"No tools matching '{query}'. Call list_tools without a query to see all."
+        return "\n".join(matches)
+
+    class UseToolInput(BaseModel):
+        tool_name: str = Field(description="Name of the tool to invoke.")
+        arguments: str = Field(
+            default="{}",
+            description="JSON object of arguments to pass to the tool.",
+        )
+
+    async def _use_tool(tool_name: str, arguments: str = "{}") -> str:
+        tool = _by_name.get(tool_name)
+        if tool is None:
+            available = ", ".join(sorted(_by_name))
+            return (
+                f"Unknown tool '{tool_name}'. "
+                f"Available: {available}"
+            )
+        try:
+            kwargs = json.loads(arguments) if arguments else {}
+        except json.JSONDecodeError as exc:
+            return f"Invalid JSON arguments: {exc}"
+
+        if not isinstance(kwargs, dict):
+            return "Arguments must be a JSON object (dict), not a list or scalar."
+
+        try:
+            if tool.coroutine:
+                result = await tool.coroutine(**kwargs)
+            else:
+                result = tool.invoke(kwargs)
+            return str(result)
+        except Exception as exc:
+            log.exception("use_tool dispatch failed: %s(%s)", tool_name, arguments)
+            return f"Tool {tool_name} failed: {type(exc).__name__}: {exc}"
+
+    list_tool = StructuredTool(
+        name="list_tools",
+        description=(
+            f"List {len(_by_name)} additional tools available for this session. "
+            "Pass an optional query to filter by keyword. Use use_tool to call them."
+        ),
+        coroutine=_list_tools,
+        args_schema=ListToolsInput,
+    )
+
+    use_tool = StructuredTool(
+        name="use_tool",
+        description=(
+            "Invoke an additional tool by name. Call list_tools first to see "
+            "available tools and their descriptions. Pass arguments as a JSON string."
+        ),
+        coroutine=_use_tool,
+        args_schema=UseToolInput,
+    )
+
+    return [list_tool, use_tool]
+
+
 # ── Public API ────────────────────────────────────────────────────────── #
 
 # Module-level cache so tools are built only once.
@@ -274,13 +405,41 @@ def get_tools_for_role(role: str) -> list[BaseTool]:
 
 
 async def async_get_tools_for_role(role: str) -> list[BaseTool]:
-    """Async variant of :func:`get_tools_for_role`."""
-    allowed = _ROLE_TOOLS.get(role.lower(), set())
+    """Async variant of :func:`get_tools_for_role`.
+
+    When the role has a ``_DIRECT_TOOLS`` entry, only those tools are
+    bound directly.  The remaining allowed tools are made discoverable
+    via ``list_tools`` / ``use_tool`` meta-tools to reduce schema tokens.
+    """
+    role_lower = role.lower()
+    allowed = _ROLE_TOOLS.get(role_lower, set())
     if not allowed:
         log.warning("No tool allowlist defined for role %r", role)
         return []
+
     all_tools = await async_get_openbad_tools()
-    return [t for t in all_tools if t.name in allowed]
+    role_tools = [t for t in all_tools if t.name in allowed]
+
+    direct_names = _DIRECT_TOOLS.get(role_lower)
+    if direct_names is None:
+        # No hierarchical routing — bind all tools directly.
+        return role_tools
+
+    direct = [t for t in role_tools if t.name in direct_names]
+    discoverable = [t for t in role_tools if t.name not in direct_names]
+
+    if discoverable:
+        meta = _build_meta_tools(role_lower, discoverable)
+        direct.extend(meta)
+        log.info(
+            "Hierarchical tools for role=%s: %d direct + %d discoverable "
+            "(via list_tools/use_tool)",
+            role_lower,
+            len(direct) - len(meta),
+            len(discoverable),
+        )
+
+    return direct
 
 
 def clear_tools_cache() -> None:

--- a/src/openbad/wui/chat_pipeline.py
+++ b/src/openbad/wui/chat_pipeline.py
@@ -1020,10 +1020,12 @@ def assemble_context(
     message_tokens = estimate_tokens(message)
 
     # Reserve tokens: system + current message + tool definitions + response headroom.
-    # Tool definitions (~1200 tokens for chat role) are injected by
-    # LangGraph's bind_tools and don't appear in our messages array,
-    # so we must account for them here.
-    _TOOL_DEFINITION_RESERVE = 1500
+    # Tool definitions are injected by LangGraph's bind_tools and don't
+    # appear in our messages array, so we must account for them here.
+    # With hierarchical tool routing the chat role binds ~10 tools
+    # (8 direct + 2 meta-tools); roles without hierarchical routing may
+    # bind more.  We use a conservative estimate that covers both cases.
+    _TOOL_DEFINITION_RESERVE = 3000
     available = max(
         0,
         budget.context_tokens

--- a/tests/test_langchain_tools.py
+++ b/tests/test_langchain_tools.py
@@ -8,8 +8,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from openbad.frameworks.langchain_tools import (
+    _DIRECT_TOOLS,
     _ROLE_TOOLS,
     _build_args_schema,
+    _build_meta_tools,
     _json_type_to_python,
     _make_tool_func,
     _mcp_tool_to_langchain,
@@ -220,6 +222,146 @@ class TestRoleFiltering:
         assert "get_entity_info" in chat_tools
         assert "update_user_entity" in chat_tools
         assert "update_assistant_entity" in chat_tools
+
+
+# ── Hierarchical tool routing tests ──────────────────────────────────── #
+
+
+class TestDirectToolsConfig:
+    def test_chat_has_direct_tools(self) -> None:
+        assert "chat" in _DIRECT_TOOLS
+
+    def test_direct_tools_subset_of_role_tools(self) -> None:
+        for role, direct in _DIRECT_TOOLS.items():
+            assert direct.issubset(_ROLE_TOOLS[role]), (
+                f"_DIRECT_TOOLS[{role!r}] has tools not in _ROLE_TOOLS: "
+                f"{direct - _ROLE_TOOLS[role]}"
+            )
+
+    def test_chat_direct_tools_are_small(self) -> None:
+        assert len(_DIRECT_TOOLS["chat"]) <= 10
+
+
+class TestBuildMetaTools:
+    def test_returns_list_and_use_tool(self) -> None:
+        fake = _mcp_tool_to_langchain(
+            _fake_mcp_tool("search_library", "Search library"),
+        )
+        meta = _build_meta_tools("chat", [fake])
+        names = {t.name for t in meta}
+        assert names == {"list_tools", "use_tool"}
+
+    @pytest.mark.asyncio
+    async def test_list_tools_shows_catalogue(self) -> None:
+        fakes = [
+            _mcp_tool_to_langchain(_fake_mcp_tool("search_library", "Search the library")),
+            _mcp_tool_to_langchain(_fake_mcp_tool("draft_book", "Draft a book")),
+        ]
+        meta = _build_meta_tools("chat", fakes)
+        list_tool = next(t for t in meta if t.name == "list_tools")
+        result = await list_tool.coroutine(query="")
+        assert "search_library" in result
+        assert "draft_book" in result
+        assert "Available tools (2)" in result
+
+    @pytest.mark.asyncio
+    async def test_list_tools_filters_by_query(self) -> None:
+        fakes = [
+            _mcp_tool_to_langchain(_fake_mcp_tool("search_library", "Search the library")),
+            _mcp_tool_to_langchain(_fake_mcp_tool("draft_book", "Draft a book")),
+        ]
+        meta = _build_meta_tools("chat", fakes)
+        list_tool = next(t for t in meta if t.name == "list_tools")
+        result = await list_tool.coroutine(query="library")
+        assert "search_library" in result
+        assert "draft_book" not in result
+
+    @pytest.mark.asyncio
+    async def test_use_tool_dispatches(self) -> None:
+        fake = _mcp_tool_to_langchain(
+            _fake_mcp_tool("search_library", "Search the library"),
+        )
+        meta = _build_meta_tools("chat", [fake])
+        use = next(t for t in meta if t.name == "use_tool")
+
+        with patch(
+            "openbad.frameworks.langchain_tools.call_skill",
+            new_callable=AsyncMock,
+            return_value="found 3 books",
+        ):
+            result = await use.coroutine(
+                tool_name="search_library",
+                arguments='{"query": "python"}',
+            )
+        assert "found 3 books" in result
+
+    @pytest.mark.asyncio
+    async def test_use_tool_rejects_unknown(self) -> None:
+        fake = _mcp_tool_to_langchain(
+            _fake_mcp_tool("search_library", "Search the library"),
+        )
+        meta = _build_meta_tools("chat", [fake])
+        use = next(t for t in meta if t.name == "use_tool")
+        result = await use.coroutine(tool_name="nonexistent", arguments="{}")
+        assert "Unknown tool" in result
+
+    @pytest.mark.asyncio
+    async def test_use_tool_rejects_bad_json(self) -> None:
+        fake = _mcp_tool_to_langchain(
+            _fake_mcp_tool("search_library", "Search"),
+        )
+        meta = _build_meta_tools("chat", [fake])
+        use = next(t for t in meta if t.name == "use_tool")
+        result = await use.coroutine(tool_name="search_library", arguments="{bad")
+        assert "Invalid JSON" in result
+
+
+class TestHierarchicalRouting:
+    @pytest.mark.asyncio
+    async def test_chat_gets_meta_tools(self) -> None:
+        # Build fake MCP tools for all chat role tools
+        chat_names = _ROLE_TOOLS["chat"]
+        fake_tools = [_fake_mcp_tool(n, f"Tool {n}") for n in chat_names]
+
+        with patch("openbad.frameworks.langchain_tools.skill_server") as mock_server:
+            mock_server.list_tools = AsyncMock(return_value=fake_tools)
+            from openbad.frameworks import langchain_tools
+
+            langchain_tools._tools_cache = None
+            langchain_tools._tools_cache = await langchain_tools._async_build_tools()
+
+            tools = await async_get_tools_for_role("chat")
+            names = {t.name for t in tools}
+
+        # Should have direct tools + list_tools + use_tool
+        direct = _DIRECT_TOOLS["chat"]
+        for name in direct:
+            assert name in names, f"Direct tool {name!r} missing"
+        assert "list_tools" in names
+        assert "use_tool" in names
+        # Total should be direct + 2 meta-tools
+        assert len(tools) == len(direct) + 2
+
+    @pytest.mark.asyncio
+    async def test_task_gets_all_tools_directly(self) -> None:
+        # Task role has no _DIRECT_TOOLS entry → all tools bound directly
+        task_names = _ROLE_TOOLS["task"]
+        fake_tools = [_fake_mcp_tool(n, f"Tool {n}") for n in task_names]
+
+        with patch("openbad.frameworks.langchain_tools.skill_server") as mock_server:
+            mock_server.list_tools = AsyncMock(return_value=fake_tools)
+            from openbad.frameworks import langchain_tools
+
+            langchain_tools._tools_cache = None
+            langchain_tools._tools_cache = await langchain_tools._async_build_tools()
+
+            tools = await async_get_tools_for_role("task")
+            names = {t.name for t in tools}
+
+        # No meta-tools for task role
+        assert "list_tools" not in names
+        assert "use_tool" not in names
+        assert len(tools) == len(task_names)
 
 
 # ── CrewAI tool adapter tests ────────────────────────────────────────── #


### PR DESCRIPTION
Closes #619 (interim — full supervisor pattern is tracked separately)

## Summary
Replace 22 direct tool bindings with 8 direct + 2 meta-tools (`list_tools`, `use_tool`) for the chat role. This reduces tool schema token consumption from ~10K to ~3K, fixing the `exceed_context_size_error` on the 24K-context local model.

## Changes
- **`src/openbad/frameworks/langchain_tools.py`**:
  - Add `_DIRECT_TOOLS` mapping for chat role (8 essential tools)
  - Add `_build_meta_tools()` — creates `list_tools` and `use_tool` StructuredTools
  - Update `async_get_tools_for_role()` to return direct + meta-tools when hierarchical routing is configured
- **`src/openbad/wui/chat_pipeline.py`**:
  - Increase `_TOOL_DEFINITION_RESERVE` from 1500 to 3000 tokens
- **`tests/test_langchain_tools.py`**:
  - 11 new tests: meta-tool construction, list/use dispatch, filtering, error handling, routing logic

## How to test
```bash
pytest tests/test_langchain_tools.py -v
```

Send a chat message — should no longer overflow context. The model can call `list_tools` to discover additional tools and `use_tool` to invoke them.

## Note
This is an interim solution. The proper fix is the multi-agent supervisor pattern tracked in #619–#623.