### PR TITLE
#632: Route complex user tasks through User-Facing Crew by default

### DIFF
--- a/src/openbad/autonomy/scheduler_worker.py
+++ b/src/openbad/autonomy/scheduler_worker.py
@@ -43,10 +43,11 @@ _AUTONOMY_INTERACTIVE_PATTERNS = (
 
 
 _COMPLEXITY_KEYWORDS = re.compile(
-    r"\b(multi[- ]?step|pipeline|integrate|refactor|migrate|redesign|architect)\b",
+    r"\b(multi[- ]?step|pipeline|integrate|refactor|migrate|redesign|architect"
+    r"|research|analyze|investigate|compare|plan|review|summarize|explain)\b",
     re.IGNORECASE,
 )
-_COMPLEXITY_DESC_THRESHOLD = 500  # characters
+_COMPLEXITY_DESC_THRESHOLD = 100  # characters
 _COMPLEXITY_SUBTASK_THRESHOLD = 2
 
 # Track per-node retry attempts so stuck nodes don't block the queue forever.
@@ -54,20 +55,28 @@ _research_retry_counts: dict[str, int] = {}
 _MAX_RESEARCH_RETRIES = 3
 
 
-def _classify_task_complexity(task: TaskModel) -> bool:
+def _classify_task_complexity(task: TaskModel, *, force_crew: bool = False) -> bool:
     """Return True if a task should be dispatched to a CrewAI crew."""
+    if force_crew:
+        return True
+
     desc = task.description or ""
+    title = task.title or ""
 
     # Explicit flag
     if "[crew]" in desc.lower():
         return True
 
     # Keyword heuristic
-    if _COMPLEXITY_KEYWORDS.search(desc):
+    if _COMPLEXITY_KEYWORDS.search(desc) or _COMPLEXITY_KEYWORDS.search(title):
         return True
 
-    # Length heuristic
+    # Length heuristic — anything beyond a one-liner qualifies
     if len(desc) > _COMPLEXITY_DESC_THRESHOLD:
+        return True
+
+    # Multi-word title (3+ words) suggests non-trivial task
+    if len(title.split()) >= 3:
         return True
 
     # Subtask count (markdown checklist items)
@@ -1099,7 +1108,8 @@ def _process_autonomy_work(
 
         task_store.update_task_status(task_to_run.task_id, TaskStatus.RUNNING)
 
-        is_complex = _classify_task_complexity(task_to_run)
+        force_crew_flag = session_allows(policy, "tasks", "force_crew", False)
+        is_complex = _classify_task_complexity(task_to_run, force_crew=force_crew_flag)
         crew_result = None
         llm = None
 

--- a/tests/test_scheduler_worker.py
+++ b/tests/test_scheduler_worker.py
@@ -353,6 +353,34 @@ class TestClassifyTaskComplexity:
         )
         assert _classify_task_complexity(task) is False
 
+    def test_multi_word_title_is_complex(self) -> None:
+        task = _make_task("Set up the deployment pipeline", "Do it.")
+        assert _classify_task_complexity(task) is True
+
+    def test_two_word_title_with_short_desc_is_simple(self) -> None:
+        task = _make_task("Check time", "What time is it?")
+        assert _classify_task_complexity(task) is False
+
+    def test_description_over_100_chars_is_complex(self) -> None:
+        task = _make_task("Task", "A" * 101)
+        assert _classify_task_complexity(task) is True
+
+    def test_description_under_100_chars_is_simple(self) -> None:
+        task = _make_task("Hi", "Short desc")
+        assert _classify_task_complexity(task) is False
+
+    def test_force_crew_flag(self) -> None:
+        task = _make_task("Hi", "Short")
+        assert _classify_task_complexity(task, force_crew=True) is True
+
+    def test_new_keywords_research(self) -> None:
+        task = _make_task("Analyze logs", "Research the recent error patterns")
+        assert _classify_task_complexity(task) is True
+
+    def test_keyword_in_title(self) -> None:
+        task = _make_task("Investigate memory leak", "")
+        assert _classify_task_complexity(task) is True
+
 
 class TestClassifyResearchComplexity:
     def test_simple_research(self) -> None:


### PR DESCRIPTION
Closes #632

## Summary

Lowers the task complexity classifier threshold so that most non-trivial tasks route through the User-Facing Crew (Chat Agent → Task Agent) instead of the single-agent ReAct path.

### Changes:
- **Keyword list expanded**: Added `research`, `analyze`, `investigate`, `compare`, `plan`, `review`, `summarize`, `explain` to complexity keywords
- **Keywords checked in title**: Previously only checked description
- **Description threshold lowered**: 500 → 100 characters
- **Multi-word title heuristic**: Titles with 3+ words automatically route to crew
- **force_crew policy option**: `session_allows(policy, 'tasks', 'force_crew', False)` — when True, all tasks use crew dispatch
- **Simple tasks stay simple**: Short descriptions (<100 chars) with 1-2 word titles and no keywords still use single-agent path (e.g. 'what time is it')

### New tests:
7 new test cases covering multi-word titles, threshold boundaries, force_crew flag, keyword-in-title matching

## How to test

```bash
pytest tests/test_scheduler_worker.py::TestClassifyTaskComplexity -v
```