### PR TITLE
#633: Activate BackgroundScanner in daemon with endocrine-driven behavior

### DIFF
--- a/src/openbad/active_inference/background_scanner.py
+++ b/src/openbad/active_inference/background_scanner.py
@@ -1,4 +1,4 @@
-"""Background scanning scheduler with FSM state awareness."""
+"""Background scanning scheduler with endocrine-driven behavior."""
 
 from __future__ import annotations
 
@@ -11,20 +11,36 @@ from openbad.active_inference.exploration_actions import ExplorationActionGenera
 if TYPE_CHECKING:
     from openbad.active_inference.engine import ExplorationEngine
     from openbad.active_inference.plugin_interface import ObservationPlugin
+    from openbad.endocrine.controller import EndocrineController
 
 logger = logging.getLogger(__name__)
 
+# Endocrine thresholds for scanning modulation
+_CORTISOL_PAUSE_THRESHOLD = 0.5
+_ADRENALINE_SUSPEND_THRESHOLD = 0.6
+_DOPAMINE_BOOST_THRESHOLD = 0.3  # Below this → increase polling (boredom)
+_DOPAMINE_BOOST_FACTOR = 0.5  # Poll at 50% of base interval when bored
+
 
 class BackgroundScanner:
-    """Manages periodic observation plugin polling with FSM-aware scheduling."""
+    """Manages periodic observation plugin polling with endocrine-driven scheduling.
+
+    Behavior modulation:
+    - Low dopamine (boredom): faster polling to seek novelty
+    - High cortisol (stress): pauses exploration to conserve resources
+    - Adrenaline spike: suspends entirely (emergency handling)
+    - SLEEP/EMERGENCY FSM states: no scanning
+    """
 
     def __init__(
         self,
         exploration_engine: ExplorationEngine,
         action_generator: ExplorationActionGenerator,
+        endocrine: EndocrineController | None = None,
     ) -> None:
         self._engine = exploration_engine
         self._action_generator = action_generator
+        self._endocrine = endocrine
         self._tasks: dict[str, asyncio.Task] = {}
         self._running = False
         self._current_state = "IDLE"
@@ -75,19 +91,43 @@ class BackgroundScanner:
                         plugin.source_id,
                     )
 
-            adjusted_interval = self._get_interval_for_state(interval)
+            adjusted_interval = self._compute_interval(interval)
             await asyncio.sleep(adjusted_interval)
 
     def _should_scan(self) -> bool:
-        """Determine if scanning should occur in current state."""
-        return self._current_state != "SLEEP"
+        """Determine if scanning should occur given FSM state and endocrine levels."""
+        # FSM suppression: no scanning in SLEEP or EMERGENCY
+        if self._current_state in ("SLEEP", "EMERGENCY"):
+            return False
 
-    def _get_interval_for_state(self, base_interval: int) -> int:
-        """Adjust polling interval based on FSM state."""
-        if self._current_state == "IDLE":
-            return base_interval
+        if self._endocrine is None:
+            return True
+
+        # Adrenaline spike → suspend entirely (all resources to threat)
+        if self._endocrine.level("adrenaline") >= _ADRENALINE_SUSPEND_THRESHOLD:
+            return False
+
+        # High cortisol → pause exploration (conserve resources)
+        return self._endocrine.level("cortisol") < _CORTISOL_PAUSE_THRESHOLD
+
+    def _compute_interval(self, base_interval: int) -> float:
+        """Compute polling interval modulated by endocrine state.
+
+        Low dopamine (boredom) → faster polling to seek novelty.
+        FSM ACTIVE state → slower polling to yield resources.
+        """
+        interval = float(base_interval)
+
+        # FSM state multiplier
         if self._current_state == "ACTIVE":
-            return base_interval * 3
-        if self._current_state == "SLEEP":
-            return base_interval * 10
-        return base_interval
+            interval *= 3.0
+        elif self._current_state == "SLEEP":
+            interval *= 10.0
+
+        # Endocrine modulation: low dopamine = boredom = seek novelty faster
+        if self._endocrine is not None:
+            dopamine = self._endocrine.level("dopamine")
+            if dopamine < _DOPAMINE_BOOST_THRESHOLD:
+                interval *= _DOPAMINE_BOOST_FACTOR
+
+        return interval

--- a/src/openbad/daemon.py
+++ b/src/openbad/daemon.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import yaml
 
+from openbad.active_inference.background_scanner import BackgroundScanner
 from openbad.endocrine.controller import EndocrineController
 from openbad.frameworks.crew_mqtt_bridge import CrewMQTTBridge
 from openbad.interoception.disk_network import DiskNetworkMonitor
@@ -69,6 +70,7 @@ class Daemon:
         self._stop_event: asyncio.Event | None = None
         self._crew_bridge: CrewMQTTBridge | None = None
         self._external_signal_plugin: ExternalSignalPlugin | None = None
+        self._scanner: BackgroundScanner | None = None
         self._telegram_bridge: TelegramBridge | None = None
         self._chat_router: PeripheralChatRouter | None = None
         self._identity_persistence: object | None = None
@@ -123,6 +125,9 @@ class Daemon:
 
         # 3. Endocrine controller
         self._endocrine = EndocrineController()
+
+        # 3b. Background scanner (endocrine-driven exploration)
+        await self._start_background_scanner()
 
         # 4. CrewAI ↔ MQTT activation bridge
         self._crew_bridge = CrewMQTTBridge(
@@ -182,6 +187,11 @@ class Daemon:
 
         # Peripheral transducers
         await self._stop_peripherals()
+
+        # Background scanner
+        if self._scanner is not None:
+            await self._scanner.stop()
+            self._scanner = None
 
         self._crew_bridge = None
         self._endocrine = None
@@ -419,6 +429,46 @@ class Daemon:
         if self._telegram_bridge is not None:
             await self._telegram_bridge.stop()
             self._telegram_bridge = None
+
+    async def _start_background_scanner(self) -> None:
+        """Instantiate and start the endocrine-driven background scanner."""
+        from openbad.active_inference.budget import ExplorationBudget
+        from openbad.active_inference.config import ActiveInferenceConfig
+        from openbad.active_inference.engine import ExplorationEngine
+        from openbad.active_inference.exploration_actions import ExplorationActionGenerator
+        from openbad.active_inference.insight_queue import InsightQueue
+        from openbad.active_inference.world_model import WorldModel
+
+        config_path = Path("/etc/openbad/active_inference.yaml")
+        if config_path.exists():
+            config = ActiveInferenceConfig.from_yaml(config_path)
+        else:
+            config = ActiveInferenceConfig()
+
+        world_model = WorldModel(
+            history_size=config.world_model_history_size,
+            ema_alpha=config.ema_alpha,
+        )
+        budget = ExplorationBudget(
+            daily_limit=config.daily_token_budget,
+            cooldown_seconds=config.cooldown_seconds,
+        )
+        engine = ExplorationEngine(config=config, world_model=world_model, budget=budget)
+        insight_queue = InsightQueue()
+        action_generator = ExplorationActionGenerator(insight_queue=insight_queue)
+
+        self._scanner = BackgroundScanner(
+            exploration_engine=engine,
+            action_generator=action_generator,
+            endocrine=self._endocrine,
+        )
+        await self._scanner.start()
+
+        # Register the external signal plugin
+        if self._external_signal_plugin is not None:
+            await self._scanner.register_plugin(self._external_signal_plugin)
+
+        logger.info("BackgroundScanner activated with endocrine modulation")
 
     def _resolve_chat_model(self) -> tuple[object | None, str | None, str]:
         """Return ``(chat_model, model_id, provider_name)`` for the default provider."""

--- a/tests/test_background_scanner_endocrine.py
+++ b/tests/test_background_scanner_endocrine.py
@@ -1,0 +1,201 @@
+"""Integration tests for BackgroundScanner endocrine-driven behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from openbad.active_inference.background_scanner import (
+    _ADRENALINE_SUSPEND_THRESHOLD,
+    _CORTISOL_PAUSE_THRESHOLD,
+    _DOPAMINE_BOOST_FACTOR,
+    _DOPAMINE_BOOST_THRESHOLD,
+    BackgroundScanner,
+)
+from openbad.active_inference.budget import ExplorationBudget
+from openbad.active_inference.config import ActiveInferenceConfig
+from openbad.active_inference.engine import ExplorationEngine
+from openbad.active_inference.exploration_actions import ExplorationActionGenerator
+from openbad.active_inference.insight_queue import InsightQueue
+from openbad.active_inference.world_model import WorldModel
+from openbad.endocrine.controller import EndocrineController
+from openbad.plugins.observations.external_signals import ExternalSignalPlugin
+
+
+@pytest.fixture()
+def endocrine() -> EndocrineController:
+    return EndocrineController()
+
+
+@pytest.fixture()
+def scanner(endocrine: EndocrineController) -> BackgroundScanner:
+    config = ActiveInferenceConfig()
+    world_model = WorldModel()
+    budget = ExplorationBudget()
+    engine = ExplorationEngine(config=config, world_model=world_model, budget=budget)
+    insight_queue = InsightQueue()
+    action_gen = ExplorationActionGenerator(insight_queue=insight_queue)
+    return BackgroundScanner(
+        exploration_engine=engine,
+        action_generator=action_gen,
+        endocrine=endocrine,
+    )
+
+
+class TestShouldScan:
+    """Tests for _should_scan() endocrine gating."""
+
+    def test_normal_state_allows_scanning(self, scanner: BackgroundScanner) -> None:
+        scanner.set_state("IDLE")
+        assert scanner._should_scan() is True
+
+    def test_sleep_state_blocks_scanning(self, scanner: BackgroundScanner) -> None:
+        scanner.set_state("SLEEP")
+        assert scanner._should_scan() is False
+
+    def test_emergency_state_blocks_scanning(self, scanner: BackgroundScanner) -> None:
+        scanner.set_state("EMERGENCY")
+        assert scanner._should_scan() is False
+
+    def test_high_cortisol_pauses_scanning(
+        self, scanner: BackgroundScanner, endocrine: EndocrineController
+    ) -> None:
+        endocrine.trigger("cortisol", _CORTISOL_PAUSE_THRESHOLD)
+        assert scanner._should_scan() is False
+
+    def test_below_cortisol_threshold_allows(
+        self, scanner: BackgroundScanner, endocrine: EndocrineController
+    ) -> None:
+        endocrine.trigger("cortisol", _CORTISOL_PAUSE_THRESHOLD - 0.1)
+        assert scanner._should_scan() is True
+
+    def test_adrenaline_spike_suspends(
+        self, scanner: BackgroundScanner, endocrine: EndocrineController
+    ) -> None:
+        endocrine.trigger("adrenaline", _ADRENALINE_SUSPEND_THRESHOLD)
+        assert scanner._should_scan() is False
+
+    def test_below_adrenaline_threshold_allows(
+        self, scanner: BackgroundScanner, endocrine: EndocrineController
+    ) -> None:
+        endocrine.trigger("adrenaline", _ADRENALINE_SUSPEND_THRESHOLD - 0.1)
+        assert scanner._should_scan() is True
+
+    def test_no_endocrine_always_scans(self) -> None:
+        """Scanner without endocrine controller always scans (graceful fallback)."""
+        config = ActiveInferenceConfig()
+        world_model = WorldModel()
+        budget = ExplorationBudget()
+        engine = ExplorationEngine(config=config, world_model=world_model, budget=budget)
+        action_gen = ExplorationActionGenerator(insight_queue=InsightQueue())
+        scanner = BackgroundScanner(
+            exploration_engine=engine,
+            action_generator=action_gen,
+            endocrine=None,
+        )
+        scanner.set_state("IDLE")
+        assert scanner._should_scan() is True
+
+
+class TestComputeInterval:
+    """Tests for _compute_interval() endocrine modulation."""
+
+    def test_idle_normal_dopamine_returns_base(
+        self, scanner: BackgroundScanner, endocrine: EndocrineController
+    ) -> None:
+        # Normal dopamine (above threshold) → no boost
+        endocrine.trigger("dopamine", _DOPAMINE_BOOST_THRESHOLD + 0.1)
+        scanner.set_state("IDLE")
+        assert scanner._compute_interval(60) == 60.0
+
+    def test_low_dopamine_boosts_polling(
+        self, scanner: BackgroundScanner, endocrine: EndocrineController
+    ) -> None:
+        # Dopamine below threshold → boredom → faster polling
+        scanner.set_state("IDLE")
+        interval = scanner._compute_interval(60)
+        assert interval == 60.0 * _DOPAMINE_BOOST_FACTOR
+
+    def test_active_state_slows_polling(
+        self, scanner: BackgroundScanner, endocrine: EndocrineController
+    ) -> None:
+        endocrine.trigger("dopamine", 0.5)  # Above threshold
+        scanner.set_state("ACTIVE")
+        assert scanner._compute_interval(60) == 180.0
+
+    def test_active_with_low_dopamine(
+        self, scanner: BackgroundScanner, endocrine: EndocrineController
+    ) -> None:
+        # ACTIVE × dopamine_boost both apply
+        scanner.set_state("ACTIVE")
+        interval = scanner._compute_interval(60)
+        assert interval == 60.0 * 3.0 * _DOPAMINE_BOOST_FACTOR
+
+
+class TestPluginRegistration:
+    """Tests for plugin lifecycle with scanner."""
+
+    @pytest.mark.asyncio()
+    async def test_register_plugin_starts_poll_loop(
+        self, scanner: BackgroundScanner
+    ) -> None:
+        await scanner.start()
+        plugin = ExternalSignalPlugin()
+        await scanner.register_plugin(plugin)
+
+        assert "external_signals" in scanner._tasks
+        assert not scanner._tasks["external_signals"].done()
+
+        await scanner.stop()
+        assert len(scanner._tasks) == 0
+
+    @pytest.mark.asyncio()
+    async def test_stop_cancels_all_tasks(self, scanner: BackgroundScanner) -> None:
+        await scanner.start()
+        plugin = ExternalSignalPlugin()
+        await scanner.register_plugin(plugin)
+
+        await scanner.stop()
+        assert scanner._running is False
+        assert len(scanner._tasks) == 0
+
+
+class TestEndocrinePollingIntegration:
+    """Integration test: verify endocrine state changes affect poll behavior."""
+
+    @pytest.mark.asyncio()
+    async def test_cortisol_spike_stops_polling(
+        self, endocrine: EndocrineController
+    ) -> None:
+        """When cortisol spikes mid-scan, the next poll cycle is skipped."""
+        config = ActiveInferenceConfig()
+        world_model = WorldModel()
+        budget = ExplorationBudget(daily_limit=100, cooldown_seconds=0)
+        engine = ExplorationEngine(config=config, world_model=world_model, budget=budget)
+        insight_queue = InsightQueue()
+        action_gen = ExplorationActionGenerator(insight_queue=insight_queue)
+
+        scanner = BackgroundScanner(
+            exploration_engine=engine,
+            action_generator=action_gen,
+            endocrine=endocrine,
+        )
+
+        plugin = ExternalSignalPlugin()
+        plugin.record()  # 1 message → surprise
+
+        await scanner.start()
+        await scanner.register_plugin(plugin)
+
+        # Let one poll complete normally
+        await asyncio.sleep(0.05)
+
+        # Spike cortisol → scanning should pause
+        endocrine.trigger("cortisol", 0.8)
+        plugin.record()  # More messages, but scanner paused
+
+        # Verify scanning is now blocked
+        assert scanner._should_scan() is False
+
+        await scanner.stop()


### PR DESCRIPTION
Closes #633

## Summary

Instantiates the BackgroundScanner in the daemon lifecycle and adds endocrine-driven behavior modulation.

### Changes:

**`src/openbad/active_inference/background_scanner.py`:**
- Added `endocrine` parameter to constructor
- `_should_scan()` now checks:
  - FSM state (SLEEP/EMERGENCY → blocked)
  - Adrenaline level ≥ 0.6 → suspended (emergency handling)
  - Cortisol level ≥ 0.5 → paused (resource conservation)
- `_compute_interval()` modulates polling:
  - Low dopamine (< 0.3) → poll at 50% base interval (boredom drives novelty-seeking)
  - ACTIVE state → 3× slower
- Graceful fallback: works without endocrine controller

**`src/openbad/daemon.py`:**
- Instantiates BackgroundScanner in `start()` after endocrine init
- Registers ExternalSignalPlugin with scanner
- Tears down scanner in `stop()`
- Loads ActiveInferenceConfig from `/etc/openbad/active_inference.yaml` (falls back to defaults)

### New tests (15):
- `TestShouldScan`: FSM blocking, cortisol pause, adrenaline suspend, graceful no-endocrine
- `TestComputeInterval`: dopamine boost, ACTIVE slowdown, combined modulation
- `TestPluginRegistration`: lifecycle start/stop
- `TestEndocrinePollingIntegration`: cortisol spike mid-scan verification

## How to test

```bash
pytest tests/test_background_scanner_endocrine.py -v
```