### PR TITLE
#634: Register observation plugins and wire immune feedback loop

### DIFF
--- a/src/openbad/active_inference/background_scanner.py
+++ b/src/openbad/active_inference/background_scanner.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from openbad.active_inference.exploration_actions import ExplorationActionGenerator
+from openbad.active_inference.immune_interceptor import ImmuneInterceptor
 
 if TYPE_CHECKING:
     from openbad.active_inference.engine import ExplorationEngine
@@ -37,10 +38,12 @@ class BackgroundScanner:
         exploration_engine: ExplorationEngine,
         action_generator: ExplorationActionGenerator,
         endocrine: EndocrineController | None = None,
+        immune_interceptor: ImmuneInterceptor | None = None,
     ) -> None:
         self._engine = exploration_engine
         self._action_generator = action_generator
         self._endocrine = endocrine
+        self._immune = immune_interceptor or ImmuneInterceptor(endocrine=endocrine)
         self._tasks: dict[str, asyncio.Task] = {}
         self._running = False
         self._current_state = "IDLE"
@@ -79,7 +82,22 @@ class BackgroundScanner:
             if self._should_scan():
                 try:
                     event = await self._engine.poll_plugin(plugin)
-                    if event.explored:
+
+                    # Immune interception: screen before cognitive processing
+                    result = self._immune.intercept(
+                        source_id=event.source_id,
+                        surprise=event.surprise,
+                        errors=event.errors,
+                    )
+
+                    if result.quarantined:
+                        logger.warning(
+                            "Observation quarantined: %s — %s",
+                            event.source_id,
+                            result.reason,
+                        )
+                    elif event.explored:
+                        # Only process high-surprise if immune clears it
                         await self._action_generator.process_high_surprise(
                             source_id=event.source_id,
                             surprise=event.surprise,
@@ -91,7 +109,9 @@ class BackgroundScanner:
                         plugin.source_id,
                     )
 
-            adjusted_interval = self._compute_interval(interval)
+            # Adjust interval with immune memory (vigilance/habituation)
+            immune_factor = self._immune.get_poll_factor(plugin.source_id)
+            adjusted_interval = self._compute_interval(interval) * immune_factor
             await asyncio.sleep(adjusted_interval)
 
     def _should_scan(self) -> bool:

--- a/src/openbad/active_inference/immune_interceptor.py
+++ b/src/openbad/active_inference/immune_interceptor.py
@@ -1,0 +1,186 @@
+"""Immune interceptor for observation pipeline.
+
+Scans observations for threats before cognitive processing,
+maintains threat-source memory for heightened vigilance,
+and triggers endocrine responses (adrenaline on threat, dopamine on novelty).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openbad.endocrine.controller import EndocrineController
+
+logger = logging.getLogger(__name__)
+
+# Threat memory decay: after this many seconds without threats, reduce vigilance
+_VIGILANCE_DECAY_SECONDS = 3600.0  # 1 hour
+# Vigilance multiplier: how much faster to poll flagged sources
+_VIGILANCE_POLL_FACTOR = 0.5
+# Habituation: after this many boring observations, slow polling
+_HABITUATION_THRESHOLD = 10
+_HABITUATION_POLL_FACTOR = 2.0
+
+
+@dataclass
+class ThreatMemory:
+    """Per-source threat tracking for immune memory."""
+
+    source_id: str
+    threat_count: int = 0
+    last_threat_ts: float = 0.0
+    boring_streak: int = 0
+
+    @property
+    def is_vigilant(self) -> bool:
+        """Source still under heightened scrutiny."""
+        if self.threat_count == 0:
+            return False
+        elapsed = time.monotonic() - self.last_threat_ts
+        return elapsed < _VIGILANCE_DECAY_SECONDS
+
+    @property
+    def is_habituated(self) -> bool:
+        """Source consistently boring — reduce attention."""
+        return self.boring_streak >= _HABITUATION_THRESHOLD
+
+
+@dataclass
+class InterceptResult:
+    """Outcome of immune interception."""
+
+    quarantined: bool = False
+    reason: str = ""
+    source_id: str = ""
+    threat_indicators: list[str] = field(default_factory=list)
+
+
+class ImmuneInterceptor:
+    """Intercepts observations between scanner and cognitive processing.
+
+    Responsibilities:
+    - Scan observations for threat indicators
+    - Quarantine suspicious data (block cognitive processing)
+    - Maintain per-source threat memory
+    - Signal endocrine responses (adrenaline on threat, dopamine on novelty)
+    - Adjust polling recommendations based on source history
+    """
+
+    def __init__(self, endocrine: EndocrineController | None = None) -> None:
+        self._endocrine = endocrine
+        self._threat_memory: dict[str, ThreatMemory] = {}
+        # Patterns that indicate threats in observation data
+        self._threat_patterns: list[str] = [
+            "authentication failure",
+            "unauthorized access",
+            "permission denied",
+            "segfault",
+            "out of memory",
+            "kernel panic",
+            "disk full",
+            "connection refused",
+            "brute force",
+            "injection attempt",
+        ]
+
+    def intercept(
+        self,
+        source_id: str,
+        surprise: float,
+        errors: dict[str, float],
+        raw_data: object | None = None,
+    ) -> InterceptResult:
+        """Screen an observation for threats before cognitive processing.
+
+        Returns InterceptResult indicating whether to quarantine.
+        Also triggers appropriate endocrine signals.
+        """
+        memory = self._get_or_create_memory(source_id)
+        threat_indicators = self._scan_for_threats(source_id, errors, raw_data)
+
+        if threat_indicators:
+            # Threat detected → quarantine + adrenaline
+            memory.threat_count += 1
+            memory.last_threat_ts = time.monotonic()
+            memory.boring_streak = 0
+
+            if self._endocrine is not None:
+                self._endocrine.trigger("adrenaline")
+
+            logger.warning(
+                "Immune quarantine: source=%s threats=%s",
+                source_id,
+                threat_indicators,
+            )
+            return InterceptResult(
+                quarantined=True,
+                reason=f"Threat detected: {', '.join(threat_indicators)}",
+                source_id=source_id,
+                threat_indicators=threat_indicators,
+            )
+
+        # No threat — update habituation tracking
+        if surprise > 0.0:
+            # Novel observation → dopamine anticipation
+            memory.boring_streak = 0
+            if self._endocrine is not None and surprise >= 0.3:
+                self._endocrine.trigger("dopamine", amount=surprise * 0.2)
+        else:
+            # Boring observation → habituation
+            memory.boring_streak += 1
+
+        return InterceptResult(quarantined=False, source_id=source_id)
+
+    def get_poll_factor(self, source_id: str) -> float:
+        """Get polling interval multiplier for a source.
+
+        < 1.0 means poll faster (vigilant), > 1.0 means poll slower (habituated).
+        """
+        memory = self._threat_memory.get(source_id)
+        if memory is None:
+            return 1.0
+        if memory.is_vigilant:
+            return _VIGILANCE_POLL_FACTOR
+        if memory.is_habituated:
+            return _HABITUATION_POLL_FACTOR
+        return 1.0
+
+    def is_quarantined_source(self, source_id: str) -> bool:
+        """Check if a source is currently under heightened vigilance."""
+        memory = self._threat_memory.get(source_id)
+        return memory is not None and memory.is_vigilant
+
+    def _get_or_create_memory(self, source_id: str) -> ThreatMemory:
+        if source_id not in self._threat_memory:
+            self._threat_memory[source_id] = ThreatMemory(source_id=source_id)
+        return self._threat_memory[source_id]
+
+    def _scan_for_threats(
+        self,
+        source_id: str,
+        errors: dict[str, float],
+        raw_data: object | None,
+    ) -> list[str]:
+        """Scan observation data for threat indicators."""
+        indicators: list[str] = []
+
+        # Check raw_data for threat patterns
+        if raw_data is not None:
+            data_str = str(raw_data).lower()
+            for pattern in self._threat_patterns:
+                if pattern in data_str:
+                    indicators.append(pattern)
+
+        # Critical error spikes from a previously-flagged source
+        memory = self._threat_memory.get(source_id)
+        if memory is not None and memory.is_vigilant:
+            # Heightened sensitivity: lower threshold for flagged sources
+            for metric, error_val in errors.items():
+                if error_val > 0.8:
+                    indicators.append(f"high_error:{metric}={error_val:.2f}")
+
+        return indicators

--- a/src/openbad/daemon.py
+++ b/src/openbad/daemon.py
@@ -468,6 +468,17 @@ class Daemon:
         if self._external_signal_plugin is not None:
             await self._scanner.register_plugin(self._external_signal_plugin)
 
+        # Register the system log watcher plugin
+        try:
+            from openbad.plugins.observations.syslog import SyslogObservationPlugin
+
+            syslog_plugin = SyslogObservationPlugin(
+                service_filters=["openbad.service", "openbad-wui.service"],
+            )
+            await self._scanner.register_plugin(syslog_plugin)
+        except Exception:
+            logger.warning("Syslog plugin registration failed", exc_info=True)
+
         logger.info("BackgroundScanner activated with endocrine modulation")
 
     def _resolve_chat_model(self) -> tuple[object | None, str | None, str]:

--- a/tests/test_immune_interceptor.py
+++ b/tests/test_immune_interceptor.py
@@ -1,0 +1,217 @@
+"""Tests for immune interceptor and plugin feedback loop."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from openbad.active_inference.immune_interceptor import (
+    _HABITUATION_THRESHOLD,
+    _VIGILANCE_DECAY_SECONDS,
+    ImmuneInterceptor,
+)
+from openbad.endocrine.controller import EndocrineController
+
+
+@pytest.fixture()
+def endocrine() -> EndocrineController:
+    return EndocrineController()
+
+
+@pytest.fixture()
+def interceptor(endocrine: EndocrineController) -> ImmuneInterceptor:
+    return ImmuneInterceptor(endocrine=endocrine)
+
+
+class TestThreatDetection:
+    """Tests for immune threat scanning."""
+
+    def test_clean_observation_not_quarantined(
+        self, interceptor: ImmuneInterceptor
+    ) -> None:
+        result = interceptor.intercept(
+            source_id="test", surprise=0.3, errors={"metric": 0.2}
+        )
+        assert result.quarantined is False
+
+    def test_threat_pattern_triggers_quarantine(
+        self, interceptor: ImmuneInterceptor
+    ) -> None:
+        result = interceptor.intercept(
+            source_id="test",
+            surprise=0.5,
+            errors={},
+            raw_data={"message": "authentication failure detected"},
+        )
+        assert result.quarantined is True
+        assert "authentication failure" in result.threat_indicators
+
+    def test_multiple_threat_patterns(
+        self, interceptor: ImmuneInterceptor
+    ) -> None:
+        result = interceptor.intercept(
+            source_id="test",
+            surprise=0.5,
+            errors={},
+            raw_data="unauthorized access with brute force",
+        )
+        assert result.quarantined is True
+        assert len(result.threat_indicators) == 2
+
+    def test_threat_triggers_adrenaline(
+        self,
+        interceptor: ImmuneInterceptor,
+        endocrine: EndocrineController,
+    ) -> None:
+        interceptor.intercept(
+            source_id="test",
+            surprise=0.5,
+            errors={},
+            raw_data="kernel panic detected",
+        )
+        assert endocrine.level("adrenaline") > 0.0
+
+
+class TestNoveltyDopamine:
+    """Tests for dopamine signaling on novel observations."""
+
+    def test_high_surprise_triggers_dopamine(
+        self,
+        interceptor: ImmuneInterceptor,
+        endocrine: EndocrineController,
+    ) -> None:
+        interceptor.intercept(
+            source_id="test", surprise=0.6, errors={"metric": 0.4}
+        )
+        assert endocrine.level("dopamine") > 0.0
+
+    def test_low_surprise_no_dopamine(
+        self,
+        interceptor: ImmuneInterceptor,
+        endocrine: EndocrineController,
+    ) -> None:
+        interceptor.intercept(
+            source_id="test", surprise=0.1, errors={"metric": 0.05}
+        )
+        assert endocrine.level("dopamine") == 0.0
+
+    def test_zero_surprise_no_dopamine(
+        self,
+        interceptor: ImmuneInterceptor,
+        endocrine: EndocrineController,
+    ) -> None:
+        interceptor.intercept(
+            source_id="test", surprise=0.0, errors={}
+        )
+        assert endocrine.level("dopamine") == 0.0
+
+
+class TestThreatMemory:
+    """Tests for immune memory and vigilance."""
+
+    def test_threat_creates_memory(self, interceptor: ImmuneInterceptor) -> None:
+        interceptor.intercept(
+            source_id="bad_source",
+            surprise=0.5,
+            errors={},
+            raw_data="segfault occurred",
+        )
+        assert interceptor.is_quarantined_source("bad_source") is True
+
+    def test_clean_source_not_quarantined(
+        self, interceptor: ImmuneInterceptor
+    ) -> None:
+        assert interceptor.is_quarantined_source("good_source") is False
+
+    def test_vigilant_source_poll_factor_faster(
+        self, interceptor: ImmuneInterceptor
+    ) -> None:
+        interceptor.intercept(
+            source_id="flagged",
+            surprise=0.5,
+            errors={},
+            raw_data="out of memory",
+        )
+        factor = interceptor.get_poll_factor("flagged")
+        assert factor < 1.0  # Poll faster
+
+    def test_vigilance_decays_over_time(
+        self, interceptor: ImmuneInterceptor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        interceptor.intercept(
+            source_id="old_threat",
+            surprise=0.5,
+            errors={},
+            raw_data="disk full event",
+        )
+        # Simulate time passing beyond decay
+        memory = interceptor._threat_memory["old_threat"]
+        monkeypatch.setattr(
+            memory, "last_threat_ts", time.monotonic() - _VIGILANCE_DECAY_SECONDS - 1
+        )
+        assert memory.is_vigilant is False
+        assert interceptor.get_poll_factor("old_threat") == 1.0
+
+
+class TestHabituation:
+    """Tests for boring observation habituation."""
+
+    def test_boring_streak_builds_habituation(
+        self, interceptor: ImmuneInterceptor
+    ) -> None:
+        for _ in range(_HABITUATION_THRESHOLD):
+            interceptor.intercept(
+                source_id="boring", surprise=0.0, errors={}
+            )
+        factor = interceptor.get_poll_factor("boring")
+        assert factor > 1.0  # Poll slower
+
+    def test_novel_observation_resets_habituation(
+        self, interceptor: ImmuneInterceptor
+    ) -> None:
+        # Build up boringness
+        for _ in range(_HABITUATION_THRESHOLD - 1):
+            interceptor.intercept(
+                source_id="mixed", surprise=0.0, errors={}
+            )
+        # Novel observation resets streak
+        interceptor.intercept(
+            source_id="mixed", surprise=0.5, errors={"x": 0.3}
+        )
+        factor = interceptor.get_poll_factor("mixed")
+        assert factor == 1.0  # Normal (not habituated)
+
+
+class TestVigilantSourceHeightenedSensitivity:
+    """Tests for heightened sensitivity on flagged sources."""
+
+    def test_flagged_source_high_error_triggers_quarantine(
+        self, interceptor: ImmuneInterceptor
+    ) -> None:
+        # First: flag the source
+        interceptor.intercept(
+            source_id="suspect",
+            surprise=0.5,
+            errors={},
+            raw_data="connection refused repeatedly",
+        )
+        # Now high error on flagged source → threat
+        result = interceptor.intercept(
+            source_id="suspect",
+            surprise=0.3,
+            errors={"error_rate": 0.9},
+        )
+        assert result.quarantined is True
+        assert any("high_error" in i for i in result.threat_indicators)
+
+    def test_unflagged_source_high_error_not_quarantined(
+        self, interceptor: ImmuneInterceptor
+    ) -> None:
+        # Same high error but source isn't flagged → no quarantine
+        result = interceptor.intercept(
+            source_id="clean",
+            surprise=0.3,
+            errors={"error_rate": 0.9},
+        )
+        assert result.quarantined is False


### PR DESCRIPTION
Closes #634

## Summary

Adds immune interception layer between the BackgroundScanner and cognitive processing, registers the syslog observation plugin, and wires endocrine feedback signals.

### New: `src/openbad/active_inference/immune_interceptor.py`
- **ImmuneInterceptor**: screens observations for threat patterns before cognitive processing
- **Threat detection**: pattern matching against known threat indicators (auth failures, segfaults, OOM, etc.)
- **Quarantine**: blocks cognitive processing of suspicious observations
- **Endocrine signals**: adrenaline on threat, dopamine on novelty (surprise ≥ 0.3)
- **Threat memory**: per-source tracking with vigilance decay (1h half-life)
- **Heightened sensitivity**: flagged sources have lower thresholds for subsequent quarantine
- **Habituation**: boring sources (10+ zero-surprise observations) get slower polling

### Modified: `src/openbad/active_inference/background_scanner.py`
- Integrated ImmuneInterceptor into poll loop
- Observations pass through immune screen before action generation
- Polling intervals modulated by immune memory (vigilance/habituation factors)

### Modified: `src/openbad/daemon.py`
- Registers SyslogObservationPlugin (monitors openbad services via journalctl)
- Syslog plugin polls every 5 minutes for errors/criticals

### New tests (15 in `tests/test_immune_interceptor.py`):
- Threat detection, quarantine, adrenaline trigger
- Novelty → dopamine signaling
- Threat memory, vigilance decay
- Habituation from boring observations
- Heightened sensitivity for flagged sources

## How to test

```bash
pytest tests/test_immune_interceptor.py tests/test_background_scanner_endocrine.py -v
```