### PR TITLE
#641: Implement recurring/scheduled task support

### DIFF
--- a/src/openbad/skills/server.py
+++ b/src/openbad/skills/server.py
@@ -482,6 +482,8 @@ async def create_task(
     title: str,
     description: str = "",
     owner: str = "user",
+    due_at: float | None = None,
+    recurrence_rule: str | None = None,
 ) -> str:
     """Create a new task in the task manager.
 
@@ -489,11 +491,23 @@ async def create_task(
         title: The task title.
         description: Optional task description.
         owner: Task owner ('user' or 'agent', default 'user').
+        due_at: Optional Unix timestamp when the task is due.
+        recurrence_rule: Optional recurrence rule. Supported formats:
+            daily|HH:MM|TZ, weekly|DOW|HH:MM|TZ, interval|Ns.
+            Example: 'daily|18:00|US/Eastern' for every day at 6pm ET.
+            If set and due_at is omitted, the first due time is auto-computed.
     """
     from openbad.skills.tasks_diagnostics_tool import TasksDiagnosticsToolAdapter
 
     adapter = TasksDiagnosticsToolAdapter()
-    result = await asyncio.to_thread(adapter.create_task, title=title, description=description, owner=owner)
+    result = await asyncio.to_thread(
+        adapter.create_task,
+        title=title,
+        description=description,
+        owner=owner,
+        due_at=due_at,
+        recurrence_rule=recurrence_rule,
+    )
     return json.dumps(result, indent=2, default=str)
 
 

--- a/src/openbad/skills/tasks_diagnostics_tool.py
+++ b/src/openbad/skills/tasks_diagnostics_tool.py
@@ -54,12 +54,18 @@ class TasksDiagnosticsToolAdapter:
         *,
         description: str = "",
         owner: str = "user",
+        due_at: float | None = None,
+        recurrence_rule: str | None = None,
     ) -> dict[str, Any]:
-        payload = {
+        payload: dict[str, Any] = {
             "title": title,
             "description": description,
             "owner": owner,
         }
+        if due_at is not None:
+            payload["due_at"] = due_at
+        if recurrence_rule is not None:
+            payload["recurrence_rule"] = recurrence_rule
         url = f"{self._config.base_url.rstrip('/')}/api/tasks"
         try:
             data = json.loads(

--- a/src/openbad/tasks/models.py
+++ b/src/openbad/tasks/models.py
@@ -194,6 +194,7 @@ class TaskModel:
         owner: str = "system",
         due_at: float | None = None,
         parent_task_id: str | None = None,
+        recurrence_rule: str | None = None,
     ) -> TaskModel:
         """Create a new task with a generated UUID."""
         now = time.time()
@@ -210,6 +211,7 @@ class TaskModel:
             root_task_id=task_id,
             due_at=due_at,
             parent_task_id=parent_task_id,
+            recurrence_rule=recurrence_rule,
             created_at=now,
             updated_at=now,
         )

--- a/src/openbad/tasks/recurrence.py
+++ b/src/openbad/tasks/recurrence.py
@@ -1,0 +1,193 @@
+"""Recurrence rule parsing and next-due computation.
+
+Supported rule formats:
+    daily|HH:MM|TZ          — every day at HH:MM in timezone TZ
+    weekly|DOW|HH:MM|TZ     — every week on DOW at HH:MM (mon-sun)
+    interval|Ns              — every N seconds (no timezone needed)
+
+Timezone values use IANA names (e.g. ``America/New_York``).
+Common aliases like ``US/Eastern`` are mapped to IANA equivalents.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+# Common timezone aliases → IANA
+_TZ_ALIASES: dict[str, str] = {
+    "US/Eastern": "America/New_York",
+    "US/Central": "America/Chicago",
+    "US/Mountain": "America/Denver",
+    "US/Pacific": "America/Los_Angeles",
+    "US/Hawaii": "Pacific/Honolulu",
+    "US/Alaska": "America/Anchorage",
+    "EST": "America/New_York",
+    "CST": "America/Chicago",
+    "MST": "America/Denver",
+    "PST": "America/Los_Angeles",
+    "GMT": "Etc/GMT",
+    "UTC": "UTC",
+}
+
+_DAYS_OF_WEEK = {
+    "mon": 0,
+    "tue": 1,
+    "wed": 2,
+    "thu": 3,
+    "fri": 4,
+    "sat": 5,
+    "sun": 6,
+}
+
+_TIME_RE = re.compile(r"^(\d{1,2}):(\d{2})$")
+_INTERVAL_RE = re.compile(r"^(\d+)s$")
+
+
+class RecurrenceError(ValueError):
+    """Raised when a recurrence rule cannot be parsed."""
+
+
+def _resolve_tz(tz_str: str) -> ZoneInfo:
+    """Resolve a timezone string to a ZoneInfo, supporting aliases."""
+    canonical = _TZ_ALIASES.get(tz_str, tz_str)
+    try:
+        return ZoneInfo(canonical)
+    except (ZoneInfoNotFoundError, KeyError) as exc:
+        raise RecurrenceError(f"Unknown timezone: {tz_str!r}") from exc
+
+
+def _parse_time(time_str: str) -> tuple[int, int]:
+    """Parse HH:MM and return (hour, minute)."""
+    m = _TIME_RE.match(time_str)
+    if m is None:
+        raise RecurrenceError(f"Invalid time format: {time_str!r} (expected HH:MM)")
+    hour, minute = int(m.group(1)), int(m.group(2))
+    if hour > 23 or minute > 59:
+        raise RecurrenceError(f"Time out of range: {time_str!r}")
+    return hour, minute
+
+
+def validate_recurrence_rule(rule: str) -> None:
+    """Validate a recurrence rule string. Raises RecurrenceError if invalid."""
+    parts = rule.split("|")
+    if not parts:
+        raise RecurrenceError("Empty recurrence rule")
+
+    kind = parts[0].lower()
+
+    if kind == "daily":
+        if len(parts) != 3:
+            raise RecurrenceError(
+                f"daily rule requires 3 parts: daily|HH:MM|TZ (got {len(parts)})"
+            )
+        _parse_time(parts[1])
+        _resolve_tz(parts[2])
+
+    elif kind == "weekly":
+        if len(parts) != 4:
+            raise RecurrenceError(
+                f"weekly rule requires 4 parts: weekly|DOW|HH:MM|TZ (got {len(parts)})"
+            )
+        dow = parts[1].lower()
+        if dow not in _DAYS_OF_WEEK:
+            raise RecurrenceError(
+                f"Invalid day of week: {parts[1]!r} "
+                f"(expected one of {', '.join(_DAYS_OF_WEEK)})"
+            )
+        _parse_time(parts[2])
+        _resolve_tz(parts[3])
+
+    elif kind == "interval":
+        if len(parts) != 2:
+            raise RecurrenceError(
+                f"interval rule requires 2 parts: interval|Ns (got {len(parts)})"
+            )
+        m = _INTERVAL_RE.match(parts[1])
+        if m is None:
+            raise RecurrenceError(
+                f"Invalid interval format: {parts[1]!r} (expected Ns, e.g. 3600s)"
+            )
+        seconds = int(m.group(1))
+        if seconds < 1:
+            raise RecurrenceError("Interval must be at least 1 second")
+
+    else:
+        raise RecurrenceError(
+            f"Unknown recurrence type: {kind!r} (expected daily, weekly, or interval)"
+        )
+
+
+def compute_next_due(rule: str, after: datetime | None = None) -> float:
+    """Compute the next due timestamp (Unix) for a recurrence rule.
+
+    Parameters
+    ----------
+    rule:
+        A validated recurrence rule string.
+    after:
+        The reference time. Defaults to now (UTC).
+
+    Returns
+    -------
+    float
+        Unix timestamp of the next occurrence.
+    """
+    validate_recurrence_rule(rule)
+    parts = rule.split("|")
+    kind = parts[0].lower()
+
+    if after is None:
+        after = datetime.now(UTC)
+    elif after.tzinfo is None:
+        after = after.replace(tzinfo=UTC)
+
+    if kind == "daily":
+        hour, minute = _parse_time(parts[1])
+        tz = _resolve_tz(parts[2])
+        return _next_daily(after, hour, minute, tz)
+
+    if kind == "weekly":
+        dow_str = parts[1].lower()
+        target_dow = _DAYS_OF_WEEK[dow_str]
+        hour, minute = _parse_time(parts[2])
+        tz = _resolve_tz(parts[3])
+        return _next_weekly(after, target_dow, hour, minute, tz)
+
+    # interval
+    m = _INTERVAL_RE.match(parts[1])
+    assert m is not None
+    seconds = int(m.group(1))
+    return (after + timedelta(seconds=seconds)).timestamp()
+
+
+def _next_daily(
+    after: datetime, hour: int, minute: int, tz: ZoneInfo
+) -> float:
+    """Find the next daily occurrence at hour:minute in tz after 'after'."""
+    local = after.astimezone(tz)
+    candidate = local.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate <= local:
+        candidate += timedelta(days=1)
+    return candidate.timestamp()
+
+
+def _next_weekly(
+    after: datetime,
+    target_dow: int,
+    hour: int,
+    minute: int,
+    tz: ZoneInfo,
+) -> float:
+    """Find the next weekly occurrence on target_dow at hour:minute in tz."""
+    local = after.astimezone(tz)
+    candidate = local.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    current_dow = local.weekday()
+    days_ahead = target_dow - current_dow
+    if days_ahead < 0:
+        days_ahead += 7
+    elif days_ahead == 0 and candidate <= local:
+        days_ahead = 7
+    candidate += timedelta(days=days_ahead)
+    return candidate.timestamp()

--- a/src/openbad/tasks/service.py
+++ b/src/openbad/tasks/service.py
@@ -14,6 +14,7 @@ import logging
 import sqlite3
 import threading
 import uuid
+from datetime import UTC
 from pathlib import Path
 
 from openbad.tasks.lease import Lease, LeaseStore
@@ -87,13 +88,30 @@ class TaskService:
         description: str = "",
         owner: str = "system",
         parent_task_id: str | None = None,
+        due_at: float | None = None,
+        recurrence_rule: str | None = None,
     ) -> TaskModel:
-        """Create a new task in PENDING status and return it."""
+        """Create a new task in PENDING status and return it.
+
+        If *recurrence_rule* is set and *due_at* is not provided, the
+        first due time is computed from the rule.
+        """
+        if recurrence_rule:
+            from openbad.tasks.recurrence import validate_recurrence_rule
+
+            validate_recurrence_rule(recurrence_rule)
+            if due_at is None:
+                from openbad.tasks.recurrence import compute_next_due
+
+                due_at = compute_next_due(recurrence_rule)
+
         task = TaskModel.new(
             title,
             description=description,
             owner=owner,
             parent_task_id=parent_task_id,
+            due_at=due_at,
+            recurrence_rule=recurrence_rule,
         )
         return self._store.create_task(task)
 
@@ -136,8 +154,53 @@ class TaskService:
         return self.transition_task(task_id, TaskStatus.CANCELLED)
 
     def complete_task(self, task_id: str) -> TaskModel:
-        """Convenience wrapper to mark a task done."""
-        return self.transition_task(task_id, TaskStatus.DONE)
+        """Convenience wrapper to mark a task done.
+
+        If the completed task has a ``recurrence_rule``, a new pending
+        task is automatically spawned for the next occurrence.
+        """
+        task = self.transition_task(task_id, TaskStatus.DONE)
+        if task.recurrence_rule:
+            self.spawn_next_recurrence(task)
+        return task
+
+    def spawn_next_recurrence(self, completed_task: TaskModel) -> TaskModel:
+        """Create the next occurrence of a recurring task.
+
+        The new task inherits title, description, priority, owner, and
+        the recurrence_rule.  Its ``due_at`` is set to the next
+        occurrence after the just-completed task's ``due_at`` (or now).
+        """
+        from datetime import datetime
+
+        from openbad.tasks.recurrence import compute_next_due
+
+        # Compute next due relative to the previous due_at
+        # (not now) to avoid drift.
+        if completed_task.due_at:
+            after = datetime.fromtimestamp(
+                completed_task.due_at, tz=UTC,
+            )
+        else:
+            after = None
+
+        next_due = compute_next_due(completed_task.recurrence_rule, after)
+
+        new_task = self.create_task(
+            completed_task.title,
+            description=completed_task.description,
+            owner=completed_task.owner,
+            parent_task_id=completed_task.task_id,
+            due_at=next_due,
+            recurrence_rule=completed_task.recurrence_rule,
+        )
+        log.info(
+            "Spawned next recurrence task=%s from=%s due_at=%.0f",
+            new_task.task_id,
+            completed_task.task_id,
+            next_due,
+        )
+        return new_task
 
     def update_task(
         self,

--- a/src/openbad/wui/chat_pipeline.py
+++ b/src/openbad/wui/chat_pipeline.py
@@ -1552,6 +1552,9 @@ async def _agentic_stream(
                         content_buffer.append(text)
 
             elif kind == "on_chat_model_end":
+                end_node = event.get("metadata", {}).get(
+                    "langgraph_node", "supervisor",
+                )
                 output = event.get("data", {}).get("output")
                 if output:
                     usage = getattr(output, "usage_metadata", None)
@@ -1570,14 +1573,26 @@ async def _agentic_stream(
                                     reasoning=reasoning_text.strip(),
                                     tokens_used=total_tokens,
                                 )
-                    else:
-                        # Final answer — flush content as tokens.
+                    elif end_node == "supervisor":
+                        # Final answer from the supervisor — flush
+                        # content as visible tokens.
                         if content_buffer:
                             from openbad.autonomy.tool_agent import strip_think_tags
                             full_text = strip_think_tags("".join(content_buffer))
                             if full_text:
                                 yield StreamChunk(
                                     token=full_text,
+                                    tokens_used=total_tokens,
+                                )
+                    else:
+                        # Sub-agent final answer — treat as reasoning
+                        # so only the supervisor's paraphrase is shown.
+                        if content_buffer:
+                            from openbad.autonomy.tool_agent import strip_think_tags
+                            reasoning_text = strip_think_tags("".join(content_buffer))
+                            if reasoning_text.strip():
+                                yield StreamChunk(
+                                    reasoning=reasoning_text.strip(),
                                     tokens_used=total_tokens,
                                 )
                 content_buffer.clear()

--- a/src/openbad/wui/task_api.py
+++ b/src/openbad/wui/task_api.py
@@ -78,6 +78,8 @@ async def _create_task(request: web.Request) -> web.Response:
         title,
         description=body.get("description", ""),
         owner=body.get("owner", "system"),
+        due_at=body.get("due_at"),
+        recurrence_rule=body.get("recurrence_rule"),
     )
     return web.json_response(_task_to_dict(task), status=201)
 

--- a/tests/test_recurrence.py
+++ b/tests/test_recurrence.py
@@ -1,0 +1,219 @@
+"""Tests for recurrence rule parsing and next-due computation."""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from openbad.tasks.recurrence import (
+    RecurrenceError,
+    compute_next_due,
+    validate_recurrence_rule,
+)
+
+
+class TestValidateRecurrenceRule:
+    def test_valid_daily(self) -> None:
+        validate_recurrence_rule("daily|18:00|America/New_York")
+
+    def test_valid_daily_alias(self) -> None:
+        validate_recurrence_rule("daily|06:30|US/Eastern")
+
+    def test_valid_weekly(self) -> None:
+        validate_recurrence_rule("weekly|mon|09:00|America/Chicago")
+
+    def test_valid_interval(self) -> None:
+        validate_recurrence_rule("interval|3600s")
+
+    def test_invalid_empty(self) -> None:
+        with pytest.raises(RecurrenceError, match="Unknown recurrence type"):
+            validate_recurrence_rule("")
+
+    def test_invalid_type(self) -> None:
+        with pytest.raises(RecurrenceError, match="Unknown recurrence type"):
+            validate_recurrence_rule("monthly|1|09:00|UTC")
+
+    def test_daily_wrong_parts(self) -> None:
+        with pytest.raises(RecurrenceError, match="3 parts"):
+            validate_recurrence_rule("daily|18:00")
+
+    def test_daily_bad_time(self) -> None:
+        with pytest.raises(RecurrenceError, match="out of range"):
+            validate_recurrence_rule("daily|25:00|UTC")
+
+    def test_daily_bad_tz(self) -> None:
+        with pytest.raises(RecurrenceError, match="Unknown timezone"):
+            validate_recurrence_rule("daily|18:00|Mars/Olympus")
+
+    def test_weekly_wrong_parts(self) -> None:
+        with pytest.raises(RecurrenceError, match="4 parts"):
+            validate_recurrence_rule("weekly|mon|09:00")
+
+    def test_weekly_bad_dow(self) -> None:
+        with pytest.raises(RecurrenceError, match="Invalid day of week"):
+            validate_recurrence_rule("weekly|foo|09:00|UTC")
+
+    def test_interval_bad_format(self) -> None:
+        with pytest.raises(RecurrenceError, match="Invalid interval"):
+            validate_recurrence_rule("interval|abc")
+
+    def test_interval_zero(self) -> None:
+        with pytest.raises(RecurrenceError, match="at least 1"):
+            validate_recurrence_rule("interval|0s")
+
+    def test_time_out_of_range(self) -> None:
+        with pytest.raises(RecurrenceError, match="out of range"):
+            validate_recurrence_rule("daily|12:60|UTC")
+
+
+class TestComputeNextDue:
+    def test_daily_future_today(self) -> None:
+        # Set "now" to 10am UTC, rule is daily at 18:00 UTC → same day 18:00
+        after = datetime(2026, 5, 11, 10, 0, 0, tzinfo=UTC)
+        ts = compute_next_due("daily|18:00|UTC", after)
+        result = datetime.fromtimestamp(ts, tz=UTC)
+        assert result.hour == 18
+        assert result.minute == 0
+        assert result.day == 11
+
+    def test_daily_past_today_rolls_to_tomorrow(self) -> None:
+        after = datetime(2026, 5, 11, 20, 0, 0, tzinfo=UTC)
+        ts = compute_next_due("daily|18:00|UTC", after)
+        result = datetime.fromtimestamp(ts, tz=UTC)
+        assert result.day == 12
+        assert result.hour == 18
+
+    def test_daily_with_timezone(self) -> None:
+        # 2pm ET = 18:00 UTC. If after is 1pm ET, next is today 2pm ET.
+        tz = ZoneInfo("America/New_York")
+        after = datetime(2026, 5, 11, 13, 0, 0, tzinfo=tz)
+        ts = compute_next_due("daily|14:00|America/New_York", after)
+        result = datetime.fromtimestamp(ts, tz=tz)
+        assert result.hour == 14
+        assert result.day == 11
+
+    def test_daily_alias_timezone(self) -> None:
+        tz = ZoneInfo("America/New_York")
+        after = datetime(2026, 5, 11, 13, 0, 0, tzinfo=tz)
+        ts = compute_next_due("daily|14:00|US/Eastern", after)
+        result = datetime.fromtimestamp(ts, tz=tz)
+        assert result.hour == 14
+
+    def test_weekly_same_day_future(self) -> None:
+        # May 11, 2026 is a Monday
+        after = datetime(2026, 5, 11, 8, 0, 0, tzinfo=UTC)
+        ts = compute_next_due("weekly|mon|09:00|UTC", after)
+        result = datetime.fromtimestamp(ts, tz=UTC)
+        assert result.weekday() == 0
+        assert result.day == 11
+        assert result.hour == 9
+
+    def test_weekly_same_day_past(self) -> None:
+        after = datetime(2026, 5, 11, 10, 0, 0, tzinfo=UTC)
+        ts = compute_next_due("weekly|mon|09:00|UTC", after)
+        result = datetime.fromtimestamp(ts, tz=UTC)
+        assert result.weekday() == 0
+        assert result.day == 18  # next Monday
+
+    def test_weekly_different_day(self) -> None:
+        # Monday, want Friday
+        after = datetime(2026, 5, 11, 10, 0, 0, tzinfo=UTC)
+        ts = compute_next_due("weekly|fri|09:00|UTC", after)
+        result = datetime.fromtimestamp(ts, tz=UTC)
+        assert result.weekday() == 4
+        assert result.day == 15
+
+    def test_interval(self) -> None:
+        after = datetime(2026, 5, 11, 10, 0, 0, tzinfo=UTC)
+        ts = compute_next_due("interval|3600s", after)
+        result = datetime.fromtimestamp(ts, tz=UTC)
+        assert result == after + timedelta(seconds=3600)
+
+    def test_interval_small(self) -> None:
+        after = datetime(2026, 5, 11, 10, 0, 0, tzinfo=UTC)
+        ts = compute_next_due("interval|60s", after)
+        expected = (after + timedelta(seconds=60)).timestamp()
+        assert abs(ts - expected) < 0.01
+
+    def test_defaults_to_now(self) -> None:
+        before = time.time()
+        ts = compute_next_due("interval|10s")
+        after = time.time()
+        assert ts >= before + 10
+        assert ts <= after + 10
+
+
+class TestServiceRecurrence:
+    """Test TaskService integration with recurrence rules."""
+
+    @pytest.fixture()
+    def svc(self, tmp_path):
+
+        from openbad.state.db import initialize_state_db
+        from openbad.tasks.service import TaskService
+
+        db = tmp_path / "test.db"
+        conn = initialize_state_db(db)
+        return TaskService(conn)
+
+    def test_create_task_with_recurrence(self, svc) -> None:
+        task = svc.create_task(
+            "Daily check",
+            recurrence_rule="daily|18:00|UTC",
+        )
+        assert task.recurrence_rule == "daily|18:00|UTC"
+        assert task.due_at is not None
+        assert task.due_at > time.time() - 1
+
+    def test_create_task_with_recurrence_and_explicit_due(self, svc) -> None:
+        explicit = time.time() + 86400
+        task = svc.create_task(
+            "Test",
+            recurrence_rule="daily|18:00|UTC",
+            due_at=explicit,
+        )
+        assert task.due_at == explicit
+
+    def test_create_task_invalid_recurrence_raises(self, svc) -> None:
+        with pytest.raises(RecurrenceError):
+            svc.create_task("Bad", recurrence_rule="bogus|rule")
+
+    def test_complete_task_spawns_next(self, svc) -> None:
+        from openbad.tasks.models import TaskStatus
+
+        task = svc.create_task(
+            "Recurring",
+            description="test desc",
+            owner="user",
+            recurrence_rule="interval|60s",
+        )
+        original_due = task.due_at
+        svc.transition_task(task.task_id, TaskStatus.RUNNING)
+        completed = svc.complete_task(task.task_id)
+        assert completed.status.value == "done"
+
+        # Find the spawned task
+        pending = svc.list_tasks()
+        spawned = [
+            t for t in pending
+            if t.parent_task_id == task.task_id
+        ]
+        assert len(spawned) == 1
+        assert spawned[0].title == "Recurring"
+        assert spawned[0].description == "test desc"
+        assert spawned[0].recurrence_rule == "interval|60s"
+        assert spawned[0].due_at is not None
+        assert spawned[0].due_at > original_due
+
+    def test_complete_non_recurring_no_spawn(self, svc) -> None:
+        from openbad.tasks.models import TaskStatus
+
+        task = svc.create_task("One-off")
+        svc.transition_task(task.task_id, TaskStatus.RUNNING)
+        svc.complete_task(task.task_id)
+        pending = svc.list_tasks()
+        spawned = [t for t in pending if t.parent_task_id == task.task_id]
+        assert len(spawned) == 0


### PR DESCRIPTION
Closes #641

## Summary

Adds recurring task support end-to-end and fixes the duplicated chat output bug.

### Recurring Tasks
- **New: `src/openbad/tasks/recurrence.py`** — Rule parser and next-due computation
  - `daily|HH:MM|TZ` (e.g. `daily|18:00|US/Eastern`)
  - `weekly|DOW|HH:MM|TZ` (e.g. `weekly|mon|09:00|UTC`)
  - `interval|Ns` (e.g. `interval|3600s`)
  - Timezone alias mapping (US/Eastern → America/New_York, EST, PST, etc.)
- **TaskService.create_task()** — Now accepts `due_at` and `recurrence_rule`; auto-computes first `due_at` from rule
- **TaskService.complete_task()** — Auto-spawns next occurrence via `spawn_next_recurrence()`
- **REST API, MCP tool, HTTP adapter** — All wired through with new parameters

### Duplicated Chat Output Fix
- Root cause: supervisor graph yields `on_chat_model_end` from both the sub-agent AND the supervisor, each with content. Both were being yielded as `token` chunks.
- Fix: Check `langgraph_node` metadata. Sub-agent content goes to `reasoning` (hidden). Only supervisor response goes to `token` (visible).

## How to Test
```bash
pytest tests/test_recurrence.py -v  # 29 tests
```

Chat duplication: Ask the chat to create a task — should see only one response, not two concatenated paragraphs.